### PR TITLE
Fix broken link_to るびま from jp.rubyist.net/magazine to magazine.rubyist.net

### DIFF
--- a/2006/about.html
+++ b/2006/about.html
@@ -171,7 +171,7 @@ Ruby は国際的にも広い支持を受けており、世界中の多くの人
 <dd><a href="RubyKaigi2006.pdf" class="external">当日配布パンフレット（PDF 1.1MB）</a>を公開しました。
 </dd>
 <dt>2006/06/28</dt>
-<dd><a href="http://jp.rubyist.net/magazine/?RubyKaigi2006" class="external">Rubyist Magazine 日本 Ruby カンファレンス 2006 特別号</a>が出ました。
+<dd><a href="https://magazine.rubyist.net/articles/rubykaigi2006/RubyKaigi2006-index.html" class="external">Rubyist Magazine 日本 Ruby カンファレンス 2006 特別号</a>が出ました。
 </dd>
 <dt>2006/06/13</dt>
 <dd><a href="program.html">プログラム</a> に講演資料へのリンクを順次追加しています。

--- a/2006/application.html
+++ b/2006/application.html
@@ -148,7 +148,7 @@
 <dd><a href="RubyKaigi2006.pdf" class="external">当日配布パンフレット（PDF 1.1MB）</a>を公開しました。
 </dd>
 <dt>2006/06/28</dt>
-<dd><a href="http://jp.rubyist.net/magazine/?RubyKaigi2006" class="external">Rubyist Magazine 日本 Ruby カンファレンス 2006 特別号</a>が出ました。
+<dd><a href="https://magazine.rubyist.net/articles/rubykaigi2006/RubyKaigi2006-index.html" class="external">Rubyist Magazine 日本 Ruby カンファレンス 2006 特別号</a>が出ました。
 </dd>
 <dt>2006/06/13</dt>
 <dd><a href="program.html">プログラム</a> に講演資料へのリンクを順次追加しています。

--- a/2006/cfp_lt.html
+++ b/2006/cfp_lt.html
@@ -80,7 +80,7 @@
 <dd><a href="RubyKaigi2006.pdf" class="external">当日配布パンフレット（PDF 1.1MB）</a>を公開しました。
 </dd>
 <dt>2006/06/28</dt>
-<dd><a href="http://jp.rubyist.net/magazine/?RubyKaigi2006" class="external">Rubyist Magazine 日本 Ruby カンファレンス 2006 特別号</a>が出ました。
+<dd><a href="https://magazine.rubyist.net/articles/rubykaigi2006/RubyKaigi2006-index.html" class="external">Rubyist Magazine 日本 Ruby カンファレンス 2006 特別号</a>が出ました。
 </dd>
 <dt>2006/06/13</dt>
 <dd><a href="program.html">プログラム</a> に講演資料へのリンクを順次追加しています。

--- a/2006/enquete.html
+++ b/2006/enquete.html
@@ -57,7 +57,7 @@
 <dd><a href="RubyKaigi2006.pdf" class="external">当日配布パンフレット（PDF 1.1MB）</a>を公開しました。
 </dd>
 <dt>2006/06/28</dt>
-<dd><a href="http://jp.rubyist.net/magazine/?RubyKaigi2006" class="external">Rubyist Magazine 日本 Ruby カンファレンス 2006 特別号</a>が出ました。
+<dd><a href="https://magazine.rubyist.net/articles/rubykaigi2006/RubyKaigi2006-index.html" class="external">Rubyist Magazine 日本 Ruby カンファレンス 2006 特別号</a>が出ました。
 </dd>
 <dt>2006/06/13</dt>
 <dd><a href="program.html">プログラム</a> に講演資料へのリンクを順次追加しています。

--- a/2006/index.html
+++ b/2006/index.html
@@ -31,7 +31,7 @@
 <p>講演を記録した音声ファイルを公開しました。</p>
 <h3><a name="l2"><span class="sanchor"> </span></a><a href="audio/index.html" class="external">音声ファイル公開</a></h3>
 <p>講演を記録した音声ファイルを公開しました。</p>
-<h3><a name="l3"><span class="sanchor"> </span></a><a href="http://jp.rubyist.net/magazine/?RubyKaigi2006" class="external">Rubyist Magazine 日本 Ruby カンファレンス 2006 特別号</a></h3>
+<h3><a name="l3"><span class="sanchor"> </span></a><a href="https://magazine.rubyist.net/articles/rubykaigi2006/RubyKaigi2006-index.html" class="external">Rubyist Magazine 日本 Ruby カンファレンス 2006 特別号</a></h3>
 <p>出ました。</p>
 <h3><a name="l4"><span class="sanchor"> </span></a>無事終了しました</h3>
 <p>日本 Ruby カンファレンス 2006 は無事に終了しました。ご協力頂いた皆様、ご参加頂いた皆様、本当にありがとうございました。</p>
@@ -158,7 +158,7 @@
 <dd><a href="RubyKaigi2006.pdf" class="external">当日配布パンフレット（PDF 1.1MB）</a>を公開しました。
 </dd>
 <dt>2006/06/28</dt>
-<dd><a href="http://jp.rubyist.net/magazine/?RubyKaigi2006" class="external">Rubyist Magazine 日本 Ruby カンファレンス 2006 特別号</a>が出ました。
+<dd><a href="https://magazine.rubyist.net/articles/rubykaigi2006/RubyKaigi2006-index.html" class="external">Rubyist Magazine 日本 Ruby カンファレンス 2006 特別号</a>が出ました。
 </dd>
 <dt>2006/06/13</dt>
 <dd><a href="program.html">プログラム</a> に講演資料へのリンクを順次追加しています。

--- a/2006/news.html
+++ b/2006/news.html
@@ -35,7 +35,7 @@
 <dd><a href="RubyKaigi2006.pdf" class="external">当日配布パンフレット（PDF 1.1MB）</a>を公開しました。
 </dd>
 <dt>2006/06/28</dt>
-<dd><a href="http://jp.rubyist.net/magazine/?RubyKaigi2006" class="external">Rubyist Magazine 日本 Ruby カンファレンス 2006 特別号</a>が出ました。
+<dd><a href="https://magazine.rubyist.net/articles/rubykaigi2006/RubyKaigi2006-index.html" class="external">Rubyist Magazine 日本 Ruby カンファレンス 2006 特別号</a>が出ました。
 </dd>
 <dt>2006/06/13</dt>
 <dd><a href="program.html">プログラム</a> に講演資料へのリンクを順次追加しています。
@@ -124,7 +124,7 @@
 <dd><a href="RubyKaigi2006.pdf" class="external">当日配布パンフレット（PDF 1.1MB）</a>を公開しました。
 </dd>
 <dt>2006/06/28</dt>
-<dd><a href="http://jp.rubyist.net/magazine/?RubyKaigi2006" class="external">Rubyist Magazine 日本 Ruby カンファレンス 2006 特別号</a>が出ました。
+<dd><a href="https://magazine.rubyist.net/articles/rubykaigi2006/RubyKaigi2006-index.html" class="external">Rubyist Magazine 日本 Ruby カンファレンス 2006 特別号</a>が出ました。
 </dd>
 <dt>2006/06/13</dt>
 <dd><a href="program.html">プログラム</a> に講演資料へのリンクを順次追加しています。

--- a/2006/party.html
+++ b/2006/party.html
@@ -69,7 +69,7 @@
 <dd><a href="RubyKaigi2006.pdf" class="external">当日配布パンフレット（PDF 1.1MB）</a>を公開しました。
 </dd>
 <dt>2006/06/28</dt>
-<dd><a href="http://jp.rubyist.net/magazine/?RubyKaigi2006" class="external">Rubyist Magazine 日本 Ruby カンファレンス 2006 特別号</a>が出ました。
+<dd><a href="https://magazine.rubyist.net/articles/rubykaigi2006/RubyKaigi2006-index.html" class="external">Rubyist Magazine 日本 Ruby カンファレンス 2006 特別号</a>が出ました。
 </dd>
 <dt>2006/06/13</dt>
 <dd><a href="program.html">プログラム</a> に講演資料へのリンクを順次追加しています。

--- a/2006/program.html
+++ b/2006/program.html
@@ -166,7 +166,7 @@
 <dd><a href="RubyKaigi2006.pdf" class="external">当日配布パンフレット（PDF 1.1MB）</a>を公開しました。
 </dd>
 <dt>2006/06/28</dt>
-<dd><a href="http://jp.rubyist.net/magazine/?RubyKaigi2006" class="external">Rubyist Magazine 日本 Ruby カンファレンス 2006 特別号</a>が出ました。
+<dd><a href="https://magazine.rubyist.net/articles/rubykaigi2006/RubyKaigi2006-index.html" class="external">Rubyist Magazine 日本 Ruby カンファレンス 2006 特別号</a>が出ました。
 </dd>
 <dt>2006/06/13</dt>
 <dd><a href="program.html">プログラム</a> に講演資料へのリンクを順次追加しています。

--- a/2006/program0610.html
+++ b/2006/program0610.html
@@ -427,7 +427,7 @@
 <dd><a href="RubyKaigi2006.pdf" class="external">当日配布パンフレット（PDF 1.1MB）</a>を公開しました。
 </dd>
 <dt>2006/06/28</dt>
-<dd><a href="http://jp.rubyist.net/magazine/?RubyKaigi2006" class="external">Rubyist Magazine 日本 Ruby カンファレンス 2006 特別号</a>が出ました。
+<dd><a href="https://magazine.rubyist.net/articles/rubykaigi2006/RubyKaigi2006-index.html" class="external">Rubyist Magazine 日本 Ruby カンファレンス 2006 特別号</a>が出ました。
 </dd>
 <dt>2006/06/13</dt>
 <dd><a href="program.html">プログラム</a> に講演資料へのリンクを順次追加しています。

--- a/2006/program0611.html
+++ b/2006/program0611.html
@@ -546,7 +546,7 @@
 <dd><a href="RubyKaigi2006.pdf" class="external">当日配布パンフレット（PDF 1.1MB）</a>を公開しました。
 </dd>
 <dt>2006/06/28</dt>
-<dd><a href="http://jp.rubyist.net/magazine/?RubyKaigi2006" class="external">Rubyist Magazine 日本 Ruby カンファレンス 2006 特別号</a>が出ました。
+<dd><a href="https://magazine.rubyist.net/articles/rubykaigi2006/RubyKaigi2006-index.html" class="external">Rubyist Magazine 日本 Ruby カンファレンス 2006 特別号</a>が出ました。
 </dd>
 <dt>2006/06/13</dt>
 <dd><a href="program.html">プログラム</a> に講演資料へのリンクを順次追加しています。

--- a/2006/tb20060610.html
+++ b/2006/tb20060610.html
@@ -221,7 +221,7 @@ Ruby会議2006. 午前中は所用でいけなくて午後のパネル企画の�
 <dd><a href="RubyKaigi2006.pdf" class="external">当日配布パンフレット（PDF 1.1MB）</a>を公開しました。
 </dd>
 <dt>2006/06/28</dt>
-<dd><a href="http://jp.rubyist.net/magazine/?RubyKaigi2006" class="external">Rubyist Magazine 日本 Ruby カンファレンス 2006 特別号</a>が出ました。
+<dd><a href="https://magazine.rubyist.net/articles/rubykaigi2006/RubyKaigi2006-index.html" class="external">Rubyist Magazine 日本 Ruby カンファレンス 2006 特別号</a>が出ました。
 </dd>
 <dt>2006/06/13</dt>
 <dd><a href="program.html">プログラム</a> に講演資料へのリンクを順次追加しています。

--- a/2006/tb20060611.html
+++ b/2006/tb20060611.html
@@ -275,7 +275,7 @@ Ruby会議2006. 午前中は所用でいけなくて午後のパネル企画の�
 <dd><a href="RubyKaigi2006.pdf" class="external">当日配布パンフレット（PDF 1.1MB）</a>を公開しました。
 </dd>
 <dt>2006/06/28</dt>
-<dd><a href="http://jp.rubyist.net/magazine/?RubyKaigi2006" class="external">Rubyist Magazine 日本 Ruby カンファレンス 2006 特別号</a>が出ました。
+<dd><a href="https://magazine.rubyist.net/articles/rubykaigi2006/RubyKaigi2006-index.html" class="external">Rubyist Magazine 日本 Ruby カンファレンス 2006 特別号</a>が出ました。
 </dd>
 <dt>2006/06/13</dt>
 <dd><a href="program.html">プログラム</a> に講演資料へのリンクを順次追加しています。

--- a/2006/videos.html
+++ b/2006/videos.html
@@ -186,7 +186,7 @@
 <dd><a href="RubyKaigi2006.pdf" class="external">当日配布パンフレット（PDF 1.1MB）</a>を公開しました。
 </dd>
 <dt>2006/06/28</dt>
-<dd><a href="http://jp.rubyist.net/magazine/?RubyKaigi2006" class="external">Rubyist Magazine 日本 Ruby カンファレンス 2006 特別号</a>が出ました。
+<dd><a href="https://magazine.rubyist.net/articles/rubykaigi2006/RubyKaigi2006-index.html" class="external">Rubyist Magazine 日本 Ruby カンファレンス 2006 特別号</a>が出ました。
 </dd>
 <dt>2006/06/13</dt>
 <dd><a href="program.html">プログラム</a> に講演資料へのリンクを順次追加しています。

--- a/2006/volunteer_staff.html
+++ b/2006/volunteer_staff.html
@@ -115,7 +115,7 @@
 <dd><a href="RubyKaigi2006.pdf" class="external">当日配布パンフレット（PDF 1.1MB）</a>を公開しました。
 </dd>
 <dt>2006/06/28</dt>
-<dd><a href="http://jp.rubyist.net/magazine/?RubyKaigi2006" class="external">Rubyist Magazine 日本 Ruby カンファレンス 2006 特別号</a>が出ました。
+<dd><a href="https://magazine.rubyist.net/articles/rubykaigi2006/RubyKaigi2006-index.html" class="external">Rubyist Magazine 日本 Ruby カンファレンス 2006 特別号</a>が出ました。
 </dd>
 <dt>2006/06/13</dt>
 <dd><a href="program.html">プログラム</a> に講演資料へのリンクを順次追加しています。

--- a/2007/Log0610-S2.html
+++ b/2007/Log0610-S2.html
@@ -101,7 +101,7 @@ Macの方はせっかくIntelのCPUが載ったのでWindowsを入れていた�
 <li><a href="http://rubyforge.org/projects/ibm_db" class="external">http://rubyforge.org/projects/ibm_db</a> …ではなく <a href="http://rubyforge.org/projects/rubyibm" class="external">http://rubyforge.org/projects/rubyibm</a> でしょうか？ (ロガー)</li>
 </ul>
 <p>DB2はXML-DBなので、XMLに対する問い合わせもサポートしている。</p>
-<p><a href="http://jp.rubyist.net/magazine/?0018-RubyOnRails" class="external">るびま18号にも記事</a>がありますし、
+<p><a href="https://magazine.rubyist.net/articles/0018/0018-RubyOnRails.html" class="external">るびま18号にも記事</a>がありますし、
 <a href="http://www-06.ibm.com/jp/developerworks/linux/050708/j_l-rubyrails.html" class="external">Ruby on RailsによるWebアプリケーションの開発</a>
 (developerWorks Japan)は2年間ずっと10位以内の人気記事にはいっている。</p>
 <p>「JavaからRubyへ」- 著者はもともとIBMの人で、「<a href="http://www-06.ibm.com/jp/developerworks/java/lib_series.shtml#cb" class="external">境界を越える</a>」という記事も書いて

--- a/2007/index.rss
+++ b/2007/index.rss
@@ -1773,7 +1773,7 @@ Macの方はせっかくIntelのCPUが載ったのでWindowsを入れていただいて :P</p>
 <li><a href="http://rubyforge.org/projects/ibm_db" class="external">http://rubyforge.org/projects/ibm_db</a> …ではなく <a href="http://rubyforge.org/projects/rubyibm" class="external">http://rubyforge.org/projects/rubyibm</a> でしょうか？ (ロガー)</li>
 </ul>
 <p>DB2はXML-DBなので、XMLに対する問い合わせもサポートしている。</p>
-<p><a href="http://jp.rubyist.net/magazine/?0018-RubyOnRails" class="external">るびま18号にも記事</a>がありますし、
+<p><a href="https://magazine.rubyist.net/articles/0018/0018-RubyOnRails.html" class="external">るびま18号にも記事</a>がありますし、
 <a href="http://www-06.ibm.com/jp/developerworks/linux/050708/j_l-rubyrails.html" class="external">Ruby on RailsによるWebアプリケーションの開発</a>
 (developerWorks Japan)は2年間ずっと10位以内の人気記事にはいっている。</p>
 <p>「JavaからRubyへ」- 著者はもともとIBMの人で、「<a href="http://www-06.ibm.com/jp/developerworks/java/lib_series.shtml#cb" class="external">境界を越える</a>」という記事も書いて

--- a/2011/ja/schedule/details/18M01/index.html
+++ b/2011/ja/schedule/details/18M01/index.html
@@ -109,7 +109,7 @@
  日本 Ruby の会 ML (http://www.fdiary.net/ml/ruby/msg/2380) や Rubyist Magazine 巻頭言 (https://magazine.rubyist.net/articles/0032/0032-ForeWord.html) で既報のとおり、日本 Ruby の会は RubyKaigi2011 後に一般社団法人として法人化されることが予定されています。 このセッションでは、その経緯や今後の日本 Ruby の会としての活動について発表します。 また、日本 Ruby の会として継続的に活動している「Rubyリファレンスマニュアル刷新計画 (通称るりま) 」と「Rubyist Magazine (通称るびま) 」について 2011 年の活動報告を行います。
 るりま Wiki: http://redmine.ruby-lang.org/projects/rurema/wiki
 るりま: http://www.ruby-lang.org/ja/documentation/
-るびま: http://jp.rubyist.net/magazine/
+るびま: https://magazine.rubyist.net/
 </p>
 <ol>
 </ol>

--- a/2011/ja/schedule/details/18M01/index.html
+++ b/2011/ja/schedule/details/18M01/index.html
@@ -106,7 +106,7 @@
 概要
 </h3>
 <p>
- 日本 Ruby の会 ML (http://www.fdiary.net/ml/ruby/msg/2380) や Rubyist Magazine 巻頭言 (http://jp.rubyist.net/magazine/?0032-ForeWord) で既報のとおり、日本 Ruby の会は RubyKaigi2011 後に一般社団法人として法人化されることが予定されています。 このセッションでは、その経緯や今後の日本 Ruby の会としての活動について発表します。 また、日本 Ruby の会として継続的に活動している「Rubyリファレンスマニュアル刷新計画 (通称るりま) 」と「Rubyist Magazine (通称るびま) 」について 2011 年の活動報告を行います。
+ 日本 Ruby の会 ML (http://www.fdiary.net/ml/ruby/msg/2380) や Rubyist Magazine 巻頭言 (https://magazine.rubyist.net/articles/0032/0032-ForeWord.html) で既報のとおり、日本 Ruby の会は RubyKaigi2011 後に一般社団法人として法人化されることが予定されています。 このセッションでは、その経緯や今後の日本 Ruby の会としての活動について発表します。 また、日本 Ruby の会として継続的に活動している「Rubyリファレンスマニュアル刷新計画 (通称るりま) 」と「Rubyist Magazine (通称るびま) 」について 2011 年の活動報告を行います。
 るりま Wiki: http://redmine.ruby-lang.org/projects/rurema/wiki
 るりま: http://www.ruby-lang.org/ja/documentation/
 るびま: http://jp.rubyist.net/magazine/

--- a/2011/ja/schedule/grid/index.html
+++ b/2011/ja/schedule/grid/index.html
@@ -1116,7 +1116,7 @@ Lightning talks 1
 <h3>
 <a class="tip" href="/2011/ja/schedule/details/18M01">
 一般社団法人日本Rubyの会と関連プロジェクト報告(るびま,るりま)
-<span> 日本 Ruby の会 ML (http://www.fdiary.net/ml/ruby/msg/2380) や Rubyist Magazine 巻頭言 (http://jp.rubyist.net/magazine/?0032-ForeWord) で既報のとおり、日本 Ruby の会は RubyKaigi2011 後に一般社団法人として法人化されることが予定されています。 このセッションでは、その経緯や今後の日本 Ruby の会としての活動について発表します。 また、日本 Ruby の会として継続的に活動している「Rubyリファレンスマニュアル刷新計画 (通称るりま) 」と「Rubyist Magazine (通称るびま) 」について 2011 年の活動報告を行います。
+<span> 日本 Ruby の会 ML (http://www.fdiary.net/ml/ruby/msg/2380) や Rubyist Magazine 巻頭言 (https://magazine.rubyist.net/articles/0032/0032-ForeWord.html) で既報のとおり、日本 Ruby の会は RubyKaigi2011 後に一般社団法人として法人化されることが予定されています。 このセッションでは、その経緯や今後の日本 Ruby の会としての活動について発表します。 また、日本 Ruby の会として継続的に活動している「Rubyリファレンスマニュアル刷新計画 (通称るりま) 」と「Rubyist Magazine (通称るびま) 」について 2011 年の活動報告を行います。
 るりま Wiki: http://redmine.ruby-lang.org/projects/rurema/wiki
 るりま: http://www.ruby-lang.org/ja/documentation/
 るびま: http://jp.rubyist.net/magazine/</span>

--- a/2011/ja/schedule/grid/index.html
+++ b/2011/ja/schedule/grid/index.html
@@ -1119,7 +1119,7 @@ Lightning talks 1
 <span> 日本 Ruby の会 ML (http://www.fdiary.net/ml/ruby/msg/2380) や Rubyist Magazine 巻頭言 (https://magazine.rubyist.net/articles/0032/0032-ForeWord.html) で既報のとおり、日本 Ruby の会は RubyKaigi2011 後に一般社団法人として法人化されることが予定されています。 このセッションでは、その経緯や今後の日本 Ruby の会としての活動について発表します。 また、日本 Ruby の会として継続的に活動している「Rubyリファレンスマニュアル刷新計画 (通称るりま) 」と「Rubyist Magazine (通称るびま) 」について 2011 年の活動報告を行います。
 るりま Wiki: http://redmine.ruby-lang.org/projects/rurema/wiki
 るりま: http://www.ruby-lang.org/ja/documentation/
-るびま: http://jp.rubyist.net/magazine/</span>
+るびま: https://magazine.rubyist.net/</span>
 </a>
 </h3>
 <ul class="presenter">

--- a/2013/volunteers/index.html
+++ b/2013/volunteers/index.html
@@ -132,7 +132,7 @@
               </strong>
             </p>
             <ul class='listMark'>
-              <li><a href="http://jp.rubyist.net/magazine">Rubyist Magazine</a>に「RubyKaigi 2013参加レポート」を寄稿いただきます</li>
+              <li><a href="https://magazine.rubyist.net">Rubyist Magazine</a>に「RubyKaigi 2013参加レポート」を寄稿いただきます</li>
               <li>レポート担当者それぞれが参加した視点から感じた、RubyKaigi 2013 というカンファレンスの雰囲気をレポートしてください</li>
               <li>これは速報レポートではないので、<a href="https://magazine.rubyist.net/articles/0040/0040-HowToBuildSprk2012ReportTeam.html">エクストリーム・スポーツではありません</a></li>
               <li><a href="https://magazine.rubyist.net/articles/0041/0041-Euroko2012.html">Euruko 2012参加レポート</a>ぐらいの「参加した雰囲気」が伝わるようなものであれば十分です</li>

--- a/2013/volunteers/index.html
+++ b/2013/volunteers/index.html
@@ -134,8 +134,8 @@
             <ul class='listMark'>
               <li><a href="http://jp.rubyist.net/magazine">Rubyist Magazine</a>に「RubyKaigi 2013参加レポート」を寄稿いただきます</li>
               <li>レポート担当者それぞれが参加した視点から感じた、RubyKaigi 2013 というカンファレンスの雰囲気をレポートしてください</li>
-              <li>これは速報レポートではないので、<a href="http://jp.rubyist.net/magazine/?0040-HowToBuildSprk2012ReportTeam">エクストリーム・スポーツではありません</a></li>
-              <li><a href="http://jp.rubyist.net/magazine/?0041-Euroko2012">Euruko 2012参加レポート</a>ぐらいの「参加した雰囲気」が伝わるようなものであれば十分です</li>
+              <li>これは速報レポートではないので、<a href="https://magazine.rubyist.net/articles/0040/0040-HowToBuildSprk2012ReportTeam.html">エクストリーム・スポーツではありません</a></li>
+              <li><a href="https://magazine.rubyist.net/articles/0041/0041-Euroko2012.html">Euruko 2012参加レポート</a>ぐらいの「参加した雰囲気」が伝わるようなものであれば十分です</li>
               <li>3日間の複数トラックなので、複数人のチームで分担することを想定しています</li>
               <li>記事の構成などはお任せいたします</li>
               <p></p>
@@ -406,7 +406,7 @@
             </p>
             <ul class='listMark'>
               <li>gihyo.jpに掲載するカンファレンスレポート記事の執筆です。keynoteを中心に執筆いただきます</li>
-              <li>網羅的なレポートではありませんし、<a href="http://jp.rubyist.net/magazine/?0040-HowToBuildSprk2012ReportTeam">エクストリーム・スポーツでもありません</a></li>
+              <li>網羅的なレポートではありませんし、<a href="https://magazine.rubyist.net/articles/0040/0040-HowToBuildSprk2012ReportTeam.html">エクストリーム・スポーツでもありません</a></li>
               <li>Rubyとそれに関連する周辺的な技術事情についての知識が、出版社の編集者の方よりは多い方を歓迎します</li>
               <li>カンファレンスの雰囲気などは、るびまでレポートできたらいいな、と思ってます</li>
               <li>3日間かけて3つのkeynoteがおこなわれるので、複数人のチームで分担したほうが安全かも、と思っています</li>


### PR DESCRIPTION
#17 の絡みで、過去のRubyKaigiのサイト内の `jp.rubyist.net` をgit grepすると昔のるびまへのdead linkが散見されて気になってしまったので、引っ越し先のそれっぽい記事にリンクを張り直してみたらどうなるかなと思ってやってみました。

結果、古いるびまへのリンク切れ自体はこれで全部直ってると思います。
しかし、その当時に書かれた記事というのはリンク先URLも含めて時代の記録でもあり著作物でもあるとは思うので、あとから勝手にいじるべきものではないのでは、という議論もあろうかと思います。

僕としてはまあどっちでもいいんですけど、とりあえずパッチだけは置いておきます。

@takahashim @kakutani あたりのご意見を伺いたいです。