### PR TITLE
Replace past kaigis url

### DIFF
--- a/2006/audio/podcast.xml
+++ b/2006/audio/podcast.xml
@@ -1,160 +1,160 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rss xmlns:dc="http://purl.org/dc/elements/1.1/" version="2.0">
   <channel>
-    <link>http://jp.rubyist.net/RubyKaigi2006/audio/</link>
+    <link>https://rubykaigi.org/2006/audio/</link>
     <title>日本Rubyカンファレンス2006</title>
     <language>Japanese</language>
     <item>
       <title>高橋征義 -- 日本Rubyカンファレンス2006 -- オープニング</title>
-      <link>http://jp.rubyist.net/RubyKaigi2006/audio/1-00-opening.mp3</link>
-      <enclosure url="http://jp.rubyist.net/RubyKaigi2006/audio/1-00-opening.mp3"
+      <link>https://rubykaigi.org/2006/audio/1-00-opening.mp3</link>
+      <enclosure url="https://rubykaigi.org/2006/audio/1-00-opening.mp3"
         length="4897423"
         type="audio/mpeg"/>
     </item>
     <item>
       <title>高橋征義 -- 日本Rubyカンファレンス2006 -- Rubyの歴史</title>
-      <link>http://jp.rubyist.net/RubyKaigi2006/audio/1-01-takahashi.mp3</link>
-      <enclosure url="http://jp.rubyist.net/RubyKaigi2006/audio/1-01-takahashi.mp3"
+      <link>https://rubykaigi.org/2006/audio/1-01-takahashi.mp3</link>
+      <enclosure url="https://rubykaigi.org/2006/audio/1-01-takahashi.mp3"
         length="18145418"
         type="audio/mpeg"/>
     </item>
     <item>
       <title>井上浩 -- 日本Rubyカンファレンス2006 -- NaClのオープンソース戦略 - そして今後の Ruby 戦略に関して</title>
-      <link>http://jp.rubyist.net/RubyKaigi2006/audio/1-02-inoue.mp3</link>
-      <enclosure url="http://jp.rubyist.net/RubyKaigi2006/audio/1-02-inoue.mp3"
+      <link>https://rubykaigi.org/2006/audio/1-02-inoue.mp3</link>
+      <enclosure url="https://rubykaigi.org/2006/audio/1-02-inoue.mp3"
         length="22401353"
         type="audio/mpeg"/>
     </item>
     <item>
       <title>まつもとゆきひろ -- 日本Rubyカンファレンス2006 -- State of the Dominion</title>
-      <link>http://jp.rubyist.net/RubyKaigi2006/audio/1-03-matz.mp3</link>
-      <enclosure url="http://jp.rubyist.net/RubyKaigi2006/audio/1-03-matz.mp3"
+      <link>https://rubykaigi.org/2006/audio/1-03-matz.mp3</link>
+      <enclosure url="https://rubykaigi.org/2006/audio/1-03-matz.mp3"
         length="64530334"
         type="audio/mpeg"/>
     </item>
     <item>
       <title>まつもとゆきひろ, ささだこういち, 小迫清美, 卜部昌平 -- 日本Rubyカンファレンス2006 -- パネル企画「Ruby 2.0」</title>
-      <link>http://jp.rubyist.net/RubyKaigi2006/audio/1-04-Ruby2.0.mp3</link>
-      <enclosure url="http://jp.rubyist.net/RubyKaigi2006/audio/1-04-Ruby2.0.mp3"
+      <link>https://rubykaigi.org/2006/audio/1-04-Ruby2.0.mp3</link>
+      <enclosure url="https://rubykaigi.org/2006/audio/1-04-Ruby2.0.mp3"
         length="55905369"
         type="audio/mpeg"/>
     </item>
     <item>
       <title>arton -- 日本Rubyカンファレンス2006 -- Rubyizeによる言語境界の越え方</title>
-      <link>http://jp.rubyist.net/RubyKaigi2006/audio/1-05-arton.mp3</link>
-      <enclosure url="http://jp.rubyist.net/RubyKaigi2006/audio/1-05-arton.mp3"
+      <link>https://rubykaigi.org/2006/audio/1-05-arton.mp3</link>
+      <enclosure url="https://rubykaigi.org/2006/audio/1-05-arton.mp3"
         length="28849438"
         type="audio/mpeg"/>
     </item>
     <item>
       <title>田中哲 -- 日本Rubyカンファレンス2006 -- 使いやすいライブラリAPIデザイン</title>
-      <link>http://jp.rubyist.net/RubyKaigi2006/audio/1-06-akr.mp3</link>
-      <enclosure url="http://jp.rubyist.net/RubyKaigi2006/audio/1-06-akr.mp3"
+      <link>https://rubykaigi.org/2006/audio/1-06-akr.mp3</link>
+      <enclosure url="https://rubykaigi.org/2006/audio/1-06-akr.mp3"
         length="29521447"
         type="audio/mpeg"/>
     </item>
     <item>
       <title>石塚圭樹 -- 日本Rubyカンファレンス2006 -- Rubyプログラミング + モデリングでより楽しくなろう - その1</title>
-      <link>http://jp.rubyist.net/RubyKaigi2006/audio/1-07-keiju.mp3</link>
-      <enclosure url="http://jp.rubyist.net/RubyKaigi2006/audio/1-07-keiju.mp3"
+      <link>https://rubykaigi.org/2006/audio/1-07-keiju.mp3</link>
+      <enclosure url="https://rubykaigi.org/2006/audio/1-07-keiju.mp3"
         length="26113485"
         type="audio/mpeg"/>
     </item>
     <item>
       <title>なひ -- 日本Rubyカンファレンス2006 -- セキュアアプリケーションプログラミング</title>
-      <link>http://jp.rubyist.net/RubyKaigi2006/audio/1-08-nahi.mp3</link>
-      <enclosure url="http://jp.rubyist.net/RubyKaigi2006/audio/1-08-nahi.mp3"
+      <link>https://rubykaigi.org/2006/audio/1-08-nahi.mp3</link>
+      <enclosure url="https://rubykaigi.org/2006/audio/1-08-nahi.mp3"
         length="31793584"
         type="audio/mpeg"/>
     </item>
     <item>
       <title>後藤謙太郎 -- 日本Rubyカンファレンス2006 -- 仕事で使うRuby</title>
-      <link>http://jp.rubyist.net/RubyKaigi2006/audio/1-09-gotoken.mp3</link>
-      <enclosure url="http://jp.rubyist.net/RubyKaigi2006/audio/1-09-gotoken.mp3"
+      <link>https://rubykaigi.org/2006/audio/1-09-gotoken.mp3</link>
+      <enclosure url="https://rubykaigi.org/2006/audio/1-09-gotoken.mp3"
         length="29761428"
         type="audio/mpeg"/>
     </item>
     <item>
       <title>前田修吾 -- 日本Rubyカンファレンス2006 -- Railsによるメタプログラミング入門</title>
-      <link>http://jp.rubyist.net/RubyKaigi2006/audio/1-10-shugo.mp3</link>
-      <enclosure url="http://jp.rubyist.net/RubyKaigi2006/audio/1-10-shugo.mp3"
+      <link>https://rubykaigi.org/2006/audio/1-10-shugo.mp3</link>
+      <enclosure url="https://rubykaigi.org/2006/audio/1-10-shugo.mp3"
         length="30385453"
         type="audio/mpeg"/>
     </item>
     <item>
       <title>ただただし -- 日本Rubyカンファレンス2006 -- Ruby anywhere - Ruby普及のためにアプリケーションができること</title>
-      <link>http://jp.rubyist.net/RubyKaigi2006/audio/2-01-tada.mp3</link>
-      <enclosure url="http://jp.rubyist.net/RubyKaigi2006/audio/2-01-tada.mp3"
+      <link>https://rubykaigi.org/2006/audio/2-01-tada.mp3</link>
+      <enclosure url="https://rubykaigi.org/2006/audio/2-01-tada.mp3"
         length="27393361"
         type="audio/mpeg"/>
     </item>
     <item>
       <title>関将俊 -- 日本Rubyカンファレンス2006 -- dRubyをもう一度</title>
-      <link>http://jp.rubyist.net/RubyKaigi2006/audio/2-02-seki.mp3</link>
-      <enclosure url="http://jp.rubyist.net/RubyKaigi2006/audio/2-02-seki.mp3"
+      <link>https://rubykaigi.org/2006/audio/2-02-seki.mp3</link>
+      <enclosure url="https://rubykaigi.org/2006/audio/2-02-seki.mp3"
         length="29009551"
         type="audio/mpeg"/>
     </item>
     <item>
       <title>中島拓 -- 日本Rubyカンファレンス2006 -- Amrita2 の紹介</title>
-      <link>http://jp.rubyist.net/RubyKaigi2006/audio/2-03-essa.mp3</link>
-      <enclosure url="http://jp.rubyist.net/RubyKaigi2006/audio/2-03-essa.mp3"
+      <link>https://rubykaigi.org/2006/audio/2-03-essa.mp3</link>
+      <enclosure url="https://rubykaigi.org/2006/audio/2-03-essa.mp3"
         length="27201292"
         type="audio/mpeg"/>
     </item>
     <item>
       <title>secondlife（舘野祐一） -- 日本Rubyカンファレンス2006 --  Perlの会社で使われるRubyの利用法とは！？</title>
-      <link>http://jp.rubyist.net/RubyKaigi2006/audio/2-04-gorou.mp3</link>
-      <enclosure url="http://jp.rubyist.net/RubyKaigi2006/audio/2-04-gorou.mp3"
+      <link>https://rubykaigi.org/2006/audio/2-04-gorou.mp3</link>
+      <enclosure url="https://rubykaigi.org/2006/audio/2-04-gorou.mp3"
         length="22625607"
         type="audio/mpeg"/>
     </item>
     <item>
       <title>大前潤, ストヤン・ジェコフ, 瀧内元気, 高木宏（Gollum） -- 日本Rubyカンファレンス2006 -- パネル企画「Rails in Production」</title>
-      <link>http://jp.rubyist.net/RubyKaigi2006/audio/2-05-RiP.mp3</link>
-      <enclosure url="http://jp.rubyist.net/RubyKaigi2006/audio/2-05-RiP.mp3"
+      <link>https://rubykaigi.org/2006/audio/2-05-RiP.mp3</link>
+      <enclosure url="https://rubykaigi.org/2006/audio/2-05-RiP.mp3"
         length="58737381"
         type="audio/mpeg"/>
     </item>
     <item>
       <title>moriq（吉田和弘） -- 日本Rubyカンファレンス2006 -- RailsによるWebアプリケーション開発・保守事例の紹介</title>
-      <link>http://jp.rubyist.net/RubyKaigi2006/audio/2-06-moriq.mp3</link>
-      <enclosure url="http://jp.rubyist.net/RubyKaigi2006/audio/2-06-moriq.mp3"
+      <link>https://rubykaigi.org/2006/audio/2-06-moriq.mp3</link>
+      <enclosure url="https://rubykaigi.org/2006/audio/2-06-moriq.mp3"
         length="27121488"
         type="audio/mpeg"/>
     </item>
     <item>
       <title>西和則 -- 日本Rubyカンファレンス2006 -- ActiveRecordを詳しく</title>
-      <link>http://jp.rubyist.net/RubyKaigi2006/audio/2-07-maiha.mp3</link>
-      <enclosure url="http://jp.rubyist.net/RubyKaigi2006/audio/2-07-maiha.mp3"
+      <link>https://rubykaigi.org/2006/audio/2-07-maiha.mp3</link>
+      <enclosure url="https://rubykaigi.org/2006/audio/2-07-maiha.mp3"
         length="27793427"
         type="audio/mpeg"/>
     </item>
     <item>
       <title>David Heinemeier Hansson -- 日本Rubyカンファレンス2006 -- One controller, many ins, many outs</title>
-      <link>http://jp.rubyist.net/RubyKaigi2006/audio/2-08-DHH.mp3</link>
-      <enclosure url="http://jp.rubyist.net/RubyKaigi2006/audio/2-08-DHH.mp3"
+      <link>https://rubykaigi.org/2006/audio/2-08-DHH.mp3</link>
+      <enclosure url="https://rubykaigi.org/2006/audio/2-08-DHH.mp3"
         length="62721325"
         type="audio/mpeg"/>
     </item>
     <item>
       <title>片山俊明, 藤本尚邦, 立川察理, cuzic, 大西正太 -- 日本Rubyカンファレンス2006 -- ライトニングトークス（1）</title>
-      <link>http://jp.rubyist.net/RubyKaigi2006/audio/2-09-LT1.mp3</link>
-      <enclosure url="http://jp.rubyist.net/RubyKaigi2006/audio/2-09-LT1.mp3"
+      <link>https://rubykaigi.org/2006/audio/2-09-LT1.mp3</link>
+      <enclosure url="https://rubykaigi.org/2006/audio/2-09-LT1.mp3"
         length="26081620"
         type="audio/mpeg"/>
     </item>
     <item>
       <title>えとー, 須藤功平, Yugui, 大林一平, 市川宙, 江渡浩一郎 -- 日本Rubyカンファレンス2006 -- ライトニングトークス（2）</title>
-      <link>http://jp.rubyist.net/RubyKaigi2006/audio/2-10-LT2.mp3</link>
-      <enclosure url="http://jp.rubyist.net/RubyKaigi2006/audio/2-10-LT2.mp3"
+      <link>https://rubykaigi.org/2006/audio/2-10-LT2.mp3</link>
+      <enclosure url="https://rubykaigi.org/2006/audio/2-10-LT2.mp3"
         length="30153951"
         type="audio/mpeg"/>
     </item>
     <item>
       <title>高橋征義 -- 日本Rubyカンファレンス2006 -- 閉会</title>
-      <link>http://jp.rubyist.net/RubyKaigi2006/audio/2-11-closing.mp3</link>
-      <enclosure url="http://jp.rubyist.net/RubyKaigi2006/audio/2-11-closing.mp3"
+      <link>https://rubykaigi.org/2006/audio/2-11-closing.mp3</link>
+      <enclosure url="https://rubykaigi.org/2006/audio/2-11-closing.mp3"
         length="3953540"
         type="audio/mpeg"/>
     </item>

--- a/2006/index.html
+++ b/2006/index.html
@@ -88,7 +88,7 @@
     <div class="section">
       <p>公式 Wiki がオープンしました!</p>
 <ul>
-<li><a href="open/index.html" class="external">http://jp.rubyist.net/RubyKaigi2006/open/</a></li>
+<li><a href="open/index.html" class="external">https://rubykaigi.org/2006/open/</a></li>
 </ul>
 <p>どしどし情報をおよせください。</p>
     </div>

--- a/2006/tb20060610.html
+++ b/2006/tb20060610.html
@@ -71,7 +71,7 @@ new/show/list/destroy/edit...のscaffoldで設計しようぜと。
 <ul>
 <li>trackback : <a href="http://blog.imladris.jp/articles/2006/06/12/ruby_kaigi_1" class="external">日本 Ruby カンファレンス 2006 行ってきた (1 日め) (blog.imladris.jp)</a> (2006-06-13 (Tue) 01:39:18)</li>
 </ul>
-<blockquote><p>&lt;p&gt;Ruby 初心者なので、&lt;a href="<a href="index.html" class="external">http://jp.rubyist.net/RubyKaigi2006/</a>"&gt;日本 Ruby カンファレンス 2006&lt;/a&gt;を聴きにいってきました。&lt;br/&gt;どれくらい初心者かというと、なんとなく...</p>
+<blockquote><p>&lt;p&gt;Ruby 初心者なので、&lt;a href="<a href="index.html" class="external">https://rubykaigi.org/2006/</a>"&gt;日本 Ruby カンファレンス 2006&lt;/a&gt;を聴きにいってきました。&lt;br/&gt;どれくらい初心者かというと、なんとなく...</p>
 </blockquote>
 <ul>
 <li>trackback : <a href="http://d.hatena.ne.jp/TakashiKikuchi/20060613/1150127476" class="external">[Ruby] Rubyカンファレンス とりあえず感想 (TakashiKikuchiの日記)</a> (2006-06-13 (Tue) 00:51:33)</li>
@@ -152,13 +152,13 @@ open-uriとnet/httpでは目的が違うん..</p>
 <ul>
 <li>trackback : <a href="http://nikki.hio.jp/?date=20060610" class="external"> (ひおにっき)</a> (2006-06-12 (Mon) 00:35:52)</li>
 </ul>
-<blockquote><p>[おでかけ] &lt;a href="<a href="index.html" class="external">http://jp.rubyist.net/RubyKaigi2006/</a>"&gt;日本 Ruby カンファレンス 2006&lt;/a&gt;
+<blockquote><p>[おでかけ] &lt;a href="<a href="index.html" class="external">https://rubykaigi.org/2006/</a>"&gt;日本 Ruby カンファレンス 2006&lt;/a&gt;
 Ruby会議2006. 午前中は所用でいけなくて午後のパネル企画のおわりあたりから。</p>
 </blockquote>
 <ul>
 <li>trackback : <a href="http://d.hatena.ne.jp/sshi/20060610/p2" class="external">[ruby]Rubyカンファレンス 一日目 (sshi.Continual)</a> (2006-06-11 (Sun) 02:13:06)</li>
 </ul>
-<blockquote><p><a href="program0610.html#l0" class="external">http://jp.rubyist.net/RubyKaigi2006/program0610.html#l0</a> というわけで午後から参加の一日目。より正確なログは誰かがあげるだろうから、自分用に覚えてることをメモ。 パネル企画「Ruby2.0」 2.0相当(このへんは謎)の1.9.1が2007年12月までにはリリースされる(Matz) YARV</p>
+<blockquote><p><a href="program0610.html#l0" class="external">https://rubykaigi.org/2006/program0610.html#l0</a> というわけで午後から参加の一日目。より正確なログは誰かがあげるだろうから、自分用に覚えてることをメモ。 パネル企画「Ruby2.0」 2.0相当(このへんは謎)の1.9.1が2007年12月までにはリリースされる(Matz) YARV</p>
 </blockquote>
 <h3><a name="l1"><span class="sanchor"> </span></a>反応リンク集</h3>
 <p>（見つけた方はぜひ追加してください）</p>

--- a/2006/tb20060611.html
+++ b/2006/tb20060611.html
@@ -180,7 +180,7 @@ DHH の発表が面白そうなん..</p>
 <ul>
 <li>trackback : <a href="http://nikki.hio.jp/?date=20060610" class="external"> (ひおにっき)</a> (2006-06-12 (Mon) 00:35:22)</li>
 </ul>
-<blockquote><p>[おでかけ] &lt;a href="<a href="index.html" class="external">http://jp.rubyist.net/RubyKaigi2006/</a>"&gt;日本 Ruby カンファレンス 2006&lt;/a&gt;
+<blockquote><p>[おでかけ] &lt;a href="<a href="index.html" class="external">https://rubykaigi.org/2006/</a>"&gt;日本 Ruby カンファレンス 2006&lt;/a&gt;
 Ruby会議2006. 午前中は所用でいけなくて午後のパネル企画のおわりあたりから。</p>
 </blockquote>
 <ul>

--- a/2007/LogRK-04.html
+++ b/2007/LogRK-04.html
@@ -57,7 +57,7 @@
 <p>で、LT落選。せっかく来たのにな。</p>
 <p>というわけで…</p>
 <h3><a name="l3"><span class="sanchor"> </span></a>速報ログ公開中</h3>
-<p><a href="Log.html" class="external">http://jp.rubyist.net/RubyKaigi2007/Log.html</a></p>
+<p><a href="Log.html" class="external">https://rubykaigi.org/2007/Log.html</a></p>
 <dl>
 <dt>製作</dt>
 <dd>るびま編集部

--- a/2007/TrackBack.html
+++ b/2007/TrackBack.html
@@ -410,7 +410,7 @@ Railsに対する感情についてはうまく伝わって..</p>
 <ul>
 <li>trackback : <a href="http://d.hatena.ne.jp/ita-wasa/20070610/1181460521" class="external">[Ruby][AP4R] RubyKaigi 2007 お仕事 Ruby : AP4R (いたわさににほんしゅ)</a> (2007-06-10 (Sun) 22:14:05)</li>
 </ul>
-<blockquote><p>発表させてもらいました。資料は、もうちょっと待ってください。 スタッフの方に取っていただいた速報ログはこちらです。ありがとうございました。 「日本 Ruby 会議 2007 - Log0610-S1-04」<a href="Log0610-S1-04.html" class="external">http://jp.rubyist.net/RubyKaigi2007/Log0610-S1-04.html</a> まとめ * シンプルAPI *</p>
+<blockquote><p>発表させてもらいました。資料は、もうちょっと待ってください。 スタッフの方に取っていただいた速報ログはこちらです。ありがとうございました。 「日本 Ruby 会議 2007 - Log0610-S1-04」<a href="Log0610-S1-04.html" class="external">https://rubykaigi.org/2007/Log0610-S1-04.html</a> まとめ * シンプルAPI *</p>
 </blockquote>
 <ul>
 <li>trackback : <a href="http://ytesaki.jot.com/WikiHome/Event/RubyKaigi2007" class="external">RubyKaigi2007 (JotSpot Wiki (ytesaki))</a> (2007-06-10 (日) 22:11:51)</li>
@@ -454,7 +454,7 @@ dRubyによるマルチコアRubyでほとんど線形のスケーラビリテ�
 <ul>
 <li>trackback : <a href="http://d.hatena.ne.jp/mikihoshi/20070610/1181429259" class="external">RubyKaigi2007 (ふしはらかんの四方山話)</a> (2007-06-10 (Sun) 10:33:36)</li>
 </ul>
-<blockquote><p><a href="index.html" class="external">http://jp.rubyist.net/RubyKaigi2007/</a> 今年も実行委員という名の喫茶店のマスターをやらせてもらってます*1。ロビーでも講演の様子を見られるので大変ありがたいところ。本日も10時から開演ですので参加者の皆さんよろしくお願いします。 もちろん、詳細は後で書く。 速報</p>
+<blockquote><p><a href="index.html" class="external">https://rubykaigi.org/2007/</a> 今年も実行委員という名の喫茶店のマスターをやらせてもらってます*1。ロビーでも講演の様子を見られるので大変ありがたいところ。本日も10時から開演ですので参加者の皆さんよろしくお願いします。 もちろん、詳細は後で書く。 速報</p>
 </blockquote>
     </div>
   </div>

--- a/2007/index.html
+++ b/2007/index.html
@@ -56,7 +56,7 @@ Ruby は言語そのものも、そして利用方法も、その時々によっ
 <h3><a name="l5"><span class="sanchor"> </span></a><a href="./BuyTicket.html">参加方法</a></h3>
 <p><a href="./BuyTicket.html">チケットの購入</a>が必要です。</p>
 <h3><a name="l6"><span class="sanchor"> </span></a>プログラム</h3>
-<p>詳細は<a href="http://jp.rubyist.net/RubyKaigi2007/Program.html" class="external">こちら</a>です。</p>
+<p>詳細は<a href="https://rubykaigi.org/2007/Program.html" class="external">こちら</a>です。</p>
 <h4><a name="l7"> </a>基調講演</h4>
 <ul>
 <li>まつもとゆきひろ (Ruby の父)</li>
@@ -105,7 +105,7 @@ Ruby は言語そのものも、そして利用方法も、その時々によっ
   <div class="body">
     <div class="section">
       <ul>
-<li><a href="http://jp.rubyist.net/RubyKaigi2006/" class="external">日本Rubyカンファレンス2006</a></li>
+<li><a href="https://rubykaigi.org/2006/" class="external">日本Rubyカンファレンス2006</a></li>
 </ul>
     </div>
   </div>

--- a/2008/index.html
+++ b/2008/index.html
@@ -96,8 +96,8 @@
                 <div class="body">
                     <div class="section">
                         <ul>
-                            <li><a href="http://jp.rubyist.net/RubyKaigi2007/" class="external">日本Ruby会議2007</a></li>
-                            <li><a href="http://jp.rubyist.net/RubyKaigi2006/" class="external">日本Rubyカンファレンス2006</a></li>
+                            <li><a href="https://rubykaigi.org/2007/" class="external">日本Ruby会議2007</a></li>
+                            <li><a href="https://rubykaigi.org/2006/" class="external">日本Rubyカンファレンス2006</a></li>
                         </ul>
                         <p><br>
                             <br>

--- a/2009/en/Information/index.html
+++ b/2009/en/Information/index.html
@@ -142,9 +142,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/Information/index.html
+++ b/2009/en/Information/index.html
@@ -142,8 +142,8 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/Sponsors/index.html
+++ b/2009/en/Sponsors/index.html
@@ -114,9 +114,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/Sponsors/index.html
+++ b/2009/en/Sponsors/index.html
@@ -114,8 +114,8 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/Team/index.html
+++ b/2009/en/Team/index.html
@@ -190,8 +190,8 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/Team/index.html
+++ b/2009/en/Team/index.html
@@ -190,9 +190,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/goodies/index.html
+++ b/2009/en/goodies/index.html
@@ -168,9 +168,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/goodies/index.html
+++ b/2009/en/goodies/index.html
@@ -168,8 +168,8 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/index.html
+++ b/2009/en/index.html
@@ -178,9 +178,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/index.html
+++ b/2009/en/index.html
@@ -178,8 +178,8 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/irc/index.html
+++ b/2009/en/irc/index.html
@@ -125,8 +125,8 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/irc/index.html
+++ b/2009/en/irc/index.html
@@ -125,9 +125,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/live/room1/index.html
+++ b/2009/en/live/room1/index.html
@@ -133,9 +133,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/live/room1/index.html
+++ b/2009/en/live/room1/index.html
@@ -133,8 +133,8 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/live/room2/index.html
+++ b/2009/en/live/room2/index.html
@@ -133,9 +133,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/live/room2/index.html
+++ b/2009/en/live/room2/index.html
@@ -133,8 +133,8 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/live/room3/index.html
+++ b/2009/en/live/room3/index.html
@@ -133,9 +133,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/live/room3/index.html
+++ b/2009/en/live/room3/index.html
@@ -133,8 +133,8 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/registrations/index.html
+++ b/2009/en/registrations/index.html
@@ -154,9 +154,9 @@ Fee: 5,000 JPY<br>
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/registrations/index.html
+++ b/2009/en/registrations/index.html
@@ -154,8 +154,8 @@ Fee: 5,000 JPY<br>
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/talks/17H01/index.html
+++ b/2009/en/talks/17H01/index.html
@@ -162,9 +162,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/talks/17H01/index.html
+++ b/2009/en/talks/17H01/index.html
@@ -162,8 +162,8 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/talks/17H02/index.html
+++ b/2009/en/talks/17H02/index.html
@@ -166,8 +166,8 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/talks/17H02/index.html
+++ b/2009/en/talks/17H02/index.html
@@ -166,9 +166,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/talks/17H03/index.html
+++ b/2009/en/talks/17H03/index.html
@@ -161,9 +161,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/talks/17H03/index.html
+++ b/2009/en/talks/17H03/index.html
@@ -161,8 +161,8 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/talks/17H04/index.html
+++ b/2009/en/talks/17H04/index.html
@@ -168,8 +168,8 @@ Finally, components of Rails 3 will be available, in an unprecedented way, as li
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/talks/17H04/index.html
+++ b/2009/en/talks/17H04/index.html
@@ -168,9 +168,9 @@ Finally, components of Rails 3 will be available, in an unprecedented way, as li
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/talks/17H05/index.html
+++ b/2009/en/talks/17H05/index.html
@@ -176,8 +176,8 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/talks/17H05/index.html
+++ b/2009/en/talks/17H05/index.html
@@ -176,9 +176,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/talks/17M01/index.html
+++ b/2009/en/talks/17M01/index.html
@@ -161,9 +161,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/talks/17M01/index.html
+++ b/2009/en/talks/17M01/index.html
@@ -161,8 +161,8 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/talks/17M02/index.html
+++ b/2009/en/talks/17M02/index.html
@@ -161,9 +161,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/talks/17M02/index.html
+++ b/2009/en/talks/17M02/index.html
@@ -161,8 +161,8 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/talks/17S01/index.html
+++ b/2009/en/talks/17S01/index.html
@@ -167,8 +167,8 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/talks/17S01/index.html
+++ b/2009/en/talks/17S01/index.html
@@ -167,9 +167,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/talks/17S02/index.html
+++ b/2009/en/talks/17S02/index.html
@@ -161,9 +161,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/talks/17S02/index.html
+++ b/2009/en/talks/17S02/index.html
@@ -161,8 +161,8 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/talks/17S03/index.html
+++ b/2009/en/talks/17S03/index.html
@@ -165,9 +165,9 @@ Using BDDs and ZDDs, I will show you the solution for n-Queen problem and the so
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/talks/17S03/index.html
+++ b/2009/en/talks/17S03/index.html
@@ -165,8 +165,8 @@ Using BDDs and ZDDs, I will show you the solution for n-Queen problem and the so
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/talks/17S04/index.html
+++ b/2009/en/talks/17S04/index.html
@@ -167,8 +167,8 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/talks/17S04/index.html
+++ b/2009/en/talks/17S04/index.html
@@ -167,9 +167,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/talks/17S05/index.html
+++ b/2009/en/talks/17S05/index.html
@@ -167,8 +167,8 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/talks/17S05/index.html
+++ b/2009/en/talks/17S05/index.html
@@ -167,9 +167,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/talks/18H01/index.html
+++ b/2009/en/talks/18H01/index.html
@@ -156,9 +156,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/talks/18H01/index.html
+++ b/2009/en/talks/18H01/index.html
@@ -156,8 +156,8 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/talks/18H02/index.html
+++ b/2009/en/talks/18H02/index.html
@@ -156,9 +156,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/talks/18H02/index.html
+++ b/2009/en/talks/18H02/index.html
@@ -156,8 +156,8 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/talks/18H03/index.html
+++ b/2009/en/talks/18H03/index.html
@@ -162,9 +162,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/talks/18H03/index.html
+++ b/2009/en/talks/18H03/index.html
@@ -162,8 +162,8 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/talks/18H04/index.html
+++ b/2009/en/talks/18H04/index.html
@@ -161,9 +161,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/talks/18H04/index.html
+++ b/2009/en/talks/18H04/index.html
@@ -161,8 +161,8 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/talks/18H05/index.html
+++ b/2009/en/talks/18H05/index.html
@@ -166,8 +166,8 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/talks/18H05/index.html
+++ b/2009/en/talks/18H05/index.html
@@ -166,9 +166,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/talks/18H06/index.html
+++ b/2009/en/talks/18H06/index.html
@@ -175,9 +175,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/talks/18H06/index.html
+++ b/2009/en/talks/18H06/index.html
@@ -175,8 +175,8 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/talks/18H07/index.html
+++ b/2009/en/talks/18H07/index.html
@@ -157,8 +157,8 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/talks/18H07/index.html
+++ b/2009/en/talks/18H07/index.html
@@ -157,9 +157,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/talks/18H08/index.html
+++ b/2009/en/talks/18H08/index.html
@@ -159,8 +159,8 @@ NIFTY Corportaion portal system engineer. I am taking charge of development of c
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/talks/18H08/index.html
+++ b/2009/en/talks/18H08/index.html
@@ -159,9 +159,9 @@ NIFTY Corportaion portal system engineer. I am taking charge of development of c
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/talks/18H09/index.html
+++ b/2009/en/talks/18H09/index.html
@@ -157,8 +157,8 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/talks/18H09/index.html
+++ b/2009/en/talks/18H09/index.html
@@ -157,9 +157,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/talks/18H10/index.html
+++ b/2009/en/talks/18H10/index.html
@@ -156,9 +156,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/talks/18H10/index.html
+++ b/2009/en/talks/18H10/index.html
@@ -156,8 +156,8 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/talks/18H11/index.html
+++ b/2009/en/talks/18H11/index.html
@@ -156,9 +156,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/talks/18H11/index.html
+++ b/2009/en/talks/18H11/index.html
@@ -156,8 +156,8 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/talks/18H12/index.html
+++ b/2009/en/talks/18H12/index.html
@@ -157,8 +157,8 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/talks/18H12/index.html
+++ b/2009/en/talks/18H12/index.html
@@ -157,9 +157,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/talks/18H13/index.html
+++ b/2009/en/talks/18H13/index.html
@@ -157,8 +157,8 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/talks/18H13/index.html
+++ b/2009/en/talks/18H13/index.html
@@ -157,9 +157,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/talks/18M01/index.html
+++ b/2009/en/talks/18M01/index.html
@@ -163,8 +163,8 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/talks/18M01/index.html
+++ b/2009/en/talks/18M01/index.html
@@ -163,9 +163,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/talks/18M02/index.html
+++ b/2009/en/talks/18M02/index.html
@@ -162,9 +162,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/talks/18M02/index.html
+++ b/2009/en/talks/18M02/index.html
@@ -162,8 +162,8 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/talks/18M03/index.html
+++ b/2009/en/talks/18M03/index.html
@@ -162,9 +162,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/talks/18M03/index.html
+++ b/2009/en/talks/18M03/index.html
@@ -162,8 +162,8 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/talks/18M04/index.html
+++ b/2009/en/talks/18M04/index.html
@@ -161,9 +161,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/talks/18M04/index.html
+++ b/2009/en/talks/18M04/index.html
@@ -161,8 +161,8 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/talks/18M05/index.html
+++ b/2009/en/talks/18M05/index.html
@@ -166,8 +166,8 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/talks/18M05/index.html
+++ b/2009/en/talks/18M05/index.html
@@ -166,9 +166,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/talks/18M06/index.html
+++ b/2009/en/talks/18M06/index.html
@@ -167,8 +167,8 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/talks/18M06/index.html
+++ b/2009/en/talks/18M06/index.html
@@ -167,9 +167,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/talks/18S01/index.html
+++ b/2009/en/talks/18S01/index.html
@@ -170,9 +170,9 @@ I will show the problems, solutions, and tips for game programming.</p>
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/talks/18S01/index.html
+++ b/2009/en/talks/18S01/index.html
@@ -170,8 +170,8 @@ I will show the problems, solutions, and tips for game programming.</p>
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/talks/18S02/index.html
+++ b/2009/en/talks/18S02/index.html
@@ -162,9 +162,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/talks/18S02/index.html
+++ b/2009/en/talks/18S02/index.html
@@ -162,8 +162,8 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/talks/18S03/index.html
+++ b/2009/en/talks/18S03/index.html
@@ -177,8 +177,8 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/talks/18S03/index.html
+++ b/2009/en/talks/18S03/index.html
@@ -177,9 +177,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/talks/18S04/index.html
+++ b/2009/en/talks/18S04/index.html
@@ -167,8 +167,8 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/talks/18S04/index.html
+++ b/2009/en/talks/18S04/index.html
@@ -167,9 +167,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/talks/18S05/index.html
+++ b/2009/en/talks/18S05/index.html
@@ -161,9 +161,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/talks/18S05/index.html
+++ b/2009/en/talks/18S05/index.html
@@ -161,8 +161,8 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/talks/18S06/index.html
+++ b/2009/en/talks/18S06/index.html
@@ -161,9 +161,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/talks/18S06/index.html
+++ b/2009/en/talks/18S06/index.html
@@ -161,8 +161,8 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/talks/18S07/index.html
+++ b/2009/en/talks/18S07/index.html
@@ -161,9 +161,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/talks/18S07/index.html
+++ b/2009/en/talks/18S07/index.html
@@ -161,8 +161,8 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/talks/19H01/index.html
+++ b/2009/en/talks/19H01/index.html
@@ -161,9 +161,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/talks/19H01/index.html
+++ b/2009/en/talks/19H01/index.html
@@ -161,8 +161,8 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/talks/19H02/index.html
+++ b/2009/en/talks/19H02/index.html
@@ -167,8 +167,8 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/talks/19H02/index.html
+++ b/2009/en/talks/19H02/index.html
@@ -167,9 +167,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/talks/19H03/index.html
+++ b/2009/en/talks/19H03/index.html
@@ -161,9 +161,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/talks/19H03/index.html
+++ b/2009/en/talks/19H03/index.html
@@ -161,8 +161,8 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/talks/19H04/index.html
+++ b/2009/en/talks/19H04/index.html
@@ -167,8 +167,8 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/talks/19H04/index.html
+++ b/2009/en/talks/19H04/index.html
@@ -167,9 +167,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/talks/19H05/index.html
+++ b/2009/en/talks/19H05/index.html
@@ -172,8 +172,8 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/talks/19H05/index.html
+++ b/2009/en/talks/19H05/index.html
@@ -172,9 +172,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/talks/19H06/index.html
+++ b/2009/en/talks/19H06/index.html
@@ -171,9 +171,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/talks/19H06/index.html
+++ b/2009/en/talks/19H06/index.html
@@ -171,8 +171,8 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/talks/19H07/index.html
+++ b/2009/en/talks/19H07/index.html
@@ -174,9 +174,9 @@ He is also the founder and president of Nihon Ruby-no-kai.</p>
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/talks/19H07/index.html
+++ b/2009/en/talks/19H07/index.html
@@ -174,8 +174,8 @@ He is also the founder and president of Nihon Ruby-no-kai.</p>
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/talks/19M01/index.html
+++ b/2009/en/talks/19M01/index.html
@@ -161,9 +161,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/talks/19M01/index.html
+++ b/2009/en/talks/19M01/index.html
@@ -161,8 +161,8 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/talks/19M02/index.html
+++ b/2009/en/talks/19M02/index.html
@@ -181,8 +181,8 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/talks/19M02/index.html
+++ b/2009/en/talks/19M02/index.html
@@ -181,9 +181,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/talks/19M03/index.html
+++ b/2009/en/talks/19M03/index.html
@@ -162,9 +162,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/talks/19M03/index.html
+++ b/2009/en/talks/19M03/index.html
@@ -162,8 +162,8 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/talks/19M04/index.html
+++ b/2009/en/talks/19M04/index.html
@@ -156,9 +156,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/talks/19M04/index.html
+++ b/2009/en/talks/19M04/index.html
@@ -156,8 +156,8 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/talks/19M05/index.html
+++ b/2009/en/talks/19M05/index.html
@@ -162,9 +162,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/talks/19M05/index.html
+++ b/2009/en/talks/19M05/index.html
@@ -162,8 +162,8 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/talks/19M06/index.html
+++ b/2009/en/talks/19M06/index.html
@@ -177,8 +177,8 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/talks/19M06/index.html
+++ b/2009/en/talks/19M06/index.html
@@ -177,9 +177,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/talks/19M07/index.html
+++ b/2009/en/talks/19M07/index.html
@@ -166,8 +166,8 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/talks/19M07/index.html
+++ b/2009/en/talks/19M07/index.html
@@ -166,9 +166,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/talks/19M08/index.html
+++ b/2009/en/talks/19M08/index.html
@@ -171,9 +171,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/talks/19M08/index.html
+++ b/2009/en/talks/19M08/index.html
@@ -171,8 +171,8 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/talks/19S01/index.html
+++ b/2009/en/talks/19S01/index.html
@@ -161,9 +161,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/talks/19S01/index.html
+++ b/2009/en/talks/19S01/index.html
@@ -161,8 +161,8 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/talks/19S02/index.html
+++ b/2009/en/talks/19S02/index.html
@@ -162,9 +162,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/talks/19S02/index.html
+++ b/2009/en/talks/19S02/index.html
@@ -162,8 +162,8 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/talks/19S03/index.html
+++ b/2009/en/talks/19S03/index.html
@@ -166,8 +166,8 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/talks/19S03/index.html
+++ b/2009/en/talks/19S03/index.html
@@ -166,9 +166,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/talks/19S04/index.html
+++ b/2009/en/talks/19S04/index.html
@@ -161,9 +161,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/talks/19S04/index.html
+++ b/2009/en/talks/19S04/index.html
@@ -161,8 +161,8 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/talks/19S05/index.html
+++ b/2009/en/talks/19S05/index.html
@@ -161,9 +161,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/talks/19S05/index.html
+++ b/2009/en/talks/19S05/index.html
@@ -161,8 +161,8 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/talks/19S06/index.html
+++ b/2009/en/talks/19S06/index.html
@@ -161,9 +161,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/talks/19S06/index.html
+++ b/2009/en/talks/19S06/index.html
@@ -161,8 +161,8 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/talks/19S07/index.html
+++ b/2009/en/talks/19S07/index.html
@@ -166,8 +166,8 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/talks/19S07/index.html
+++ b/2009/en/talks/19S07/index.html
@@ -166,9 +166,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/en/talks/index.html
+++ b/2009/en/talks/index.html
@@ -669,8 +669,8 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
-      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2008/english.html">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/english.html">RubyKaigi2007</a></li>
       <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>

--- a/2009/en/talks/index.html
+++ b/2009/en/talks/index.html
@@ -669,9 +669,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/en">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/index.html
+++ b/2009/index.html
@@ -197,9 +197,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/Information/index.html
+++ b/2009/ja/Information/index.html
@@ -170,9 +170,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/Press/index.html
+++ b/2009/ja/Press/index.html
@@ -129,9 +129,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/Sponsors/index.html
+++ b/2009/ja/Sponsors/index.html
@@ -293,9 +293,9 @@ SKIPの開発・コミュニティ運営は、ユーザコミュニティ"SKIP�
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/Team/index.html
+++ b/2009/ja/Team/index.html
@@ -197,9 +197,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/goodies/index.html
+++ b/2009/ja/goodies/index.html
@@ -180,9 +180,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/index.html
+++ b/2009/ja/index.html
@@ -197,9 +197,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/irc/index.html
+++ b/2009/ja/irc/index.html
@@ -126,9 +126,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/live/room1/index.html
+++ b/2009/ja/live/room1/index.html
@@ -140,9 +140,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/live/room2/index.html
+++ b/2009/ja/live/room2/index.html
@@ -140,9 +140,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/live/room3/index.html
+++ b/2009/ja/live/room3/index.html
@@ -140,9 +140,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/registrations/index.html
+++ b/2009/ja/registrations/index.html
@@ -175,9 +175,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/17H01/index.html
+++ b/2009/ja/talks/17H01/index.html
@@ -169,9 +169,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/17H02/index.html
+++ b/2009/ja/talks/17H02/index.html
@@ -173,9 +173,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/17H03/index.html
+++ b/2009/ja/talks/17H03/index.html
@@ -168,9 +168,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/17H04/index.html
+++ b/2009/ja/talks/17H04/index.html
@@ -175,9 +175,9 @@ Finally, components of Rails 3 will be available, in an unprecedented way, as li
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/17H05/index.html
+++ b/2009/ja/talks/17H05/index.html
@@ -189,9 +189,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/17H06/index.html
+++ b/2009/ja/talks/17H06/index.html
@@ -163,9 +163,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/17H07/index.html
+++ b/2009/ja/talks/17H07/index.html
@@ -163,9 +163,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/17H08/index.html
+++ b/2009/ja/talks/17H08/index.html
@@ -164,9 +164,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/17H09/index.html
+++ b/2009/ja/talks/17H09/index.html
@@ -164,9 +164,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/17H10/index.html
+++ b/2009/ja/talks/17H10/index.html
@@ -163,9 +163,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/17H11/index.html
+++ b/2009/ja/talks/17H11/index.html
@@ -163,9 +163,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/17H12/index.html
+++ b/2009/ja/talks/17H12/index.html
@@ -164,9 +164,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/17H13/index.html
+++ b/2009/ja/talks/17H13/index.html
@@ -163,9 +163,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/17H14/index.html
+++ b/2009/ja/talks/17H14/index.html
@@ -163,9 +163,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/17H15/index.html
+++ b/2009/ja/talks/17H15/index.html
@@ -163,9 +163,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/17H16/index.html
+++ b/2009/ja/talks/17H16/index.html
@@ -163,9 +163,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/17M01/index.html
+++ b/2009/ja/talks/17M01/index.html
@@ -169,9 +169,9 @@ Ruby on Railsは、単にプロダクトとして高く評価されていると�
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/17M02/index.html
+++ b/2009/ja/talks/17M02/index.html
@@ -168,9 +168,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/17S01/index.html
+++ b/2009/ja/talks/17S01/index.html
@@ -174,9 +174,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/17S02/index.html
+++ b/2009/ja/talks/17S02/index.html
@@ -168,9 +168,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/17S03/index.html
+++ b/2009/ja/talks/17S03/index.html
@@ -169,9 +169,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/17S04/index.html
+++ b/2009/ja/talks/17S04/index.html
@@ -174,9 +174,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/17S05/index.html
+++ b/2009/ja/talks/17S05/index.html
@@ -174,9 +174,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/18H01/index.html
+++ b/2009/ja/talks/18H01/index.html
@@ -163,9 +163,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/18H02/index.html
+++ b/2009/ja/talks/18H02/index.html
@@ -163,9 +163,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/18H03/index.html
+++ b/2009/ja/talks/18H03/index.html
@@ -169,9 +169,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/18H04/index.html
+++ b/2009/ja/talks/18H04/index.html
@@ -168,9 +168,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/18H05/index.html
+++ b/2009/ja/talks/18H05/index.html
@@ -173,9 +173,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/18H06/index.html
+++ b/2009/ja/talks/18H06/index.html
@@ -189,9 +189,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/18H07/index.html
+++ b/2009/ja/talks/18H07/index.html
@@ -164,9 +164,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/18H08/index.html
+++ b/2009/ja/talks/18H08/index.html
@@ -166,9 +166,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/18H09/index.html
+++ b/2009/ja/talks/18H09/index.html
@@ -164,9 +164,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/18H10/index.html
+++ b/2009/ja/talks/18H10/index.html
@@ -163,9 +163,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/18H11/index.html
+++ b/2009/ja/talks/18H11/index.html
@@ -163,9 +163,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/18H12/index.html
+++ b/2009/ja/talks/18H12/index.html
@@ -164,9 +164,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/18H13/index.html
+++ b/2009/ja/talks/18H13/index.html
@@ -172,9 +172,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/18H14/index.html
+++ b/2009/ja/talks/18H14/index.html
@@ -163,9 +163,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/18H15/index.html
+++ b/2009/ja/talks/18H15/index.html
@@ -164,9 +164,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/18H16/index.html
+++ b/2009/ja/talks/18H16/index.html
@@ -164,9 +164,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/18H17/index.html
+++ b/2009/ja/talks/18H17/index.html
@@ -167,9 +167,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/18H18/index.html
+++ b/2009/ja/talks/18H18/index.html
@@ -163,9 +163,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/18H19/index.html
+++ b/2009/ja/talks/18H19/index.html
@@ -164,9 +164,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/18H20/index.html
+++ b/2009/ja/talks/18H20/index.html
@@ -164,9 +164,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/18H21/index.html
+++ b/2009/ja/talks/18H21/index.html
@@ -168,9 +168,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/18H22/index.html
+++ b/2009/ja/talks/18H22/index.html
@@ -163,9 +163,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/18H23/index.html
+++ b/2009/ja/talks/18H23/index.html
@@ -163,9 +163,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/18H24/index.html
+++ b/2009/ja/talks/18H24/index.html
@@ -163,9 +163,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/18M01/index.html
+++ b/2009/ja/talks/18M01/index.html
@@ -170,9 +170,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/18M02/index.html
+++ b/2009/ja/talks/18M02/index.html
@@ -169,9 +169,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/18M03/index.html
+++ b/2009/ja/talks/18M03/index.html
@@ -169,9 +169,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/18M04/index.html
+++ b/2009/ja/talks/18M04/index.html
@@ -168,9 +168,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/18M05/index.html
+++ b/2009/ja/talks/18M05/index.html
@@ -173,9 +173,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/18M06/index.html
+++ b/2009/ja/talks/18M06/index.html
@@ -174,9 +174,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/18S01/index.html
+++ b/2009/ja/talks/18S01/index.html
@@ -179,9 +179,9 @@ Rubyでゲーム作りが注目されていたりいなかったりしますが�
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/18S02/index.html
+++ b/2009/ja/talks/18S02/index.html
@@ -169,9 +169,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/18S03/index.html
+++ b/2009/ja/talks/18S03/index.html
@@ -184,9 +184,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/18S04/index.html
+++ b/2009/ja/talks/18S04/index.html
@@ -175,9 +175,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/18S05/index.html
+++ b/2009/ja/talks/18S05/index.html
@@ -169,9 +169,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/18S06/index.html
+++ b/2009/ja/talks/18S06/index.html
@@ -168,9 +168,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/18S07/index.html
+++ b/2009/ja/talks/18S07/index.html
@@ -168,9 +168,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/19H01/index.html
+++ b/2009/ja/talks/19H01/index.html
@@ -168,9 +168,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/19H02/index.html
+++ b/2009/ja/talks/19H02/index.html
@@ -174,9 +174,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/19H03/index.html
+++ b/2009/ja/talks/19H03/index.html
@@ -168,9 +168,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/19H04/index.html
+++ b/2009/ja/talks/19H04/index.html
@@ -174,9 +174,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/19H05/index.html
+++ b/2009/ja/talks/19H05/index.html
@@ -179,9 +179,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/19H06/index.html
+++ b/2009/ja/talks/19H06/index.html
@@ -178,9 +178,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/19H07/index.html
+++ b/2009/ja/talks/19H07/index.html
@@ -179,9 +179,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/19M01/index.html
+++ b/2009/ja/talks/19M01/index.html
@@ -168,9 +168,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/19M02/index.html
+++ b/2009/ja/talks/19M02/index.html
@@ -188,9 +188,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/19M03/index.html
+++ b/2009/ja/talks/19M03/index.html
@@ -169,9 +169,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/19M04/index.html
+++ b/2009/ja/talks/19M04/index.html
@@ -163,9 +163,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/19M05/index.html
+++ b/2009/ja/talks/19M05/index.html
@@ -169,9 +169,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/19M06/index.html
+++ b/2009/ja/talks/19M06/index.html
@@ -184,9 +184,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/19M07/index.html
+++ b/2009/ja/talks/19M07/index.html
@@ -173,9 +173,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/19M08/index.html
+++ b/2009/ja/talks/19M08/index.html
@@ -178,9 +178,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/19S01/index.html
+++ b/2009/ja/talks/19S01/index.html
@@ -168,9 +168,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/19S02/index.html
+++ b/2009/ja/talks/19S02/index.html
@@ -169,9 +169,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/19S03/index.html
+++ b/2009/ja/talks/19S03/index.html
@@ -173,9 +173,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/19S04/index.html
+++ b/2009/ja/talks/19S04/index.html
@@ -168,9 +168,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/19S05/index.html
+++ b/2009/ja/talks/19S05/index.html
@@ -168,9 +168,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/19S06/index.html
+++ b/2009/ja/talks/19S06/index.html
@@ -168,9 +168,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/19S07/index.html
+++ b/2009/ja/talks/19S07/index.html
@@ -173,9 +173,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2009/ja/talks/index.html
+++ b/2009/ja/talks/index.html
@@ -676,9 +676,9 @@
     <h2>RubyKaigi Archive</h2>
     <ul>
       <li><a href="/2009/ja">RubyKaigi2009</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2008/">RubyKaigi2008</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2007/">RubyKaigi2007</a></li>
-      <li><a href="http://jp.rubyist.net/RubyKaigi2006/">RubyKaigi2006</a></li>
+      <li><a href="https://rubykaigi.org/2008/">RubyKaigi2008</a></li>
+      <li><a href="https://rubykaigi.org/2007/">RubyKaigi2007</a></li>
+      <li><a href="https://rubykaigi.org/2006/">RubyKaigi2006</a></li>
     </ul>
   </div>
 

--- a/2010/en/Accommodation/index.html
+++ b/2010/en/Accommodation/index.html
@@ -88,17 +88,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/Accommodation/index.html
+++ b/2010/en/Accommodation/index.html
@@ -88,12 +88,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/Goodies/index.html
+++ b/2010/en/Goodies/index.html
@@ -88,17 +88,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/Goodies/index.html
+++ b/2010/en/Goodies/index.html
@@ -88,12 +88,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/Information/index.html
+++ b/2010/en/Information/index.html
@@ -88,17 +88,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/Information/index.html
+++ b/2010/en/Information/index.html
@@ -88,12 +88,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/Live/index.html
+++ b/2010/en/Live/index.html
@@ -88,17 +88,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/Live/index.html
+++ b/2010/en/Live/index.html
@@ -88,12 +88,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/Microsoft/index.html
+++ b/2010/en/Microsoft/index.html
@@ -88,17 +88,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/Microsoft/index.html
+++ b/2010/en/Microsoft/index.html
@@ -88,12 +88,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/NaCl/index.html
+++ b/2010/en/NaCl/index.html
@@ -88,17 +88,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/NaCl/index.html
+++ b/2010/en/NaCl/index.html
@@ -88,12 +88,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/Photos/index.html
+++ b/2010/en/Photos/index.html
@@ -88,17 +88,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/Photos/index.html
+++ b/2010/en/Photos/index.html
@@ -88,12 +88,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/Prospectus/index.html
+++ b/2010/en/Prospectus/index.html
@@ -88,17 +88,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/Prospectus/index.html
+++ b/2010/en/Prospectus/index.html
@@ -88,12 +88,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/Registration/index.html
+++ b/2010/en/Registration/index.html
@@ -88,12 +88,12 @@ RubyKaigi 2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/">
+<a href="https://rubykaigi.org/2008/english.html">
 RubyKaigi 2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/">
+<a href="https://rubykaigi.org/2007/english.html">
 RubyKaigi 2007
 </a>
 </li>

--- a/2010/en/Registration/index.html
+++ b/2010/en/Registration/index.html
@@ -88,17 +88,17 @@ RubyKaigi 2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/">
+<a href="https://rubykaigi.org/2008/">
 RubyKaigi 2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/">
+<a href="https://rubykaigi.org/2007/">
 RubyKaigi 2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/">
+<a href="https://rubykaigi.org/2006/">
 RubyKaigi 2006
 </a>
 </li>

--- a/2010/en/Ricoh/index.html
+++ b/2010/en/Ricoh/index.html
@@ -88,17 +88,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/Ricoh/index.html
+++ b/2010/en/Ricoh/index.html
@@ -88,12 +88,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/Sponsors/index.html
+++ b/2010/en/Sponsors/index.html
@@ -88,12 +88,12 @@ RubyKaigi 2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/">
+<a href="https://rubykaigi.org/2008/english.html">
 RubyKaigi 2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/">
+<a href="https://rubykaigi.org/2007/english.html">
 RubyKaigi 2007
 </a>
 </li>

--- a/2010/en/Sponsors/index.html
+++ b/2010/en/Sponsors/index.html
@@ -88,17 +88,17 @@ RubyKaigi 2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/">
+<a href="https://rubykaigi.org/2008/">
 RubyKaigi 2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/">
+<a href="https://rubykaigi.org/2007/">
 RubyKaigi 2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/">
+<a href="https://rubykaigi.org/2006/">
 RubyKaigi 2006
 </a>
 </li>

--- a/2010/en/SponsorsGold/index.html
+++ b/2010/en/SponsorsGold/index.html
@@ -88,17 +88,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/SponsorsGold/index.html
+++ b/2010/en/SponsorsGold/index.html
@@ -88,12 +88,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/SponsorsPlatinum/index.html
+++ b/2010/en/SponsorsPlatinum/index.html
@@ -88,17 +88,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/SponsorsPlatinum/index.html
+++ b/2010/en/SponsorsPlatinum/index.html
@@ -88,12 +88,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/Team/index.html
+++ b/2010/en/Team/index.html
@@ -88,17 +88,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/Team/index.html
+++ b/2010/en/Team/index.html
@@ -88,12 +88,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/Twitter/index.html
+++ b/2010/en/Twitter/index.html
@@ -88,17 +88,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/Twitter/index.html
+++ b/2010/en/Twitter/index.html
@@ -88,12 +88,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/1/index.html
+++ b/2010/en/events/1/index.html
@@ -88,17 +88,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/1/index.html
+++ b/2010/en/events/1/index.html
@@ -88,12 +88,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/10/index.html
+++ b/2010/en/events/10/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/10/index.html
+++ b/2010/en/events/10/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/100/index.html
+++ b/2010/en/events/100/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/100/index.html
+++ b/2010/en/events/100/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/101/index.html
+++ b/2010/en/events/101/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/101/index.html
+++ b/2010/en/events/101/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/102/index.html
+++ b/2010/en/events/102/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/102/index.html
+++ b/2010/en/events/102/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/11/index.html
+++ b/2010/en/events/11/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/11/index.html
+++ b/2010/en/events/11/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/12/index.html
+++ b/2010/en/events/12/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/12/index.html
+++ b/2010/en/events/12/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/14/index.html
+++ b/2010/en/events/14/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/14/index.html
+++ b/2010/en/events/14/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/15/index.html
+++ b/2010/en/events/15/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/15/index.html
+++ b/2010/en/events/15/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/16/index.html
+++ b/2010/en/events/16/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/16/index.html
+++ b/2010/en/events/16/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/18/index.html
+++ b/2010/en/events/18/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/18/index.html
+++ b/2010/en/events/18/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/19/index.html
+++ b/2010/en/events/19/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/19/index.html
+++ b/2010/en/events/19/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/2/index.html
+++ b/2010/en/events/2/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/2/index.html
+++ b/2010/en/events/2/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/20/index.html
+++ b/2010/en/events/20/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/20/index.html
+++ b/2010/en/events/20/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/21/index.html
+++ b/2010/en/events/21/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/21/index.html
+++ b/2010/en/events/21/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/22/index.html
+++ b/2010/en/events/22/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/22/index.html
+++ b/2010/en/events/22/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/23/index.html
+++ b/2010/en/events/23/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/23/index.html
+++ b/2010/en/events/23/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/24/index.html
+++ b/2010/en/events/24/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/24/index.html
+++ b/2010/en/events/24/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/25/index.html
+++ b/2010/en/events/25/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/25/index.html
+++ b/2010/en/events/25/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/26/index.html
+++ b/2010/en/events/26/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/26/index.html
+++ b/2010/en/events/26/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/27/index.html
+++ b/2010/en/events/27/index.html
@@ -88,17 +88,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/27/index.html
+++ b/2010/en/events/27/index.html
@@ -88,12 +88,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/28/index.html
+++ b/2010/en/events/28/index.html
@@ -88,17 +88,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/28/index.html
+++ b/2010/en/events/28/index.html
@@ -88,12 +88,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/29/index.html
+++ b/2010/en/events/29/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/29/index.html
+++ b/2010/en/events/29/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/3/index.html
+++ b/2010/en/events/3/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/3/index.html
+++ b/2010/en/events/3/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/30/index.html
+++ b/2010/en/events/30/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/30/index.html
+++ b/2010/en/events/30/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/32/index.html
+++ b/2010/en/events/32/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/32/index.html
+++ b/2010/en/events/32/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/33/index.html
+++ b/2010/en/events/33/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/33/index.html
+++ b/2010/en/events/33/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/34/index.html
+++ b/2010/en/events/34/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/34/index.html
+++ b/2010/en/events/34/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/36/index.html
+++ b/2010/en/events/36/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/36/index.html
+++ b/2010/en/events/36/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/38/index.html
+++ b/2010/en/events/38/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/38/index.html
+++ b/2010/en/events/38/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/39/index.html
+++ b/2010/en/events/39/index.html
@@ -88,17 +88,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/39/index.html
+++ b/2010/en/events/39/index.html
@@ -88,12 +88,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/4/index.html
+++ b/2010/en/events/4/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/4/index.html
+++ b/2010/en/events/4/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/40/index.html
+++ b/2010/en/events/40/index.html
@@ -88,17 +88,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/40/index.html
+++ b/2010/en/events/40/index.html
@@ -88,12 +88,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/41/index.html
+++ b/2010/en/events/41/index.html
@@ -88,17 +88,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/41/index.html
+++ b/2010/en/events/41/index.html
@@ -88,12 +88,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/42/index.html
+++ b/2010/en/events/42/index.html
@@ -88,17 +88,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/42/index.html
+++ b/2010/en/events/42/index.html
@@ -88,12 +88,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/43/index.html
+++ b/2010/en/events/43/index.html
@@ -88,17 +88,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/43/index.html
+++ b/2010/en/events/43/index.html
@@ -88,12 +88,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/44/index.html
+++ b/2010/en/events/44/index.html
@@ -88,17 +88,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/44/index.html
+++ b/2010/en/events/44/index.html
@@ -88,12 +88,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/45/index.html
+++ b/2010/en/events/45/index.html
@@ -88,17 +88,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/45/index.html
+++ b/2010/en/events/45/index.html
@@ -88,12 +88,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/46/index.html
+++ b/2010/en/events/46/index.html
@@ -88,17 +88,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/46/index.html
+++ b/2010/en/events/46/index.html
@@ -88,12 +88,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/47/index.html
+++ b/2010/en/events/47/index.html
@@ -88,17 +88,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/47/index.html
+++ b/2010/en/events/47/index.html
@@ -88,12 +88,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/48/index.html
+++ b/2010/en/events/48/index.html
@@ -88,17 +88,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/48/index.html
+++ b/2010/en/events/48/index.html
@@ -88,12 +88,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/49/index.html
+++ b/2010/en/events/49/index.html
@@ -88,17 +88,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/49/index.html
+++ b/2010/en/events/49/index.html
@@ -88,12 +88,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/50/index.html
+++ b/2010/en/events/50/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/50/index.html
+++ b/2010/en/events/50/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/51/index.html
+++ b/2010/en/events/51/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/51/index.html
+++ b/2010/en/events/51/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/52/index.html
+++ b/2010/en/events/52/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/52/index.html
+++ b/2010/en/events/52/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/54/index.html
+++ b/2010/en/events/54/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/54/index.html
+++ b/2010/en/events/54/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/55/index.html
+++ b/2010/en/events/55/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/55/index.html
+++ b/2010/en/events/55/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/57/index.html
+++ b/2010/en/events/57/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/57/index.html
+++ b/2010/en/events/57/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/59/index.html
+++ b/2010/en/events/59/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/59/index.html
+++ b/2010/en/events/59/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/6/index.html
+++ b/2010/en/events/6/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/6/index.html
+++ b/2010/en/events/6/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/60/index.html
+++ b/2010/en/events/60/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/60/index.html
+++ b/2010/en/events/60/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/61/index.html
+++ b/2010/en/events/61/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/61/index.html
+++ b/2010/en/events/61/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/62/index.html
+++ b/2010/en/events/62/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/62/index.html
+++ b/2010/en/events/62/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/63/index.html
+++ b/2010/en/events/63/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/63/index.html
+++ b/2010/en/events/63/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/64/index.html
+++ b/2010/en/events/64/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/64/index.html
+++ b/2010/en/events/64/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/65/index.html
+++ b/2010/en/events/65/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/65/index.html
+++ b/2010/en/events/65/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/66/index.html
+++ b/2010/en/events/66/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/66/index.html
+++ b/2010/en/events/66/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/67/index.html
+++ b/2010/en/events/67/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/67/index.html
+++ b/2010/en/events/67/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/68/index.html
+++ b/2010/en/events/68/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/68/index.html
+++ b/2010/en/events/68/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/69/index.html
+++ b/2010/en/events/69/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/69/index.html
+++ b/2010/en/events/69/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/7/index.html
+++ b/2010/en/events/7/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/7/index.html
+++ b/2010/en/events/7/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/70/index.html
+++ b/2010/en/events/70/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/70/index.html
+++ b/2010/en/events/70/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/71/index.html
+++ b/2010/en/events/71/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/71/index.html
+++ b/2010/en/events/71/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/72/index.html
+++ b/2010/en/events/72/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/72/index.html
+++ b/2010/en/events/72/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/73/index.html
+++ b/2010/en/events/73/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/73/index.html
+++ b/2010/en/events/73/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/75/index.html
+++ b/2010/en/events/75/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/75/index.html
+++ b/2010/en/events/75/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/77/index.html
+++ b/2010/en/events/77/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/77/index.html
+++ b/2010/en/events/77/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/78/index.html
+++ b/2010/en/events/78/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/78/index.html
+++ b/2010/en/events/78/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/80/index.html
+++ b/2010/en/events/80/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/80/index.html
+++ b/2010/en/events/80/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/81/index.html
+++ b/2010/en/events/81/index.html
@@ -88,17 +88,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/81/index.html
+++ b/2010/en/events/81/index.html
@@ -88,12 +88,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/82/index.html
+++ b/2010/en/events/82/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/82/index.html
+++ b/2010/en/events/82/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/83/index.html
+++ b/2010/en/events/83/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/83/index.html
+++ b/2010/en/events/83/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/84/index.html
+++ b/2010/en/events/84/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/84/index.html
+++ b/2010/en/events/84/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/85/index.html
+++ b/2010/en/events/85/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/85/index.html
+++ b/2010/en/events/85/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/86/index.html
+++ b/2010/en/events/86/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/86/index.html
+++ b/2010/en/events/86/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/88/index.html
+++ b/2010/en/events/88/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/88/index.html
+++ b/2010/en/events/88/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/89/index.html
+++ b/2010/en/events/89/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/89/index.html
+++ b/2010/en/events/89/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/9/index.html
+++ b/2010/en/events/9/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/9/index.html
+++ b/2010/en/events/9/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/91/index.html
+++ b/2010/en/events/91/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/91/index.html
+++ b/2010/en/events/91/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/92/index.html
+++ b/2010/en/events/92/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/92/index.html
+++ b/2010/en/events/92/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/94/index.html
+++ b/2010/en/events/94/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/94/index.html
+++ b/2010/en/events/94/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/95/index.html
+++ b/2010/en/events/95/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/95/index.html
+++ b/2010/en/events/95/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/96/index.html
+++ b/2010/en/events/96/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/96/index.html
+++ b/2010/en/events/96/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/97/index.html
+++ b/2010/en/events/97/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/97/index.html
+++ b/2010/en/events/97/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/98/index.html
+++ b/2010/en/events/98/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/98/index.html
+++ b/2010/en/events/98/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/99/index.html
+++ b/2010/en/events/99/index.html
@@ -82,17 +82,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/99/index.html
+++ b/2010/en/events/99/index.html
@@ -82,12 +82,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/events/index.html
+++ b/2010/en/events/index.html
@@ -88,17 +88,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/events/index.html
+++ b/2010/en/events/index.html
@@ -88,12 +88,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/index.html
+++ b/2010/en/index.html
@@ -88,17 +88,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/index.html
+++ b/2010/en/index.html
@@ -88,12 +88,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/en/timetable/index.html
+++ b/2010/en/timetable/index.html
@@ -88,17 +88,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     RubyKaigi 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     RubyKaigi 2006
                   </a>
                 </li>

--- a/2010/en/timetable/index.html
+++ b/2010/en/timetable/index.html
@@ -88,12 +88,12 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2008/">
+                  <a href="https://rubykaigi.org/2008/english.html">
                     RubyKaigi 2008
                   </a>
                 </li>
                 <li>
-                  <a href="https://rubykaigi.org/2007/">
+                  <a href="https://rubykaigi.org/2007/english.html">
                     RubyKaigi 2007
                   </a>
                 </li>

--- a/2010/index.html
+++ b/2010/index.html
@@ -91,17 +91,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/Accommodation/index.html
+++ b/2010/ja/Accommodation/index.html
@@ -91,17 +91,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/Goodies/index.html
+++ b/2010/ja/Goodies/index.html
@@ -91,17 +91,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/Information/index.html
+++ b/2010/ja/Information/index.html
@@ -91,17 +91,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/Live/index.html
+++ b/2010/ja/Live/index.html
@@ -91,17 +91,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/Microsoft/index.html
+++ b/2010/ja/Microsoft/index.html
@@ -91,17 +91,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/NaCl/index.html
+++ b/2010/ja/NaCl/index.html
@@ -91,17 +91,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/Photos/index.html
+++ b/2010/ja/Photos/index.html
@@ -91,17 +91,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/Press/index.html
+++ b/2010/ja/Press/index.html
@@ -91,17 +91,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/Prospectus/index.html
+++ b/2010/ja/Prospectus/index.html
@@ -91,17 +91,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/Registration/index.html
+++ b/2010/ja/Registration/index.html
@@ -91,17 +91,17 @@ Goldスポンサー
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/">
+<a href="https://rubykaigi.org/2008/">
 日本Ruby会議 2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/">
+<a href="https://rubykaigi.org/2007/">
 日本Ruby会議 2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/">
+<a href="https://rubykaigi.org/2006/">
 日本Ruby会議 2006
 </a>
 </li>

--- a/2010/ja/Ricoh/index.html
+++ b/2010/ja/Ricoh/index.html
@@ -91,17 +91,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/Sponsors/index.html
+++ b/2010/ja/Sponsors/index.html
@@ -91,17 +91,17 @@ Goldスポンサー
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/">
+<a href="https://rubykaigi.org/2008/">
 日本Ruby会議 2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/">
+<a href="https://rubykaigi.org/2007/">
 日本Ruby会議 2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/">
+<a href="https://rubykaigi.org/2006/">
 日本Ruby会議 2006
 </a>
 </li>

--- a/2010/ja/SponsorsGold/index.html
+++ b/2010/ja/SponsorsGold/index.html
@@ -91,17 +91,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/SponsorsPlatinum/index.html
+++ b/2010/ja/SponsorsPlatinum/index.html
@@ -91,17 +91,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/Team/index.html
+++ b/2010/ja/Team/index.html
@@ -91,17 +91,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/Twitter/index.html
+++ b/2010/ja/Twitter/index.html
@@ -91,17 +91,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/1/index.html
+++ b/2010/ja/events/1/index.html
@@ -91,17 +91,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/10/index.html
+++ b/2010/ja/events/10/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/100/index.html
+++ b/2010/ja/events/100/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/101/index.html
+++ b/2010/ja/events/101/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/102/index.html
+++ b/2010/ja/events/102/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/11/index.html
+++ b/2010/ja/events/11/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/12/index.html
+++ b/2010/ja/events/12/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/14/index.html
+++ b/2010/ja/events/14/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/15/index.html
+++ b/2010/ja/events/15/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/16/index.html
+++ b/2010/ja/events/16/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/18/index.html
+++ b/2010/ja/events/18/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/19/index.html
+++ b/2010/ja/events/19/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/2/index.html
+++ b/2010/ja/events/2/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/20/index.html
+++ b/2010/ja/events/20/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/21/index.html
+++ b/2010/ja/events/21/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/22/index.html
+++ b/2010/ja/events/22/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/23/index.html
+++ b/2010/ja/events/23/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/24/index.html
+++ b/2010/ja/events/24/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/25/index.html
+++ b/2010/ja/events/25/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/26/index.html
+++ b/2010/ja/events/26/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/27/index.html
+++ b/2010/ja/events/27/index.html
@@ -91,17 +91,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/28/index.html
+++ b/2010/ja/events/28/index.html
@@ -91,17 +91,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/29/index.html
+++ b/2010/ja/events/29/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/3/index.html
+++ b/2010/ja/events/3/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/30/index.html
+++ b/2010/ja/events/30/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/32/index.html
+++ b/2010/ja/events/32/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/33/index.html
+++ b/2010/ja/events/33/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/34/index.html
+++ b/2010/ja/events/34/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/36/index.html
+++ b/2010/ja/events/36/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/38/index.html
+++ b/2010/ja/events/38/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/39/index.html
+++ b/2010/ja/events/39/index.html
@@ -91,17 +91,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/4/index.html
+++ b/2010/ja/events/4/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/40/index.html
+++ b/2010/ja/events/40/index.html
@@ -91,17 +91,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/41/index.html
+++ b/2010/ja/events/41/index.html
@@ -91,17 +91,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/42/index.html
+++ b/2010/ja/events/42/index.html
@@ -91,17 +91,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/43/index.html
+++ b/2010/ja/events/43/index.html
@@ -91,17 +91,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/44/index.html
+++ b/2010/ja/events/44/index.html
@@ -91,17 +91,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/45/index.html
+++ b/2010/ja/events/45/index.html
@@ -91,17 +91,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/46/index.html
+++ b/2010/ja/events/46/index.html
@@ -91,17 +91,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/47/index.html
+++ b/2010/ja/events/47/index.html
@@ -91,17 +91,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/48/index.html
+++ b/2010/ja/events/48/index.html
@@ -91,17 +91,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/49/index.html
+++ b/2010/ja/events/49/index.html
@@ -91,17 +91,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/50/index.html
+++ b/2010/ja/events/50/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/51/index.html
+++ b/2010/ja/events/51/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/52/index.html
+++ b/2010/ja/events/52/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/54/index.html
+++ b/2010/ja/events/54/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/55/index.html
+++ b/2010/ja/events/55/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/57/index.html
+++ b/2010/ja/events/57/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/59/index.html
+++ b/2010/ja/events/59/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/6/index.html
+++ b/2010/ja/events/6/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/60/index.html
+++ b/2010/ja/events/60/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/61/index.html
+++ b/2010/ja/events/61/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/62/index.html
+++ b/2010/ja/events/62/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/63/index.html
+++ b/2010/ja/events/63/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/64/index.html
+++ b/2010/ja/events/64/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/65/index.html
+++ b/2010/ja/events/65/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/66/index.html
+++ b/2010/ja/events/66/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/67/index.html
+++ b/2010/ja/events/67/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/68/index.html
+++ b/2010/ja/events/68/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/69/index.html
+++ b/2010/ja/events/69/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/7/index.html
+++ b/2010/ja/events/7/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/70/index.html
+++ b/2010/ja/events/70/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/71/index.html
+++ b/2010/ja/events/71/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/72/index.html
+++ b/2010/ja/events/72/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/73/index.html
+++ b/2010/ja/events/73/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/75/index.html
+++ b/2010/ja/events/75/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/77/index.html
+++ b/2010/ja/events/77/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/78/index.html
+++ b/2010/ja/events/78/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/80/index.html
+++ b/2010/ja/events/80/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/81/index.html
+++ b/2010/ja/events/81/index.html
@@ -91,17 +91,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/82/index.html
+++ b/2010/ja/events/82/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/83/index.html
+++ b/2010/ja/events/83/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/84/index.html
+++ b/2010/ja/events/84/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/85/index.html
+++ b/2010/ja/events/85/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/86/index.html
+++ b/2010/ja/events/86/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/88/index.html
+++ b/2010/ja/events/88/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/89/index.html
+++ b/2010/ja/events/89/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/9/index.html
+++ b/2010/ja/events/9/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/91/index.html
+++ b/2010/ja/events/91/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/92/index.html
+++ b/2010/ja/events/92/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/94/index.html
+++ b/2010/ja/events/94/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/95/index.html
+++ b/2010/ja/events/95/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/96/index.html
+++ b/2010/ja/events/96/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/97/index.html
+++ b/2010/ja/events/97/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/98/index.html
+++ b/2010/ja/events/98/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/99/index.html
+++ b/2010/ja/events/99/index.html
@@ -85,17 +85,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/events/index.html
+++ b/2010/ja/events/index.html
@@ -91,17 +91,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/index.html
+++ b/2010/ja/index.html
@@ -91,17 +91,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2010/ja/timetable/index.html
+++ b/2010/ja/timetable/index.html
@@ -91,17 +91,17 @@
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2008/">
+                  <a href="https://rubykaigi.org/2008/">
                     日本Ruby会議 2008
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2007/">
+                  <a href="https://rubykaigi.org/2007/">
                     日本Ruby会議 2007
                   </a>
                 </li>
                 <li>
-                  <a href="http://jp.rubyist.net/RubyKaigi2006/">
+                  <a href="https://rubykaigi.org/2006/">
                     日本Ruby会議 2006
                   </a>
                 </li>

--- a/2011/en/about/index.html
+++ b/2011/en/about/index.html
@@ -453,17 +453,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/about/index.html
+++ b/2011/en/about/index.html
@@ -453,12 +453,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/advent_calendar/index.html
+++ b/2011/en/advent_calendar/index.html
@@ -803,12 +803,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/advent_calendar/index.html
+++ b/2011/en/advent_calendar/index.html
@@ -803,17 +803,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/archives/index.html
+++ b/2011/en/archives/index.html
@@ -113,7 +113,7 @@ RubyKaigi2009
 RubyKaigi2008
 </h2>
 <p>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 <img alt="RubyKaigi2008" src="/2011/images/rubykaigi2008.png">
 </a>
 </p>
@@ -123,7 +123,7 @@ RubyKaigi2008
 RubyKaigi2007
 </h2>
 <p>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 <img alt="RubyKaigi2007" src="/2011/images/rubykaigi2007.png">
 </a>
 </p>
@@ -356,12 +356,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/archives/index.html
+++ b/2011/en/archives/index.html
@@ -113,7 +113,7 @@ RubyKaigi2009
 RubyKaigi2008
 </h2>
 <p>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 <img alt="RubyKaigi2008" src="/2011/images/rubykaigi2008.png">
 </a>
 </p>
@@ -123,7 +123,7 @@ RubyKaigi2008
 RubyKaigi2007
 </h2>
 <p>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 <img alt="RubyKaigi2007" src="/2011/images/rubykaigi2007.png">
 </a>
 </p>
@@ -133,7 +133,7 @@ RubyKaigi2007
 RubyKaigi2006
 </h2>
 <p>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 <img alt="RubyKaigi2006" src="/2011/images/rubykaigi2006.png">
 </a>
 </p>
@@ -356,17 +356,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/for_attendees/index.html
+++ b/2011/en/for_attendees/index.html
@@ -850,17 +850,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/for_attendees/index.html
+++ b/2011/en/for_attendees/index.html
@@ -850,12 +850,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/index.html
+++ b/2011/en/index.html
@@ -1190,12 +1190,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/index.html
+++ b/2011/en/index.html
@@ -1190,17 +1190,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/live1/index.html
+++ b/2011/en/live1/index.html
@@ -317,12 +317,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/live1/index.html
+++ b/2011/en/live1/index.html
@@ -317,17 +317,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/live2/index.html
+++ b/2011/en/live2/index.html
@@ -317,12 +317,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/live2/index.html
+++ b/2011/en/live2/index.html
@@ -317,17 +317,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/registration/index.html
+++ b/2011/en/registration/index.html
@@ -443,12 +443,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/registration/index.html
+++ b/2011/en/registration/index.html
@@ -443,17 +443,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/16M01/index.html
+++ b/2011/en/schedule/details/16M01/index.html
@@ -377,12 +377,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/16M01/index.html
+++ b/2011/en/schedule/details/16M01/index.html
@@ -377,17 +377,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/16M02/index.html
+++ b/2011/en/schedule/details/16M02/index.html
@@ -368,17 +368,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/16M02/index.html
+++ b/2011/en/schedule/details/16M02/index.html
@@ -368,12 +368,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/16M03/index.html
+++ b/2011/en/schedule/details/16M03/index.html
@@ -374,12 +374,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/16M03/index.html
+++ b/2011/en/schedule/details/16M03/index.html
@@ -374,17 +374,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/16M04/index.html
+++ b/2011/en/schedule/details/16M04/index.html
@@ -374,12 +374,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/16M04/index.html
+++ b/2011/en/schedule/details/16M04/index.html
@@ -374,17 +374,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/16M05/index.html
+++ b/2011/en/schedule/details/16M05/index.html
@@ -374,12 +374,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/16M05/index.html
+++ b/2011/en/schedule/details/16M05/index.html
@@ -374,17 +374,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/16M06/index.html
+++ b/2011/en/schedule/details/16M06/index.html
@@ -384,12 +384,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/16M06/index.html
+++ b/2011/en/schedule/details/16M06/index.html
@@ -384,17 +384,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/16M07/index.html
+++ b/2011/en/schedule/details/16M07/index.html
@@ -377,12 +377,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/16M07/index.html
+++ b/2011/en/schedule/details/16M07/index.html
@@ -377,17 +377,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/16M08/index.html
+++ b/2011/en/schedule/details/16M08/index.html
@@ -370,12 +370,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/16M08/index.html
+++ b/2011/en/schedule/details/16M08/index.html
@@ -370,17 +370,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/16MDN/index.html
+++ b/2011/en/schedule/details/16MDN/index.html
@@ -337,12 +337,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/16MDN/index.html
+++ b/2011/en/schedule/details/16MDN/index.html
@@ -337,17 +337,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/16MOP/index.html
+++ b/2011/en/schedule/details/16MOP/index.html
@@ -354,12 +354,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/16MOP/index.html
+++ b/2011/en/schedule/details/16MOP/index.html
@@ -354,17 +354,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/16S01/index.html
+++ b/2011/en/schedule/details/16S01/index.html
@@ -376,17 +376,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/16S01/index.html
+++ b/2011/en/schedule/details/16S01/index.html
@@ -376,12 +376,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/16S02/index.html
+++ b/2011/en/schedule/details/16S02/index.html
@@ -368,17 +368,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/16S02/index.html
+++ b/2011/en/schedule/details/16S02/index.html
@@ -368,12 +368,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/16S03/index.html
+++ b/2011/en/schedule/details/16S03/index.html
@@ -371,17 +371,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/16S03/index.html
+++ b/2011/en/schedule/details/16S03/index.html
@@ -371,12 +371,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/16S04/index.html
+++ b/2011/en/schedule/details/16S04/index.html
@@ -380,17 +380,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/16S04/index.html
+++ b/2011/en/schedule/details/16S04/index.html
@@ -380,12 +380,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/16S05/index.html
+++ b/2011/en/schedule/details/16S05/index.html
@@ -387,12 +387,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/16S05/index.html
+++ b/2011/en/schedule/details/16S05/index.html
@@ -387,17 +387,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/16S06/index.html
+++ b/2011/en/schedule/details/16S06/index.html
@@ -377,12 +377,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/16S06/index.html
+++ b/2011/en/schedule/details/16S06/index.html
@@ -377,17 +377,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/17M01/index.html
+++ b/2011/en/schedule/details/17M01/index.html
@@ -374,12 +374,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/17M01/index.html
+++ b/2011/en/schedule/details/17M01/index.html
@@ -374,17 +374,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/17M02/index.html
+++ b/2011/en/schedule/details/17M02/index.html
@@ -374,12 +374,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/17M02/index.html
+++ b/2011/en/schedule/details/17M02/index.html
@@ -374,17 +374,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/17M03/index.html
+++ b/2011/en/schedule/details/17M03/index.html
@@ -385,12 +385,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/17M03/index.html
+++ b/2011/en/schedule/details/17M03/index.html
@@ -385,17 +385,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/17M04/index.html
+++ b/2011/en/schedule/details/17M04/index.html
@@ -374,12 +374,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/17M04/index.html
+++ b/2011/en/schedule/details/17M04/index.html
@@ -374,17 +374,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/17M05/index.html
+++ b/2011/en/schedule/details/17M05/index.html
@@ -376,17 +376,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/17M05/index.html
+++ b/2011/en/schedule/details/17M05/index.html
@@ -376,12 +376,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/17M06/index.html
+++ b/2011/en/schedule/details/17M06/index.html
@@ -386,17 +386,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/17M06/index.html
+++ b/2011/en/schedule/details/17M06/index.html
@@ -386,12 +386,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/17M07/index.html
+++ b/2011/en/schedule/details/17M07/index.html
@@ -376,17 +376,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/17M07/index.html
+++ b/2011/en/schedule/details/17M07/index.html
@@ -376,12 +376,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/17M08/index.html
+++ b/2011/en/schedule/details/17M08/index.html
@@ -369,12 +369,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/17M08/index.html
+++ b/2011/en/schedule/details/17M08/index.html
@@ -369,17 +369,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/17M09/index.html
+++ b/2011/en/schedule/details/17M09/index.html
@@ -374,12 +374,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/17M09/index.html
+++ b/2011/en/schedule/details/17M09/index.html
@@ -374,17 +374,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/17M10/index.html
+++ b/2011/en/schedule/details/17M10/index.html
@@ -545,12 +545,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/17M10/index.html
+++ b/2011/en/schedule/details/17M10/index.html
@@ -545,17 +545,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/17M10_01/index.html
+++ b/2011/en/schedule/details/17M10_01/index.html
@@ -370,12 +370,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/17M10_01/index.html
+++ b/2011/en/schedule/details/17M10_01/index.html
@@ -370,17 +370,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/17M10_02/index.html
+++ b/2011/en/schedule/details/17M10_02/index.html
@@ -364,12 +364,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/17M10_02/index.html
+++ b/2011/en/schedule/details/17M10_02/index.html
@@ -364,17 +364,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/17M10_03/index.html
+++ b/2011/en/schedule/details/17M10_03/index.html
@@ -358,12 +358,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/17M10_03/index.html
+++ b/2011/en/schedule/details/17M10_03/index.html
@@ -358,17 +358,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/17M10_04/index.html
+++ b/2011/en/schedule/details/17M10_04/index.html
@@ -366,12 +366,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/17M10_04/index.html
+++ b/2011/en/schedule/details/17M10_04/index.html
@@ -366,17 +366,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/17M10_05/index.html
+++ b/2011/en/schedule/details/17M10_05/index.html
@@ -364,12 +364,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/17M10_05/index.html
+++ b/2011/en/schedule/details/17M10_05/index.html
@@ -364,17 +364,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/17M10_06/index.html
+++ b/2011/en/schedule/details/17M10_06/index.html
@@ -370,12 +370,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/17M10_06/index.html
+++ b/2011/en/schedule/details/17M10_06/index.html
@@ -370,17 +370,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/17M10_07/index.html
+++ b/2011/en/schedule/details/17M10_07/index.html
@@ -370,12 +370,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/17M10_07/index.html
+++ b/2011/en/schedule/details/17M10_07/index.html
@@ -370,17 +370,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/17M10_08/index.html
+++ b/2011/en/schedule/details/17M10_08/index.html
@@ -364,12 +364,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/17M10_08/index.html
+++ b/2011/en/schedule/details/17M10_08/index.html
@@ -364,17 +364,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/17M10_09/index.html
+++ b/2011/en/schedule/details/17M10_09/index.html
@@ -364,12 +364,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/17M10_09/index.html
+++ b/2011/en/schedule/details/17M10_09/index.html
@@ -364,17 +364,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/17M10_10/index.html
+++ b/2011/en/schedule/details/17M10_10/index.html
@@ -364,12 +364,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/17M10_10/index.html
+++ b/2011/en/schedule/details/17M10_10/index.html
@@ -364,17 +364,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/17M10_11/index.html
+++ b/2011/en/schedule/details/17M10_11/index.html
@@ -364,12 +364,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/17M10_11/index.html
+++ b/2011/en/schedule/details/17M10_11/index.html
@@ -364,17 +364,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/17S01/index.html
+++ b/2011/en/schedule/details/17S01/index.html
@@ -377,12 +377,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/17S01/index.html
+++ b/2011/en/schedule/details/17S01/index.html
@@ -377,17 +377,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/17S02/index.html
+++ b/2011/en/schedule/details/17S02/index.html
@@ -374,12 +374,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/17S02/index.html
+++ b/2011/en/schedule/details/17S02/index.html
@@ -374,17 +374,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/17S03/index.html
+++ b/2011/en/schedule/details/17S03/index.html
@@ -376,17 +376,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/17S03/index.html
+++ b/2011/en/schedule/details/17S03/index.html
@@ -376,12 +376,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/17S04/index.html
+++ b/2011/en/schedule/details/17S04/index.html
@@ -374,12 +374,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/17S04/index.html
+++ b/2011/en/schedule/details/17S04/index.html
@@ -374,17 +374,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/17S05/index.html
+++ b/2011/en/schedule/details/17S05/index.html
@@ -374,12 +374,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/17S05/index.html
+++ b/2011/en/schedule/details/17S05/index.html
@@ -374,17 +374,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/17S06/index.html
+++ b/2011/en/schedule/details/17S06/index.html
@@ -374,12 +374,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/17S06/index.html
+++ b/2011/en/schedule/details/17S06/index.html
@@ -374,17 +374,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/17S07/index.html
+++ b/2011/en/schedule/details/17S07/index.html
@@ -389,17 +389,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/17S07/index.html
+++ b/2011/en/schedule/details/17S07/index.html
@@ -389,12 +389,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/17S08/index.html
+++ b/2011/en/schedule/details/17S08/index.html
@@ -377,12 +377,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/17S08/index.html
+++ b/2011/en/schedule/details/17S08/index.html
@@ -377,17 +377,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/17S09/index.html
+++ b/2011/en/schedule/details/17S09/index.html
@@ -375,12 +375,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/17S09/index.html
+++ b/2011/en/schedule/details/17S09/index.html
@@ -375,17 +375,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/17S10/index.html
+++ b/2011/en/schedule/details/17S10/index.html
@@ -378,17 +378,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/17S10/index.html
+++ b/2011/en/schedule/details/17S10/index.html
@@ -378,12 +378,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/18M01/index.html
+++ b/2011/en/schedule/details/18M01/index.html
@@ -398,17 +398,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/18M01/index.html
+++ b/2011/en/schedule/details/18M01/index.html
@@ -398,12 +398,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/18M03/index.html
+++ b/2011/en/schedule/details/18M03/index.html
@@ -394,12 +394,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/18M03/index.html
+++ b/2011/en/schedule/details/18M03/index.html
@@ -394,17 +394,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/18M05/index.html
+++ b/2011/en/schedule/details/18M05/index.html
@@ -384,12 +384,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/18M05/index.html
+++ b/2011/en/schedule/details/18M05/index.html
@@ -384,17 +384,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/18M06/index.html
+++ b/2011/en/schedule/details/18M06/index.html
@@ -380,17 +380,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/18M06/index.html
+++ b/2011/en/schedule/details/18M06/index.html
@@ -380,12 +380,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/18M07/index.html
+++ b/2011/en/schedule/details/18M07/index.html
@@ -374,12 +374,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/18M07/index.html
+++ b/2011/en/schedule/details/18M07/index.html
@@ -374,17 +374,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/18M08/index.html
+++ b/2011/en/schedule/details/18M08/index.html
@@ -377,12 +377,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/18M08/index.html
+++ b/2011/en/schedule/details/18M08/index.html
@@ -377,17 +377,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/18M09/index.html
+++ b/2011/en/schedule/details/18M09/index.html
@@ -543,12 +543,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/18M09/index.html
+++ b/2011/en/schedule/details/18M09/index.html
@@ -543,17 +543,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/18M09_01/index.html
+++ b/2011/en/schedule/details/18M09_01/index.html
@@ -358,12 +358,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/18M09_01/index.html
+++ b/2011/en/schedule/details/18M09_01/index.html
@@ -358,17 +358,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/18M09_02/index.html
+++ b/2011/en/schedule/details/18M09_02/index.html
@@ -358,12 +358,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/18M09_02/index.html
+++ b/2011/en/schedule/details/18M09_02/index.html
@@ -358,17 +358,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/18M09_03/index.html
+++ b/2011/en/schedule/details/18M09_03/index.html
@@ -358,12 +358,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/18M09_03/index.html
+++ b/2011/en/schedule/details/18M09_03/index.html
@@ -358,17 +358,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/18M09_04/index.html
+++ b/2011/en/schedule/details/18M09_04/index.html
@@ -364,12 +364,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/18M09_04/index.html
+++ b/2011/en/schedule/details/18M09_04/index.html
@@ -364,17 +364,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/18M09_05/index.html
+++ b/2011/en/schedule/details/18M09_05/index.html
@@ -364,12 +364,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/18M09_05/index.html
+++ b/2011/en/schedule/details/18M09_05/index.html
@@ -364,17 +364,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/18M09_06/index.html
+++ b/2011/en/schedule/details/18M09_06/index.html
@@ -364,12 +364,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/18M09_06/index.html
+++ b/2011/en/schedule/details/18M09_06/index.html
@@ -364,17 +364,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/18M09_07/index.html
+++ b/2011/en/schedule/details/18M09_07/index.html
@@ -364,12 +364,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/18M09_07/index.html
+++ b/2011/en/schedule/details/18M09_07/index.html
@@ -364,17 +364,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/18M09_08/index.html
+++ b/2011/en/schedule/details/18M09_08/index.html
@@ -364,12 +364,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/18M09_08/index.html
+++ b/2011/en/schedule/details/18M09_08/index.html
@@ -364,17 +364,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/18M09_09/index.html
+++ b/2011/en/schedule/details/18M09_09/index.html
@@ -364,12 +364,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/18M09_09/index.html
+++ b/2011/en/schedule/details/18M09_09/index.html
@@ -364,17 +364,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/18M09_10/index.html
+++ b/2011/en/schedule/details/18M09_10/index.html
@@ -364,12 +364,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/18M09_10/index.html
+++ b/2011/en/schedule/details/18M09_10/index.html
@@ -364,17 +364,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/18M09_11/index.html
+++ b/2011/en/schedule/details/18M09_11/index.html
@@ -364,12 +364,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/18M09_11/index.html
+++ b/2011/en/schedule/details/18M09_11/index.html
@@ -364,17 +364,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/18M10/index.html
+++ b/2011/en/schedule/details/18M10/index.html
@@ -374,12 +374,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/18M10/index.html
+++ b/2011/en/schedule/details/18M10/index.html
@@ -374,17 +374,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/18MCL/index.html
+++ b/2011/en/schedule/details/18MCL/index.html
@@ -347,17 +347,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/18MCL/index.html
+++ b/2011/en/schedule/details/18MCL/index.html
@@ -347,12 +347,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/18S01/index.html
+++ b/2011/en/schedule/details/18S01/index.html
@@ -374,12 +374,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/18S01/index.html
+++ b/2011/en/schedule/details/18S01/index.html
@@ -374,17 +374,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/18S02/index.html
+++ b/2011/en/schedule/details/18S02/index.html
@@ -377,12 +377,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/18S02/index.html
+++ b/2011/en/schedule/details/18S02/index.html
@@ -377,17 +377,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/18S03/index.html
+++ b/2011/en/schedule/details/18S03/index.html
@@ -384,12 +384,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/18S03/index.html
+++ b/2011/en/schedule/details/18S03/index.html
@@ -384,17 +384,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/18S04/index.html
+++ b/2011/en/schedule/details/18S04/index.html
@@ -387,12 +387,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/18S04/index.html
+++ b/2011/en/schedule/details/18S04/index.html
@@ -387,17 +387,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/18S05/index.html
+++ b/2011/en/schedule/details/18S05/index.html
@@ -368,17 +368,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/18S05/index.html
+++ b/2011/en/schedule/details/18S05/index.html
@@ -368,12 +368,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/18S06/index.html
+++ b/2011/en/schedule/details/18S06/index.html
@@ -375,12 +375,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/18S06/index.html
+++ b/2011/en/schedule/details/18S06/index.html
@@ -375,17 +375,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/18S07/index.html
+++ b/2011/en/schedule/details/18S07/index.html
@@ -369,12 +369,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/18S07/index.html
+++ b/2011/en/schedule/details/18S07/index.html
@@ -369,17 +369,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/details/18S08/index.html
+++ b/2011/en/schedule/details/18S08/index.html
@@ -377,12 +377,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/schedule/details/18S08/index.html
+++ b/2011/en/schedule/details/18S08/index.html
@@ -377,17 +377,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/grid/index.html
+++ b/2011/en/schedule/grid/index.html
@@ -2437,17 +2437,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/schedule/grid/index.html
+++ b/2011/en/schedule/grid/index.html
@@ -2437,12 +2437,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/sponsors/index.html
+++ b/2011/en/sponsors/index.html
@@ -989,12 +989,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/sponsors/index.html
+++ b/2011/en/sponsors/index.html
@@ -989,17 +989,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/sponsors_gold/index.html
+++ b/2011/en/sponsors_gold/index.html
@@ -630,17 +630,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/sponsors_gold/index.html
+++ b/2011/en/sponsors_gold/index.html
@@ -630,12 +630,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/sponsors_individual/index.html
+++ b/2011/en/sponsors_individual/index.html
@@ -1192,17 +1192,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/sponsors_individual/index.html
+++ b/2011/en/sponsors_individual/index.html
@@ -1192,12 +1192,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/sponsors_platinum/index.html
+++ b/2011/en/sponsors_platinum/index.html
@@ -466,12 +466,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/sponsors_platinum/index.html
+++ b/2011/en/sponsors_platinum/index.html
@@ -466,17 +466,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/sponsors_ruby_R01/index.html
+++ b/2011/en/sponsors_ruby_R01/index.html
@@ -315,17 +315,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/sponsors_ruby_R01/index.html
+++ b/2011/en/sponsors_ruby_R01/index.html
@@ -315,12 +315,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/sponsors_ruby_R02/index.html
+++ b/2011/en/sponsors_ruby_R02/index.html
@@ -322,12 +322,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/sponsors_ruby_R02/index.html
+++ b/2011/en/sponsors_ruby_R02/index.html
@@ -322,17 +322,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/sponsors_ruby_R03/index.html
+++ b/2011/en/sponsors_ruby_R03/index.html
@@ -314,17 +314,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/en/sponsors_ruby_R03/index.html
+++ b/2011/en/sponsors_ruby_R03/index.html
@@ -314,12 +314,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/team/index.html
+++ b/2011/en/team/index.html
@@ -763,12 +763,12 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/english.html" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="https://rubykaigi.org/2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/english.html" target="_blank">
 RubyKaigi2007
 </a>
 </li>

--- a/2011/en/team/index.html
+++ b/2011/en/team/index.html
@@ -763,17 +763,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/index.html
+++ b/2011/index.html
@@ -1190,17 +1190,17 @@ RubyKaigi2009
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 RubyKaigi2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 RubyKaigi2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 RubyKaigi2006
 </a>
 </li>

--- a/2011/ja/about/index.html
+++ b/2011/ja/about/index.html
@@ -453,17 +453,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/advent_calendar/index.html
+++ b/2011/ja/advent_calendar/index.html
@@ -808,17 +808,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/archives/index.html
+++ b/2011/ja/archives/index.html
@@ -113,7 +113,7 @@
 日本Ruby会議2008
 </h2>
 <p>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 <img alt="日本Ruby会議2008" src="/2011/images/rubykaigi2008.png">
 </a>
 </p>
@@ -123,7 +123,7 @@
 日本Ruby会議2007
 </h2>
 <p>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 <img alt="日本Ruby会議2007" src="/2011/images/rubykaigi2007.png">
 </a>
 </p>
@@ -133,7 +133,7 @@
 日本Ruby会議2006
 </h2>
 <p>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 <img alt="日本Ruby会議2006" src="/2011/images/rubykaigi2006.png">
 </a>
 </p>
@@ -356,17 +356,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/for_attendees/index.html
+++ b/2011/ja/for_attendees/index.html
@@ -808,17 +808,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/index.html
+++ b/2011/ja/index.html
@@ -1192,17 +1192,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/live1/index.html
+++ b/2011/ja/live1/index.html
@@ -317,17 +317,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/live2/index.html
+++ b/2011/ja/live2/index.html
@@ -317,17 +317,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/registration/index.html
+++ b/2011/ja/registration/index.html
@@ -446,17 +446,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/16M01/index.html
+++ b/2011/ja/schedule/details/16M01/index.html
@@ -377,17 +377,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/16M02/index.html
+++ b/2011/ja/schedule/details/16M02/index.html
@@ -368,17 +368,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/16M03/index.html
+++ b/2011/ja/schedule/details/16M03/index.html
@@ -374,17 +374,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/16M04/index.html
+++ b/2011/ja/schedule/details/16M04/index.html
@@ -374,17 +374,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/16M05/index.html
+++ b/2011/ja/schedule/details/16M05/index.html
@@ -374,17 +374,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/16M06/index.html
+++ b/2011/ja/schedule/details/16M06/index.html
@@ -383,17 +383,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/16M07/index.html
+++ b/2011/ja/schedule/details/16M07/index.html
@@ -377,17 +377,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/16M08/index.html
+++ b/2011/ja/schedule/details/16M08/index.html
@@ -372,17 +372,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/16MDN/index.html
+++ b/2011/ja/schedule/details/16MDN/index.html
@@ -337,17 +337,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/16MOP/index.html
+++ b/2011/ja/schedule/details/16MOP/index.html
@@ -354,17 +354,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/16S01/index.html
+++ b/2011/ja/schedule/details/16S01/index.html
@@ -372,17 +372,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/16S02/index.html
+++ b/2011/ja/schedule/details/16S02/index.html
@@ -368,17 +368,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/16S03/index.html
+++ b/2011/ja/schedule/details/16S03/index.html
@@ -369,17 +369,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/16S04/index.html
+++ b/2011/ja/schedule/details/16S04/index.html
@@ -380,17 +380,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/16S05/index.html
+++ b/2011/ja/schedule/details/16S05/index.html
@@ -386,17 +386,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/16S06/index.html
+++ b/2011/ja/schedule/details/16S06/index.html
@@ -374,17 +374,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/17M01/index.html
+++ b/2011/ja/schedule/details/17M01/index.html
@@ -377,17 +377,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/17M02/index.html
+++ b/2011/ja/schedule/details/17M02/index.html
@@ -374,17 +374,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/17M03/index.html
+++ b/2011/ja/schedule/details/17M03/index.html
@@ -378,17 +378,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/17M04/index.html
+++ b/2011/ja/schedule/details/17M04/index.html
@@ -375,17 +375,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/17M05/index.html
+++ b/2011/ja/schedule/details/17M05/index.html
@@ -376,17 +376,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/17M06/index.html
+++ b/2011/ja/schedule/details/17M06/index.html
@@ -386,17 +386,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/17M07/index.html
+++ b/2011/ja/schedule/details/17M07/index.html
@@ -376,17 +376,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/17M08/index.html
+++ b/2011/ja/schedule/details/17M08/index.html
@@ -369,17 +369,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/17M09/index.html
+++ b/2011/ja/schedule/details/17M09/index.html
@@ -374,17 +374,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/17M10/index.html
+++ b/2011/ja/schedule/details/17M10/index.html
@@ -545,17 +545,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/17M10_01/index.html
+++ b/2011/ja/schedule/details/17M10_01/index.html
@@ -370,17 +370,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/17M10_02/index.html
+++ b/2011/ja/schedule/details/17M10_02/index.html
@@ -364,17 +364,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/17M10_03/index.html
+++ b/2011/ja/schedule/details/17M10_03/index.html
@@ -358,17 +358,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/17M10_04/index.html
+++ b/2011/ja/schedule/details/17M10_04/index.html
@@ -366,17 +366,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/17M10_05/index.html
+++ b/2011/ja/schedule/details/17M10_05/index.html
@@ -364,17 +364,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/17M10_06/index.html
+++ b/2011/ja/schedule/details/17M10_06/index.html
@@ -370,17 +370,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/17M10_07/index.html
+++ b/2011/ja/schedule/details/17M10_07/index.html
@@ -370,17 +370,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/17M10_08/index.html
+++ b/2011/ja/schedule/details/17M10_08/index.html
@@ -364,17 +364,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/17M10_09/index.html
+++ b/2011/ja/schedule/details/17M10_09/index.html
@@ -364,17 +364,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/17M10_10/index.html
+++ b/2011/ja/schedule/details/17M10_10/index.html
@@ -364,17 +364,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/17M10_11/index.html
+++ b/2011/ja/schedule/details/17M10_11/index.html
@@ -364,17 +364,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/17S01/index.html
+++ b/2011/ja/schedule/details/17S01/index.html
@@ -377,17 +377,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/17S02/index.html
+++ b/2011/ja/schedule/details/17S02/index.html
@@ -376,17 +376,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/17S03/index.html
+++ b/2011/ja/schedule/details/17S03/index.html
@@ -376,17 +376,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/17S04/index.html
+++ b/2011/ja/schedule/details/17S04/index.html
@@ -374,17 +374,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/17S05/index.html
+++ b/2011/ja/schedule/details/17S05/index.html
@@ -374,17 +374,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/17S06/index.html
+++ b/2011/ja/schedule/details/17S06/index.html
@@ -374,17 +374,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/17S07/index.html
+++ b/2011/ja/schedule/details/17S07/index.html
@@ -390,17 +390,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/17S08/index.html
+++ b/2011/ja/schedule/details/17S08/index.html
@@ -379,17 +379,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/17S09/index.html
+++ b/2011/ja/schedule/details/17S09/index.html
@@ -372,17 +372,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/17S10/index.html
+++ b/2011/ja/schedule/details/17S10/index.html
@@ -378,17 +378,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/18M01/index.html
+++ b/2011/ja/schedule/details/18M01/index.html
@@ -401,17 +401,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/18M03/index.html
+++ b/2011/ja/schedule/details/18M03/index.html
@@ -394,17 +394,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/18M05/index.html
+++ b/2011/ja/schedule/details/18M05/index.html
@@ -382,17 +382,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/18M06/index.html
+++ b/2011/ja/schedule/details/18M06/index.html
@@ -382,17 +382,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/18M07/index.html
+++ b/2011/ja/schedule/details/18M07/index.html
@@ -374,17 +374,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/18M08/index.html
+++ b/2011/ja/schedule/details/18M08/index.html
@@ -377,17 +377,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/18M09/index.html
+++ b/2011/ja/schedule/details/18M09/index.html
@@ -543,17 +543,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/18M09_01/index.html
+++ b/2011/ja/schedule/details/18M09_01/index.html
@@ -358,17 +358,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/18M09_02/index.html
+++ b/2011/ja/schedule/details/18M09_02/index.html
@@ -358,17 +358,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/18M09_03/index.html
+++ b/2011/ja/schedule/details/18M09_03/index.html
@@ -358,17 +358,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/18M09_04/index.html
+++ b/2011/ja/schedule/details/18M09_04/index.html
@@ -364,17 +364,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/18M09_05/index.html
+++ b/2011/ja/schedule/details/18M09_05/index.html
@@ -364,17 +364,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/18M09_06/index.html
+++ b/2011/ja/schedule/details/18M09_06/index.html
@@ -364,17 +364,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/18M09_07/index.html
+++ b/2011/ja/schedule/details/18M09_07/index.html
@@ -364,17 +364,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/18M09_08/index.html
+++ b/2011/ja/schedule/details/18M09_08/index.html
@@ -364,17 +364,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/18M09_09/index.html
+++ b/2011/ja/schedule/details/18M09_09/index.html
@@ -364,17 +364,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/18M09_10/index.html
+++ b/2011/ja/schedule/details/18M09_10/index.html
@@ -364,17 +364,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/18M09_11/index.html
+++ b/2011/ja/schedule/details/18M09_11/index.html
@@ -364,17 +364,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/18M10/index.html
+++ b/2011/ja/schedule/details/18M10/index.html
@@ -374,17 +374,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/18MCL/index.html
+++ b/2011/ja/schedule/details/18MCL/index.html
@@ -347,17 +347,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/18S01/index.html
+++ b/2011/ja/schedule/details/18S01/index.html
@@ -374,17 +374,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/18S02/index.html
+++ b/2011/ja/schedule/details/18S02/index.html
@@ -370,17 +370,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/18S03/index.html
+++ b/2011/ja/schedule/details/18S03/index.html
@@ -384,17 +384,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/18S04/index.html
+++ b/2011/ja/schedule/details/18S04/index.html
@@ -392,17 +392,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/18S05/index.html
+++ b/2011/ja/schedule/details/18S05/index.html
@@ -368,17 +368,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/18S06/index.html
+++ b/2011/ja/schedule/details/18S06/index.html
@@ -375,17 +375,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/18S07/index.html
+++ b/2011/ja/schedule/details/18S07/index.html
@@ -369,17 +369,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/details/18S08/index.html
+++ b/2011/ja/schedule/details/18S08/index.html
@@ -380,17 +380,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/schedule/grid/index.html
+++ b/2011/ja/schedule/grid/index.html
@@ -2435,17 +2435,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/sponsors/index.html
+++ b/2011/ja/sponsors/index.html
@@ -987,17 +987,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/sponsors_gold/index.html
+++ b/2011/ja/sponsors_gold/index.html
@@ -633,17 +633,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/sponsors_individual/index.html
+++ b/2011/ja/sponsors_individual/index.html
@@ -1192,17 +1192,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/sponsors_platinum/index.html
+++ b/2011/ja/sponsors_platinum/index.html
@@ -467,17 +467,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/sponsors_ruby_R01/index.html
+++ b/2011/ja/sponsors_ruby_R01/index.html
@@ -344,17 +344,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/sponsors_ruby_R02/index.html
+++ b/2011/ja/sponsors_ruby_R02/index.html
@@ -324,17 +324,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/sponsors_ruby_R03/index.html
+++ b/2011/ja/sponsors_ruby_R03/index.html
@@ -314,17 +314,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2011/ja/team/index.html
+++ b/2011/ja/team/index.html
@@ -763,17 +763,17 @@ FAQ
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" target="_blank">
+<a href="https://rubykaigi.org/2008/" target="_blank">
 日本Ruby会議2008
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" target="_blank">
+<a href="https://rubykaigi.org/2007/" target="_blank">
 日本Ruby会議2007
 </a>
 </li>
 <li>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" target="_blank">
+<a href="https://rubykaigi.org/2006/" target="_blank">
 日本Ruby会議2006
 </a>
 </li>

--- a/2018/past_kaigis/index.html
+++ b/2018/past_kaigis/index.html
@@ -205,7 +205,7 @@
                   </div>
                   <div class='col-xs-12 col-md-4 col-lg-3'>
                     <div class='past-kaigis-item'>
-                      <a href="https://rubykaigi.org/2008/" class="past-kaigis-item__inner" target="_blank"><img src="/2018/images/past-kaigis/2008.png" alt="RubyKaigi 2008" class="past-kaigis-item__image" />
+                      <a href="http://jp.rubyist.net/RubyKaigi2008/" class="past-kaigis-item__inner" target="_blank"><img src="/2018/images/past-kaigis/2008.png" alt="RubyKaigi 2008" class="past-kaigis-item__image" />
                       <div class='past-kaigis-item__name'>
                         RubyKaigi 2008
                       </div>
@@ -214,7 +214,7 @@
                   </div>
                   <div class='col-xs-12 col-md-4 col-lg-3'>
                     <div class='past-kaigis-item'>
-                      <a href="https://rubykaigi.org/2007/" class="past-kaigis-item__inner" target="_blank"><img src="/2018/images/past-kaigis/2007.png" alt="RubyKaigi 2007" class="past-kaigis-item__image" />
+                      <a href="http://jp.rubyist.net/RubyKaigi2007/" class="past-kaigis-item__inner" target="_blank"><img src="/2018/images/past-kaigis/2007.png" alt="RubyKaigi 2007" class="past-kaigis-item__image" />
                       <div class='past-kaigis-item__name'>
                         RubyKaigi 2007
                       </div>
@@ -223,7 +223,7 @@
                   </div>
                   <div class='col-xs-12 col-md-4 col-lg-3'>
                     <div class='past-kaigis-item'>
-                      <a href="https://rubykaigi.org/2006/" class="past-kaigis-item__inner" target="_blank"><img src="/2018/images/past-kaigis/2006.png" alt="RubyKaigi 2006" class="past-kaigis-item__image" />
+                      <a href="http://jp.rubyist.net/RubyKaigi2006/" class="past-kaigis-item__inner" target="_blank"><img src="/2018/images/past-kaigis/2006.png" alt="RubyKaigi 2006" class="past-kaigis-item__image" />
                       <div class='past-kaigis-item__name'>
                         RubyKaigi 2006
                       </div>

--- a/2018/past_kaigis/index.html
+++ b/2018/past_kaigis/index.html
@@ -205,7 +205,7 @@
                   </div>
                   <div class='col-xs-12 col-md-4 col-lg-3'>
                     <div class='past-kaigis-item'>
-                      <a href="http://jp.rubyist.net/RubyKaigi2008/" class="past-kaigis-item__inner" target="_blank"><img src="/2018/images/past-kaigis/2008.png" alt="RubyKaigi 2008" class="past-kaigis-item__image" />
+                      <a href="https://rubykaigi.org/2008/" class="past-kaigis-item__inner" target="_blank"><img src="/2018/images/past-kaigis/2008.png" alt="RubyKaigi 2008" class="past-kaigis-item__image" />
                       <div class='past-kaigis-item__name'>
                         RubyKaigi 2008
                       </div>
@@ -214,7 +214,7 @@
                   </div>
                   <div class='col-xs-12 col-md-4 col-lg-3'>
                     <div class='past-kaigis-item'>
-                      <a href="http://jp.rubyist.net/RubyKaigi2007/" class="past-kaigis-item__inner" target="_blank"><img src="/2018/images/past-kaigis/2007.png" alt="RubyKaigi 2007" class="past-kaigis-item__image" />
+                      <a href="https://rubykaigi.org/2007/" class="past-kaigis-item__inner" target="_blank"><img src="/2018/images/past-kaigis/2007.png" alt="RubyKaigi 2007" class="past-kaigis-item__image" />
                       <div class='past-kaigis-item__name'>
                         RubyKaigi 2007
                       </div>
@@ -223,7 +223,7 @@
                   </div>
                   <div class='col-xs-12 col-md-4 col-lg-3'>
                     <div class='past-kaigis-item'>
-                      <a href="http://jp.rubyist.net/RubyKaigi2006/" class="past-kaigis-item__inner" target="_blank"><img src="/2018/images/past-kaigis/2006.png" alt="RubyKaigi 2006" class="past-kaigis-item__image" />
+                      <a href="https://rubykaigi.org/2006/" class="past-kaigis-item__inner" target="_blank"><img src="/2018/images/past-kaigis/2006.png" alt="RubyKaigi 2006" class="past-kaigis-item__image" />
                       <div class='past-kaigis-item__name'>
                         RubyKaigi 2006
                       </div>

--- a/2019/past_kaigis/index.html
+++ b/2019/past_kaigis/index.html
@@ -193,7 +193,7 @@ RubyKaigi 2009
 </div>
 <div class='col-xs-12 col-sm-6 col-md-4 col-lg-3'>
 <div class='past-kaigis-item'>
-<a href="https://rubykaigi.org/2008/" class="past-kaigis-item__inner" target="_blank"><img src="/2019/images/past-kaigis/2008.png" alt="RubyKaigi 2008" class="past-kaigis-item__image" />
+<a href="http://jp.rubyist.net/RubyKaigi2008/" class="past-kaigis-item__inner" target="_blank"><img src="/2019/images/past-kaigis/2008.png" alt="RubyKaigi 2008" class="past-kaigis-item__image" />
 <div class='past-kaigis-item__name'>
 RubyKaigi 2008
 </div>
@@ -201,7 +201,7 @@ RubyKaigi 2008
 </div>
 <div class='col-xs-12 col-sm-6 col-md-4 col-lg-3'>
 <div class='past-kaigis-item'>
-<a href="https://rubykaigi.org/2007/" class="past-kaigis-item__inner" target="_blank"><img src="/2019/images/past-kaigis/2007.png" alt="RubyKaigi 2007" class="past-kaigis-item__image" />
+<a href="http://jp.rubyist.net/RubyKaigi2007/" class="past-kaigis-item__inner" target="_blank"><img src="/2019/images/past-kaigis/2007.png" alt="RubyKaigi 2007" class="past-kaigis-item__image" />
 <div class='past-kaigis-item__name'>
 RubyKaigi 2007
 </div>
@@ -209,7 +209,7 @@ RubyKaigi 2007
 </div>
 <div class='col-xs-12 col-sm-6 col-md-4 col-lg-3'>
 <div class='past-kaigis-item'>
-<a href="https://rubykaigi.org/2006/" class="past-kaigis-item__inner" target="_blank"><img src="/2019/images/past-kaigis/2006.png" alt="RubyKaigi 2006" class="past-kaigis-item__image" />
+<a href="http://jp.rubyist.net/RubyKaigi2006/" class="past-kaigis-item__inner" target="_blank"><img src="/2019/images/past-kaigis/2006.png" alt="RubyKaigi 2006" class="past-kaigis-item__image" />
 <div class='past-kaigis-item__name'>
 RubyKaigi 2006
 </div>

--- a/2019/past_kaigis/index.html
+++ b/2019/past_kaigis/index.html
@@ -193,7 +193,7 @@ RubyKaigi 2009
 </div>
 <div class='col-xs-12 col-sm-6 col-md-4 col-lg-3'>
 <div class='past-kaigis-item'>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" class="past-kaigis-item__inner" target="_blank"><img src="/2019/images/past-kaigis/2008.png" alt="RubyKaigi 2008" class="past-kaigis-item__image" />
+<a href="https://rubykaigi.org/2008/" class="past-kaigis-item__inner" target="_blank"><img src="/2019/images/past-kaigis/2008.png" alt="RubyKaigi 2008" class="past-kaigis-item__image" />
 <div class='past-kaigis-item__name'>
 RubyKaigi 2008
 </div>
@@ -201,7 +201,7 @@ RubyKaigi 2008
 </div>
 <div class='col-xs-12 col-sm-6 col-md-4 col-lg-3'>
 <div class='past-kaigis-item'>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" class="past-kaigis-item__inner" target="_blank"><img src="/2019/images/past-kaigis/2007.png" alt="RubyKaigi 2007" class="past-kaigis-item__image" />
+<a href="https://rubykaigi.org/2007/" class="past-kaigis-item__inner" target="_blank"><img src="/2019/images/past-kaigis/2007.png" alt="RubyKaigi 2007" class="past-kaigis-item__image" />
 <div class='past-kaigis-item__name'>
 RubyKaigi 2007
 </div>
@@ -209,7 +209,7 @@ RubyKaigi 2007
 </div>
 <div class='col-xs-12 col-sm-6 col-md-4 col-lg-3'>
 <div class='past-kaigis-item'>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" class="past-kaigis-item__inner" target="_blank"><img src="/2019/images/past-kaigis/2006.png" alt="RubyKaigi 2006" class="past-kaigis-item__image" />
+<a href="https://rubykaigi.org/2006/" class="past-kaigis-item__inner" target="_blank"><img src="/2019/images/past-kaigis/2006.png" alt="RubyKaigi 2006" class="past-kaigis-item__image" />
 <div class='past-kaigis-item__name'>
 RubyKaigi 2006
 </div>

--- a/2020/past_kaigis/index.html
+++ b/2020/past_kaigis/index.html
@@ -192,7 +192,7 @@ RubyKaigi 2009
 </div>
 <div class='col-xs-12 col-sm-6 col-md-4 col-lg-3'>
 <div class='past-kaigis-item'>
-<a href="https://rubykaigi.org/2008/" class="past-kaigis-item__inner" target="_blank"><img src="/2020/images/past-kaigis/2008.png" alt="RubyKaigi 2008" class="past-kaigis-item__image" />
+<a href="http://jp.rubyist.net/RubyKaigi2008/" class="past-kaigis-item__inner" target="_blank"><img src="/2020/images/past-kaigis/2008.png" alt="RubyKaigi 2008" class="past-kaigis-item__image" />
 <div class='past-kaigis-item__name'>
 RubyKaigi 2008
 </div>
@@ -200,7 +200,7 @@ RubyKaigi 2008
 </div>
 <div class='col-xs-12 col-sm-6 col-md-4 col-lg-3'>
 <div class='past-kaigis-item'>
-<a href="https://rubykaigi.org/2007/" class="past-kaigis-item__inner" target="_blank"><img src="/2020/images/past-kaigis/2007.png" alt="RubyKaigi 2007" class="past-kaigis-item__image" />
+<a href="http://jp.rubyist.net/RubyKaigi2007/" class="past-kaigis-item__inner" target="_blank"><img src="/2020/images/past-kaigis/2007.png" alt="RubyKaigi 2007" class="past-kaigis-item__image" />
 <div class='past-kaigis-item__name'>
 RubyKaigi 2007
 </div>
@@ -208,7 +208,7 @@ RubyKaigi 2007
 </div>
 <div class='col-xs-12 col-sm-6 col-md-4 col-lg-3'>
 <div class='past-kaigis-item'>
-<a href="https://rubykaigi.org/2006/" class="past-kaigis-item__inner" target="_blank"><img src="/2020/images/past-kaigis/2006.png" alt="RubyKaigi 2006" class="past-kaigis-item__image" />
+<a href="http://jp.rubyist.net/RubyKaigi2006/" class="past-kaigis-item__inner" target="_blank"><img src="/2020/images/past-kaigis/2006.png" alt="RubyKaigi 2006" class="past-kaigis-item__image" />
 <div class='past-kaigis-item__name'>
 RubyKaigi 2006
 </div>

--- a/2020/past_kaigis/index.html
+++ b/2020/past_kaigis/index.html
@@ -192,7 +192,7 @@ RubyKaigi 2009
 </div>
 <div class='col-xs-12 col-sm-6 col-md-4 col-lg-3'>
 <div class='past-kaigis-item'>
-<a href="http://jp.rubyist.net/RubyKaigi2008/" class="past-kaigis-item__inner" target="_blank"><img src="/2020/images/past-kaigis/2008.png" alt="RubyKaigi 2008" class="past-kaigis-item__image" />
+<a href="https://rubykaigi.org/2008/" class="past-kaigis-item__inner" target="_blank"><img src="/2020/images/past-kaigis/2008.png" alt="RubyKaigi 2008" class="past-kaigis-item__image" />
 <div class='past-kaigis-item__name'>
 RubyKaigi 2008
 </div>
@@ -200,7 +200,7 @@ RubyKaigi 2008
 </div>
 <div class='col-xs-12 col-sm-6 col-md-4 col-lg-3'>
 <div class='past-kaigis-item'>
-<a href="http://jp.rubyist.net/RubyKaigi2007/" class="past-kaigis-item__inner" target="_blank"><img src="/2020/images/past-kaigis/2007.png" alt="RubyKaigi 2007" class="past-kaigis-item__image" />
+<a href="https://rubykaigi.org/2007/" class="past-kaigis-item__inner" target="_blank"><img src="/2020/images/past-kaigis/2007.png" alt="RubyKaigi 2007" class="past-kaigis-item__image" />
 <div class='past-kaigis-item__name'>
 RubyKaigi 2007
 </div>
@@ -208,7 +208,7 @@ RubyKaigi 2007
 </div>
 <div class='col-xs-12 col-sm-6 col-md-4 col-lg-3'>
 <div class='past-kaigis-item'>
-<a href="http://jp.rubyist.net/RubyKaigi2006/" class="past-kaigis-item__inner" target="_blank"><img src="/2020/images/past-kaigis/2006.png" alt="RubyKaigi 2006" class="past-kaigis-item__image" />
+<a href="https://rubykaigi.org/2006/" class="past-kaigis-item__inner" target="_blank"><img src="/2020/images/past-kaigis/2006.png" alt="RubyKaigi 2006" class="past-kaigis-item__image" />
 <div class='past-kaigis-item__name'>
 RubyKaigi 2006
 </div>


### PR DESCRIPTION
ref: [RubyKaigi 2006-2008のコンテンツを移行する #368](https://github.com/ruby-no-kai/official/issues/368)

結局ひととおりURLを書き換えてしまいました。
```
# VSCodeにて
http:\/\/jp\.rubyist\.net\/RubyKaigi(2006|2007|2008)\/
↓
https://rubykaigi.org/$1/
```

ただし、 http://rubykaigi.org/2006/open/ はどのみちリンク切れです。
（もしかして https://github.com/ruby-no-kai/official/wiki/ にリンクすればよい？）
MP3ファイルのリンクは全部確認してませんが、他は大丈夫だと思います。


また、2007と2008は英語ページがあるようだったので、英語ページのURLにしておきました。

- https://rubykaigi.org/2007/english.html
- https://rubykaigi.org/2008/english.html

全部確認できるものでもないので、えいやでマージするしかないかなと思ってます 🚀 
