### PR TITLE
kddeisz  =>  kddnewton

### DIFF
--- a/2014/presentation/S-PrathameshSonpatki/index.html
+++ b/2014/presentation/S-PrathameshSonpatki/index.html
@@ -81,7 +81,7 @@
         <h3>Presentation Material(s)</h3>
         <ul class='presentation-materials'>
           <li>
-            <a target="_blank" href="https://speakerdeck.com/chaitanya/deep-down-fixtures">Deep down fixtures
+            <a target="_blank" href="https://speakerdeck.com/prathamesh/deep-down-fixtures">Deep down fixtures
             <i class='fa fa-external-link'></i>
             </a>
           </li>

--- a/2017/presentations/kddeisz.html
+++ b/2017/presentations/kddeisz.html
@@ -152,7 +152,7 @@
                       </h2>
                       <ul class='presentation-materials__list'>
                         <li>
-                          <a href="https://speakerdeck.com/kddeisz/compiling-ruby" target="_blank"><i class='fa fa-angle-right'></i>
+                          <a href="https://speakerdeck.com/kddnewton/compiling-ruby" target="_blank"><i class='fa fa-angle-right'></i>
                           Compiling Ruby
                           </a>
                         </li>

--- a/2019/presentations/kddeisz.html
+++ b/2019/presentations/kddeisz.html
@@ -183,7 +183,7 @@ Presentation Material
 </h2>
 <ul class='presentation-materials__list'>
 <li>
-<a href="https://speakerdeck.com/kddeisz/pre-evaluation-in-ruby" target="_blank"><i class='fa fa-file-o'></i>
+<a href="https://speakerdeck.com/kddnewton/pre-evaluation-in-ruby" target="_blank"><i class='fa fa-file-o'></i>
 Pre-evaluation in Ruby
 </a></li>
 </ul>

--- a/2019/presentations/samphippen.html
+++ b/2019/presentations/samphippen.html
@@ -178,7 +178,7 @@ Presentation Material
 </h2>
 <ul class='presentation-materials__list'>
 <li>
-<a href="https://speakerdeck.com/samphippen/how-rspec-works" target="_blank"><i class='fa fa-file-o'></i>
+<a href="https://speakerdeck.com/penelope_zone/how-rspec-works" target="_blank"><i class='fa fa-file-o'></i>
 How RSpec Works
 </a></li>
 </ul>


### PR DESCRIPTION
KevinのID変更に追随するパッチです。
他の年にもあるんですが、とりあえず2017年から。彼自身のidentityは変わったようですが、こっちのURLは変わらず、 https://rubykaigi.org/2017/presentations/kddeisz.html
のままになるようにしています。というのがちょっとだけトリッキーではあるんですが、まあいいかな、と。