### PR TITLE
Broken link_to wyhaines slides

### DIFF
--- a/2018/presentations/wyhaines.html
+++ b/2018/presentations/wyhaines.html
@@ -193,7 +193,7 @@
                         </h2>
                         <ul class='presentation-materials__list'>
                           <li>
-                            <a href="https://slides.com/wyhaines/its-rubies-all-the-way-down/live" target="_blank"><i class='fa fa-file-o'></i>
+                            <a href="https://slides.com/wyhaines/its-rubies-all-the-way-down" target="_blank"><i class='fa fa-file-o'></i>
                             It's Rubies All The Way Down
                             </a>
                           </li>


### PR DESCRIPTION
2018年の発表資料へのリンクが切れているのを1件修正しています。 https://github.com/amatsuda/rubykaigi.org/commit/f91cf7d1bbcb5d314264c639393c8b0cadffefcf
これはslides.comのURLの作りが変わったのか、それとも元々壊れてたのか、というとたぶん前者なんでしょうねぇ。