### PR TITLE
Fetch Google Fonts via HTTPS for 2016 pages

### DIFF
--- a/2016/code-of-conduct/index.html
+++ b/2016/code-of-conduct/index.html
@@ -20,7 +20,7 @@
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
     <script src="https://code.jquery.com/jquery-2.0.3.min.js"></script>
-    <link href="http://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
+    <link href="https://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
     <script src="/2016/javascripts/all.js"></script>
     <link href="/2016/stylesheets/all.css" rel="stylesheet" media="all" />
     <link href="/2016/images/favicon.png" rel="icon" type="image/png" />

--- a/2016/goodies/index.html
+++ b/2016/goodies/index.html
@@ -20,7 +20,7 @@
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
     <script src="https://code.jquery.com/jquery-2.0.3.min.js"></script>
-    <link href="http://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
+    <link href="https://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
     <script src="/2016/javascripts/all.js"></script>
     <link href="/2016/stylesheets/all.css" rel="stylesheet" media="all" />
     <link href="/2016/images/favicon.png" rel="icon" type="image/png" />

--- a/2016/index.html
+++ b/2016/index.html
@@ -19,7 +19,7 @@
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
     <script src="https://code.jquery.com/jquery-2.0.3.min.js"></script>
-    <link href="http://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
+    <link href="https://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
     <script src="/2016/javascripts/all.js"></script>
     <link href="/2016/stylesheets/all.css" rel="stylesheet" media="all" />
     <link href="/2016/images/favicon.png" rel="icon" type="image/png" />

--- a/2016/parties/index.html
+++ b/2016/parties/index.html
@@ -20,7 +20,7 @@
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
     <script src="https://code.jquery.com/jquery-2.0.3.min.js"></script>
-    <link href="http://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
+    <link href="https://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
     <script src="/2016/javascripts/all.js"></script>
     <link href="/2016/stylesheets/all.css" rel="stylesheet" media="all" />
     <link href="/2016/images/favicon.png" rel="icon" type="image/png" />

--- a/2016/presentations/0xColby.html
+++ b/2016/presentations/0xColby.html
@@ -20,7 +20,7 @@
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
     <script src="https://code.jquery.com/jquery-2.0.3.min.js"></script>
-    <link href="http://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
+    <link href="https://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
     <script src="/2016/javascripts/all.js"></script>
     <link href="/2016/stylesheets/all.css" rel="stylesheet" media="all" />
     <link href="/2016/images/favicon.png" rel="icon" type="image/png" />

--- a/2016/presentations/MattStudies.html
+++ b/2016/presentations/MattStudies.html
@@ -20,7 +20,7 @@
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
     <script src="https://code.jquery.com/jquery-2.0.3.min.js"></script>
-    <link href="http://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
+    <link href="https://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
     <script src="/2016/javascripts/all.js"></script>
     <link href="/2016/stylesheets/all.css" rel="stylesheet" media="all" />
     <link href="/2016/images/favicon.png" rel="icon" type="image/png" />

--- a/2016/presentations/amirrajan.html
+++ b/2016/presentations/amirrajan.html
@@ -20,7 +20,7 @@
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
     <script src="https://code.jquery.com/jquery-2.0.3.min.js"></script>
-    <link href="http://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
+    <link href="https://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
     <script src="/2016/javascripts/all.js"></script>
     <link href="/2016/stylesheets/all.css" rel="stylesheet" media="all" />
     <link href="/2016/images/favicon.png" rel="icon" type="image/png" />

--- a/2016/presentations/anildigital.html
+++ b/2016/presentations/anildigital.html
@@ -20,7 +20,7 @@
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
     <script src="https://code.jquery.com/jquery-2.0.3.min.js"></script>
-    <link href="http://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
+    <link href="https://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
     <script src="/2016/javascripts/all.js"></script>
     <link href="/2016/stylesheets/all.css" rel="stylesheet" media="all" />
     <link href="/2016/images/favicon.png" rel="icon" type="image/png" />

--- a/2016/presentations/chrisarcand.html
+++ b/2016/presentations/chrisarcand.html
@@ -20,7 +20,7 @@
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
     <script src="https://code.jquery.com/jquery-2.0.3.min.js"></script>
-    <link href="http://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
+    <link href="https://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
     <script src="/2016/javascripts/all.js"></script>
     <link href="/2016/stylesheets/all.css" rel="stylesheet" media="all" />
     <link href="/2016/images/favicon.png" rel="icon" type="image/png" />

--- a/2016/presentations/cruby_committers.html
+++ b/2016/presentations/cruby_committers.html
@@ -20,7 +20,7 @@
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
     <script src="https://code.jquery.com/jquery-2.0.3.min.js"></script>
-    <link href="http://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
+    <link href="https://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
     <script src="/2016/javascripts/all.js"></script>
     <link href="/2016/stylesheets/all.css" rel="stylesheet" media="all" />
     <link href="/2016/images/favicon.png" rel="icon" type="image/png" />

--- a/2016/presentations/drbrain.html
+++ b/2016/presentations/drbrain.html
@@ -20,7 +20,7 @@
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
     <script src="https://code.jquery.com/jquery-2.0.3.min.js"></script>
-    <link href="http://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
+    <link href="https://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
     <script src="/2016/javascripts/all.js"></script>
     <link href="/2016/stylesheets/all.css" rel="stylesheet" media="all" />
     <link href="/2016/images/favicon.png" rel="icon" type="image/png" />

--- a/2016/presentations/duerst.html
+++ b/2016/presentations/duerst.html
@@ -20,7 +20,7 @@
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
     <script src="https://code.jquery.com/jquery-2.0.3.min.js"></script>
-    <link href="http://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
+    <link href="https://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
     <script src="/2016/javascripts/all.js"></script>
     <link href="/2016/stylesheets/all.css" rel="stylesheet" media="all" />
     <link href="/2016/images/favicon.png" rel="icon" type="image/png" />

--- a/2016/presentations/elct9620.html
+++ b/2016/presentations/elct9620.html
@@ -20,7 +20,7 @@
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
     <script src="https://code.jquery.com/jquery-2.0.3.min.js"></script>
-    <link href="http://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
+    <link href="https://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
     <script src="/2016/javascripts/all.js"></script>
     <link href="/2016/stylesheets/all.css" rel="stylesheet" media="all" />
     <link href="/2016/images/favicon.png" rel="icon" type="image/png" />

--- a/2016/presentations/ericqweinstein.html
+++ b/2016/presentations/ericqweinstein.html
@@ -20,7 +20,7 @@
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
     <script src="https://code.jquery.com/jquery-2.0.3.min.js"></script>
-    <link href="http://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
+    <link href="https://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
     <script src="/2016/javascripts/all.js"></script>
     <link href="/2016/stylesheets/all.css" rel="stylesheet" media="all" />
     <link href="/2016/images/favicon.png" rel="icon" type="image/png" />

--- a/2016/presentations/franckverrot.html
+++ b/2016/presentations/franckverrot.html
@@ -20,7 +20,7 @@
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
     <script src="https://code.jquery.com/jquery-2.0.3.min.js"></script>
-    <link href="http://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
+    <link href="https://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
     <script src="/2016/javascripts/all.js"></script>
     <link href="/2016/stylesheets/all.css" rel="stylesheet" media="all" />
     <link href="/2016/images/favicon.png" rel="icon" type="image/png" />

--- a/2016/presentations/hsbt.html
+++ b/2016/presentations/hsbt.html
@@ -20,7 +20,7 @@
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
     <script src="https://code.jquery.com/jquery-2.0.3.min.js"></script>
-    <link href="http://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
+    <link href="https://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
     <script src="/2016/javascripts/all.js"></script>
     <link href="/2016/stylesheets/all.css" rel="stylesheet" media="all" />
     <link href="/2016/images/favicon.png" rel="icon" type="image/png" />

--- a/2016/presentations/johnlinvc.html
+++ b/2016/presentations/johnlinvc.html
@@ -20,7 +20,7 @@
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
     <script src="https://code.jquery.com/jquery-2.0.3.min.js"></script>
-    <link href="http://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
+    <link href="https://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
     <script src="/2016/javascripts/all.js"></script>
     <link href="/2016/stylesheets/all.css" rel="stylesheet" media="all" />
     <link href="/2016/images/favicon.png" rel="icon" type="image/png" />

--- a/2016/presentations/juliancheal.html
+++ b/2016/presentations/juliancheal.html
@@ -20,7 +20,7 @@
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
     <script src="https://code.jquery.com/jquery-2.0.3.min.js"></script>
-    <link href="http://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
+    <link href="https://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
     <script src="/2016/javascripts/all.js"></script>
     <link href="/2016/stylesheets/all.css" rel="stylesheet" media="all" />
     <link href="/2016/images/favicon.png" rel="icon" type="image/png" />

--- a/2016/presentations/k0kubun.html
+++ b/2016/presentations/k0kubun.html
@@ -20,7 +20,7 @@
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
     <script src="https://code.jquery.com/jquery-2.0.3.min.js"></script>
-    <link href="http://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
+    <link href="https://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
     <script src="/2016/javascripts/all.js"></script>
     <link href="/2016/stylesheets/all.css" rel="stylesheet" media="all" />
     <link href="/2016/images/favicon.png" rel="icon" type="image/png" />

--- a/2016/presentations/kazuho.html
+++ b/2016/presentations/kazuho.html
@@ -20,7 +20,7 @@
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
     <script src="https://code.jquery.com/jquery-2.0.3.min.js"></script>
-    <link href="http://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
+    <link href="https://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
     <script src="/2016/javascripts/all.js"></script>
     <link href="/2016/stylesheets/all.css" rel="stylesheet" media="all" />
     <link href="/2016/images/favicon.png" rel="icon" type="image/png" />

--- a/2016/presentations/ko1.html
+++ b/2016/presentations/ko1.html
@@ -20,7 +20,7 @@
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
     <script src="https://code.jquery.com/jquery-2.0.3.min.js"></script>
-    <link href="http://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
+    <link href="https://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
     <script src="/2016/javascripts/all.js"></script>
     <link href="/2016/stylesheets/all.css" rel="stylesheet" media="all" />
     <link href="/2016/images/favicon.png" rel="icon" type="image/png" />

--- a/2016/presentations/ktou.html
+++ b/2016/presentations/ktou.html
@@ -20,7 +20,7 @@
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
     <script src="https://code.jquery.com/jquery-2.0.3.min.js"></script>
-    <link href="http://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
+    <link href="https://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
     <script src="/2016/javascripts/all.js"></script>
     <link href="/2016/stylesheets/all.css" rel="stylesheet" media="all" />
     <link href="/2016/images/favicon.png" rel="icon" type="image/png" />

--- a/2016/presentations/m_seki.html
+++ b/2016/presentations/m_seki.html
@@ -20,7 +20,7 @@
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
     <script src="https://code.jquery.com/jquery-2.0.3.min.js"></script>
-    <link href="http://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
+    <link href="https://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
     <script src="/2016/javascripts/all.js"></script>
     <link href="/2016/stylesheets/all.css" rel="stylesheet" media="all" />
     <link href="/2016/images/favicon.png" rel="icon" type="image/png" />

--- a/2016/presentations/masa16tanaka.html
+++ b/2016/presentations/masa16tanaka.html
@@ -20,7 +20,7 @@
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
     <script src="https://code.jquery.com/jquery-2.0.3.min.js"></script>
-    <link href="http://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
+    <link href="https://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
     <script src="/2016/javascripts/all.js"></script>
     <link href="/2016/stylesheets/all.css" rel="stylesheet" media="all" />
     <link href="/2016/images/favicon.png" rel="icon" type="image/png" />

--- a/2016/presentations/mrkn.html
+++ b/2016/presentations/mrkn.html
@@ -20,7 +20,7 @@
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
     <script src="https://code.jquery.com/jquery-2.0.3.min.js"></script>
-    <link href="http://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
+    <link href="https://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
     <script src="/2016/javascripts/all.js"></script>
     <link href="/2016/stylesheets/all.css" rel="stylesheet" media="all" />
     <link href="/2016/images/favicon.png" rel="icon" type="image/png" />

--- a/2016/presentations/nalsh.html
+++ b/2016/presentations/nalsh.html
@@ -20,7 +20,7 @@
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
     <script src="https://code.jquery.com/jquery-2.0.3.min.js"></script>
-    <link href="http://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
+    <link href="https://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
     <script src="/2016/javascripts/all.js"></script>
     <link href="/2016/stylesheets/all.css" rel="stylesheet" media="all" />
     <link href="/2016/images/favicon.png" rel="icon" type="image/png" />

--- a/2016/presentations/narittan.html
+++ b/2016/presentations/narittan.html
@@ -20,7 +20,7 @@
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
     <script src="https://code.jquery.com/jquery-2.0.3.min.js"></script>
-    <link href="http://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
+    <link href="https://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
     <script src="/2016/javascripts/all.js"></script>
     <link href="/2016/stylesheets/all.css" rel="stylesheet" media="all" />
     <link href="/2016/images/favicon.png" rel="icon" type="image/png" />

--- a/2016/presentations/nirvdrum.html
+++ b/2016/presentations/nirvdrum.html
@@ -20,7 +20,7 @@
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
     <script src="https://code.jquery.com/jquery-2.0.3.min.js"></script>
-    <link href="http://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
+    <link href="https://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
     <script src="/2016/javascripts/all.js"></script>
     <link href="/2016/stylesheets/all.css" rel="stylesheet" media="all" />
     <link href="/2016/images/favicon.png" rel="icon" type="image/png" />

--- a/2016/presentations/okkez.html
+++ b/2016/presentations/okkez.html
@@ -20,7 +20,7 @@
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
     <script src="https://code.jquery.com/jquery-2.0.3.min.js"></script>
-    <link href="http://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
+    <link href="https://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
     <script src="/2016/javascripts/all.js"></script>
     <link href="/2016/stylesheets/all.css" rel="stylesheet" media="all" />
     <link href="/2016/images/favicon.png" rel="icon" type="image/png" />

--- a/2016/presentations/pitr_ch.html
+++ b/2016/presentations/pitr_ch.html
@@ -20,7 +20,7 @@
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
     <script src="https://code.jquery.com/jquery-2.0.3.min.js"></script>
-    <link href="http://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
+    <link href="https://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
     <script src="/2016/javascripts/all.js"></script>
     <link href="/2016/stylesheets/all.css" rel="stylesheet" media="all" />
     <link href="/2016/images/favicon.png" rel="icon" type="image/png" />

--- a/2016/presentations/searls.html
+++ b/2016/presentations/searls.html
@@ -20,7 +20,7 @@
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
     <script src="https://code.jquery.com/jquery-2.0.3.min.js"></script>
-    <link href="http://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
+    <link href="https://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
     <script src="/2016/javascripts/all.js"></script>
     <link href="/2016/stylesheets/all.css" rel="stylesheet" media="all" />
     <link href="/2016/images/favicon.png" rel="icon" type="image/png" />

--- a/2016/presentations/shyouhei.html
+++ b/2016/presentations/shyouhei.html
@@ -20,7 +20,7 @@
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
     <script src="https://code.jquery.com/jquery-2.0.3.min.js"></script>
-    <link href="http://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
+    <link href="https://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
     <script src="/2016/javascripts/all.js"></script>
     <link href="/2016/stylesheets/all.css" rel="stylesheet" media="all" />
     <link href="/2016/images/favicon.png" rel="icon" type="image/png" />

--- a/2016/presentations/tagomoris.html
+++ b/2016/presentations/tagomoris.html
@@ -20,7 +20,7 @@
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
     <script src="https://code.jquery.com/jquery-2.0.3.min.js"></script>
-    <link href="http://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
+    <link href="https://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
     <script src="/2016/javascripts/all.js"></script>
     <link href="/2016/stylesheets/all.css" rel="stylesheet" media="all" />
     <link href="/2016/images/favicon.png" rel="icon" type="image/png" />

--- a/2016/presentations/takkanm.html
+++ b/2016/presentations/takkanm.html
@@ -20,7 +20,7 @@
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
     <script src="https://code.jquery.com/jquery-2.0.3.min.js"></script>
-    <link href="http://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
+    <link href="https://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
     <script src="/2016/javascripts/all.js"></script>
     <link href="/2016/stylesheets/all.css" rel="stylesheet" media="all" />
     <link href="/2016/images/favicon.png" rel="icon" type="image/png" />

--- a/2016/presentations/tanaka_akr.html
+++ b/2016/presentations/tanaka_akr.html
@@ -20,7 +20,7 @@
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
     <script src="https://code.jquery.com/jquery-2.0.3.min.js"></script>
-    <link href="http://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
+    <link href="https://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
     <script src="/2016/javascripts/all.js"></script>
     <link href="/2016/stylesheets/all.css" rel="stylesheet" media="all" />
     <link href="/2016/images/favicon.png" rel="icon" type="image/png" />

--- a/2016/presentations/the_thagomizer.html
+++ b/2016/presentations/the_thagomizer.html
@@ -20,7 +20,7 @@
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
     <script src="https://code.jquery.com/jquery-2.0.3.min.js"></script>
-    <link href="http://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
+    <link href="https://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
     <script src="/2016/javascripts/all.js"></script>
     <link href="/2016/stylesheets/all.css" rel="stylesheet" media="all" />
     <link href="/2016/images/favicon.png" rel="icon" type="image/png" />

--- a/2016/presentations/tkawa.html
+++ b/2016/presentations/tkawa.html
@@ -20,7 +20,7 @@
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
     <script src="https://code.jquery.com/jquery-2.0.3.min.js"></script>
-    <link href="http://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
+    <link href="https://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
     <script src="/2016/javascripts/all.js"></script>
     <link href="/2016/stylesheets/all.css" rel="stylesheet" media="all" />
     <link href="/2016/images/favicon.png" rel="icon" type="image/png" />

--- a/2016/presentations/tom_enebo.html
+++ b/2016/presentations/tom_enebo.html
@@ -20,7 +20,7 @@
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
     <script src="https://code.jquery.com/jquery-2.0.3.min.js"></script>
-    <link href="http://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
+    <link href="https://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
     <script src="/2016/javascripts/all.js"></script>
     <link href="/2016/stylesheets/all.css" rel="stylesheet" media="all" />
     <link href="/2016/images/favicon.png" rel="icon" type="image/png" />

--- a/2016/presentations/udzura.html
+++ b/2016/presentations/udzura.html
@@ -20,7 +20,7 @@
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
     <script src="https://code.jquery.com/jquery-2.0.3.min.js"></script>
-    <link href="http://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
+    <link href="https://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
     <script src="/2016/javascripts/all.js"></script>
     <link href="/2016/stylesheets/all.css" rel="stylesheet" media="all" />
     <link href="/2016/images/favicon.png" rel="icon" type="image/png" />

--- a/2016/presentations/v0dro.html
+++ b/2016/presentations/v0dro.html
@@ -20,7 +20,7 @@
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
     <script src="https://code.jquery.com/jquery-2.0.3.min.js"></script>
-    <link href="http://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
+    <link href="https://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
     <script src="/2016/javascripts/all.js"></script>
     <link href="/2016/stylesheets/all.css" rel="stylesheet" media="all" />
     <link href="/2016/images/favicon.png" rel="icon" type="image/png" />

--- a/2016/presentations/wyhaines.html
+++ b/2016/presentations/wyhaines.html
@@ -20,7 +20,7 @@
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
     <script src="https://code.jquery.com/jquery-2.0.3.min.js"></script>
-    <link href="http://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
+    <link href="https://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
     <script src="/2016/javascripts/all.js"></script>
     <link href="/2016/stylesheets/all.css" rel="stylesheet" media="all" />
     <link href="/2016/images/favicon.png" rel="icon" type="image/png" />

--- a/2016/presentations/youchan.html
+++ b/2016/presentations/youchan.html
@@ -20,7 +20,7 @@
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
     <script src="https://code.jquery.com/jquery-2.0.3.min.js"></script>
-    <link href="http://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
+    <link href="https://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
     <script src="/2016/javascripts/all.js"></script>
     <link href="/2016/stylesheets/all.css" rel="stylesheet" media="all" />
     <link href="/2016/images/favicon.png" rel="icon" type="image/png" />

--- a/2016/presentations/yukihiro_matz.html
+++ b/2016/presentations/yukihiro_matz.html
@@ -20,7 +20,7 @@
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
     <script src="https://code.jquery.com/jquery-2.0.3.min.js"></script>
-    <link href="http://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
+    <link href="https://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
     <script src="/2016/javascripts/all.js"></script>
     <link href="/2016/stylesheets/all.css" rel="stylesheet" media="all" />
     <link href="/2016/images/favicon.png" rel="icon" type="image/png" />

--- a/2016/presentations/yuri_at_earth.html
+++ b/2016/presentations/yuri_at_earth.html
@@ -20,7 +20,7 @@
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
     <script src="https://code.jquery.com/jquery-2.0.3.min.js"></script>
-    <link href="http://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
+    <link href="https://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
     <script src="/2016/javascripts/all.js"></script>
     <link href="/2016/stylesheets/all.css" rel="stylesheet" media="all" />
     <link href="/2016/images/favicon.png" rel="icon" type="image/png" />

--- a/2016/schedule/index.html
+++ b/2016/schedule/index.html
@@ -20,7 +20,7 @@
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
     <script src="https://code.jquery.com/jquery-2.0.3.min.js"></script>
-    <link href="http://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
+    <link href="https://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
     <script src="/2016/javascripts/all.js"></script>
     <link href="/2016/stylesheets/all.css" rel="stylesheet" media="all" />
     <link href="/2016/images/favicon.png" rel="icon" type="image/png" />

--- a/2016/speakers/index.html
+++ b/2016/speakers/index.html
@@ -20,7 +20,7 @@
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
     <script src="https://code.jquery.com/jquery-2.0.3.min.js"></script>
-    <link href="http://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
+    <link href="https://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
     <script src="/2016/javascripts/all.js"></script>
     <link href="/2016/stylesheets/all.css" rel="stylesheet" media="all" />
     <link href="/2016/images/favicon.png" rel="icon" type="image/png" />

--- a/2016/sponsors/index.html
+++ b/2016/sponsors/index.html
@@ -20,7 +20,7 @@
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
     <script src="https://code.jquery.com/jquery-2.0.3.min.js"></script>
-    <link href="http://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
+    <link href="https://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
     <script src="/2016/javascripts/all.js"></script>
     <link href="/2016/stylesheets/all.css" rel="stylesheet" media="all" />
     <link href="/2016/images/favicon.png" rel="icon" type="image/png" />

--- a/2016/team/index.html
+++ b/2016/team/index.html
@@ -20,7 +20,7 @@
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
     <script src="https://code.jquery.com/jquery-2.0.3.min.js"></script>
-    <link href="http://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
+    <link href="https://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
     <script src="/2016/javascripts/all.js"></script>
     <link href="/2016/stylesheets/all.css" rel="stylesheet" media="all" />
     <link href="/2016/images/favicon.png" rel="icon" type="image/png" />

--- a/2016/venue/index.html
+++ b/2016/venue/index.html
@@ -20,7 +20,7 @@
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
     <script src="https://code.jquery.com/jquery-2.0.3.min.js"></script>
-    <link href="http://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
+    <link href="https://fonts.googleapis.com/css?family=Titillium+Web:400,600,200,300,700" rel="stylesheet" media="all" />
     <script src="/2016/javascripts/all.js"></script>
     <link href="/2016/stylesheets/all.css" rel="stylesheet" media="all" />
     <link href="/2016/images/favicon.png" rel="icon" type="image/png" />


### PR DESCRIPTION
なんか、過去のKaigiのページのコンテンツをどこまでいじるべきかというのは難しいところ、というか、なるべくいじるべきではないと僕は思ってるんですが、しかし現状すでにpast_kaigisからは各年のアーカイブにHTTPSでリンクしてあって、 https://rubykaigi.org/2021-takeout/past_kaigis
そして、2016年のサイト内各ページからGoogle Fonts APIをHTTPで読んでるので、CORS的なやつで引っかかってwebフォントの取得に失敗しています。
サーバー的に`http://fonts.googleapis.com`を Allow-Origin してもいいのかもしれないけど、どちらかといえばこの際HTTPSに揃えるようにしちゃったほうが健全かな、と思ってこのようにしてみました。
ソース側の修正はこんな感じです。 https://github.com/amatsuda/rubykaigi2016/commit/8ce1b9bcb3de2452e8250994c36dacfc28940719

2016だけじゃなくて他の年も同様のものがあるかもしれず、引き続き調査します。