### PR TITLE
2013: commonNoImage URL should be generated by image helper

### DIFF
--- a/2013/lightning_talks/index.html
+++ b/2013/lightning_talks/index.html
@@ -68,7 +68,7 @@
               <div>
                 <div class='speakerProfile'>
                   <p class='avatar'>
-                    <img alt="YASUKAWA, Yohei" width="200" height="200" src="http://www.gravatar.com/avatar/f9e2dfe1e5e7b40cfe5bafa0c730293d?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+                    <img alt="YASUKAWA, Yohei" width="200" height="200" src="http://www.gravatar.com/avatar/f9e2dfe1e5e7b40cfe5bafa0c730293d?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
                   </p>
                   <span class='info'>
                     <span class='name'>
@@ -116,7 +116,7 @@
               <div>
                 <div class='speakerProfile'>
                   <p class='avatar'>
-                    <img alt="Yuki Torii" width="200" height="200" src="http://www.gravatar.com/avatar/c67596c92e9d161d314f69de3f05f00c?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+                    <img alt="Yuki Torii" width="200" height="200" src="http://www.gravatar.com/avatar/c67596c92e9d161d314f69de3f05f00c?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
                   </p>
                   <span class='info'>
                     <span class='name'>
@@ -164,7 +164,7 @@
               <div>
                 <div class='speakerProfile'>
                   <p class='avatar'>
-                    <img alt="Christian Sousa" width="200" height="200" src="http://www.gravatar.com/avatar/9702d5802302c61b996d905ac59b7c00?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+                    <img alt="Christian Sousa" width="200" height="200" src="http://www.gravatar.com/avatar/9702d5802302c61b996d905ac59b7c00?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
                   </p>
                   <span class='info'>
                     <span class='name'>
@@ -210,7 +210,7 @@
               <div>
                 <div class='speakerProfile'>
                   <p class='avatar'>
-                    <img alt="Rikiya Ayukawa" width="200" height="200" src="http://www.gravatar.com/avatar/?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+                    <img alt="Rikiya Ayukawa" width="200" height="200" src="http://www.gravatar.com/avatar/?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
                   </p>
                   <span class='info'>
                     <span class='name'>
@@ -257,7 +257,7 @@
               <div>
                 <div class='speakerProfile'>
                   <p class='avatar'>
-                    <img alt="Naotoshi Seo" width="200" height="200" src="http://www.gravatar.com/avatar/aef92c3acc29ad8543e04135687fc4f1?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+                    <img alt="Naotoshi Seo" width="200" height="200" src="http://www.gravatar.com/avatar/aef92c3acc29ad8543e04135687fc4f1?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
                   </p>
                   <span class='info'>
                     <span class='name'>
@@ -300,7 +300,7 @@
               <div>
                 <div class='speakerProfile'>
                   <p class='avatar'>
-                    <img alt="Shimpei Makimoto" width="200" height="200" src="http://www.gravatar.com/avatar/3e809b3e856f5eed33e279cf93657d3c?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+                    <img alt="Shimpei Makimoto" width="200" height="200" src="http://www.gravatar.com/avatar/3e809b3e856f5eed33e279cf93657d3c?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
                   </p>
                   <span class='info'>
                     <span class='name'>
@@ -343,7 +343,7 @@
               <div>
                 <div class='speakerProfile'>
                   <p class='avatar'>
-                    <img alt="Mu-Fan Teng" width="200" height="200" src="http://www.gravatar.com/avatar/c7c4962ce9539d003fd7f0f06539e9d3?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+                    <img alt="Mu-Fan Teng" width="200" height="200" src="http://www.gravatar.com/avatar/c7c4962ce9539d003fd7f0f06539e9d3?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
                   </p>
                   <span class='info'>
                     <span class='name'>
@@ -395,7 +395,7 @@
               <div>
                 <div class='speakerProfile'>
                   <p class='avatar'>
-                    <img alt="chikahiro tokoro @kibitan" width="200" height="200" src="http://www.gravatar.com/avatar/70d31d2a58c69153b84b7a0f5d648ea7?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+                    <img alt="chikahiro tokoro @kibitan" width="200" height="200" src="http://www.gravatar.com/avatar/70d31d2a58c69153b84b7a0f5d648ea7?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
                   </p>
                   <span class='info'>
                     <span class='name'>
@@ -458,7 +458,7 @@
               <div>
                 <div class='speakerProfile'>
                   <p class='avatar'>
-                    <img alt="Kazuhiro Sera" width="200" height="200" src="http://www.gravatar.com/avatar/132fe0f031849e12eea7ce74f99b90f0?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+                    <img alt="Kazuhiro Sera" width="200" height="200" src="http://www.gravatar.com/avatar/132fe0f031849e12eea7ce74f99b90f0?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
                   </p>
                   <span class='info'>
                     <span class='name'>
@@ -500,7 +500,7 @@
               <div>
                 <div class='speakerProfile'>
                   <p class='avatar'>
-                    <img alt="Peter Evjan" width="200" height="200" src="http://www.gravatar.com/avatar/bd36ec7f184adfb371f9738da5b53e6d?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+                    <img alt="Peter Evjan" width="200" height="200" src="http://www.gravatar.com/avatar/bd36ec7f184adfb371f9738da5b53e6d?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
                   </p>
                   <span class='info'>
                     <span class='name'>
@@ -546,7 +546,7 @@
               <div>
                 <div class='speakerProfile'>
                   <p class='avatar'>
-                    <img alt="Hiroyuki Inoue" width="200" height="200" src="http://www.gravatar.com/avatar/464f7715290af1c0cd41e6bf9d1ee8cc?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+                    <img alt="Hiroyuki Inoue" width="200" height="200" src="http://www.gravatar.com/avatar/464f7715290af1c0cd41e6bf9d1ee8cc?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
                   </p>
                   <span class='info'>
                     <span class='name'>

--- a/2013/speakers/index.html
+++ b/2013/speakers/index.html
@@ -47,7 +47,7 @@
           <ul class='speakers'><li><p class='name'>
               Yukihiro "Matz" Matsumoto  </p>
             <p class='avatar'>
-              <img alt="Yukihiro &quot;Matz&quot; Matsumoto" width="180" height="180" src="http://www.gravatar.com/avatar/0ec4920185b657a03edf01fff96b4e9b?s=180&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />  </p>
+              <img alt="Yukihiro &quot;Matz&quot; Matsumoto" width="180" height="180" src="http://www.gravatar.com/avatar/0ec4920185b657a03edf01fff96b4e9b?s=180&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />  </p>
             <p class='links'>
               <span class='btn'>
                 <a href='https://github.com/matz' target='_blank'>
@@ -62,7 +62,7 @@
             </p></li><li><p class='name'>
               José Valim  </p>
             <p class='avatar'>
-              <img alt="José Valim" width="180" height="180" src="http://www.gravatar.com/avatar/e837f6b7fd146ab16ed3d663476c063e?s=180&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />  </p>
+              <img alt="José Valim" width="180" height="180" src="http://www.gravatar.com/avatar/e837f6b7fd146ab16ed3d663476c063e?s=180&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />  </p>
             <p class='links'>
               <span class='btn'>
                 <a href='https://github.com/josevalim' target='_blank'>
@@ -77,7 +77,7 @@
             </p></li><li><p class='name'>
               Akira “akr” Tanaka  </p>
             <p class='avatar'>
-              <img alt="Akira “akr” Tanaka" width="180" height="180" src="http://www.gravatar.com/avatar/b11f10c4cd9d53970e7be20caa43f940?s=180&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />  </p>
+              <img alt="Akira “akr” Tanaka" width="180" height="180" src="http://www.gravatar.com/avatar/b11f10c4cd9d53970e7be20caa43f940?s=180&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />  </p>
             <p class='links'>
               <span class='btn'>
                 <a href='https://github.com/akr' target='_blank'>
@@ -98,7 +98,7 @@
           <ul class='speakers'><li><p class='name'>
               Martin Bosslet  </p>
             <p class='avatar'>
-              <img alt="Martin Bosslet" width="100" height="100" src="http://www.gravatar.com/avatar/1ecef11b3cc6abfda85798858745ef72?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />  </p>
+              <img alt="Martin Bosslet" width="100" height="100" src="http://www.gravatar.com/avatar/1ecef11b3cc6abfda85798858745ef72?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />  </p>
             <p class='links'>
               <span class='btn'>
                 <a href='https://github.com/emboss' target='_blank'>
@@ -113,7 +113,7 @@
             </p></li><li><p class='name'>
               Keiju Ishitsuka  </p>
             <p class='avatar'>
-              <img alt="Keiju Ishitsuka" width="100" height="100" src="http://www.gravatar.com/avatar/?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />  </p>
+              <img alt="Keiju Ishitsuka" width="100" height="100" src="http://www.gravatar.com/avatar/?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />  </p>
             <p class='links'>
               <span class='btnDisabled'>
                 <a>
@@ -128,7 +128,7 @@
             </p></li><li><p class='name'>
               Shugo Maeda  </p>
             <p class='avatar'>
-              <img alt="Shugo Maeda" width="100" height="100" src="http://www.gravatar.com/avatar/18a797893e6768e048c1d15429f96bb4?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />  </p>
+              <img alt="Shugo Maeda" width="100" height="100" src="http://www.gravatar.com/avatar/18a797893e6768e048c1d15429f96bb4?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />  </p>
             <p class='links'>
               <span class='btn'>
                 <a href='https://github.com/shugo' target='_blank'>
@@ -143,7 +143,7 @@
             </p></li><li><p class='name'>
               Akira Matsuda  </p>
             <p class='avatar'>
-              <img alt="Akira Matsuda" width="100" height="100" src="http://www.gravatar.com/avatar/76a777ff80f30bd3b390e275cce625bc?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />  </p>
+              <img alt="Akira Matsuda" width="100" height="100" src="http://www.gravatar.com/avatar/76a777ff80f30bd3b390e275cce625bc?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />  </p>
             <p class='links'>
               <span class='btn'>
                 <a href='https://github.com/amatsuda' target='_blank'>
@@ -158,7 +158,7 @@
             </p></li><li><p class='name'>
               Usaku NAKAMURA  </p>
             <p class='avatar'>
-              <img alt="Usaku NAKAMURA" width="100" height="100" src="http://www.gravatar.com/avatar/8cbb39dadafaf2287a83a13ee4981ec9?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />  </p>
+              <img alt="Usaku NAKAMURA" width="100" height="100" src="http://www.gravatar.com/avatar/8cbb39dadafaf2287a83a13ee4981ec9?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />  </p>
             <p class='links'>
               <span class='btn'>
                 <a href='https://github.com/unak' target='_blank'>
@@ -173,7 +173,7 @@
             </p></li><li><p class='name'>
               Aaron Patterson  </p>
             <p class='avatar'>
-              <img alt="Aaron Patterson" width="100" height="100" src="http://www.gravatar.com/avatar/f29327647a9cff5c69618bae420792ea?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />  </p>
+              <img alt="Aaron Patterson" width="100" height="100" src="http://www.gravatar.com/avatar/f29327647a9cff5c69618bae420792ea?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />  </p>
             <p class='links'>
               <span class='btn'>
                 <a href='https://github.com/tenderlove' target='_blank'>
@@ -188,7 +188,7 @@
             </p></li><li><p class='name'>
               Masatoshi SEKI  </p>
             <p class='avatar'>
-              <img alt="Masatoshi SEKI" width="100" height="100" src="http://www.gravatar.com/avatar/40f4d1f2e77078955bd01e9fb4a503ba?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />  </p>
+              <img alt="Masatoshi SEKI" width="100" height="100" src="http://www.gravatar.com/avatar/40f4d1f2e77078955bd01e9fb4a503ba?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />  </p>
             <p class='links'>
               <span class='btn'>
                 <a href='https://github.com/seki' target='_blank'>
@@ -203,7 +203,7 @@
             </p></li><li><p class='name'>
               Koichi Sasada  </p>
             <p class='avatar'>
-              <img alt="Koichi Sasada" width="100" height="100" src="http://www.gravatar.com/avatar/?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />  </p>
+              <img alt="Koichi Sasada" width="100" height="100" src="http://www.gravatar.com/avatar/?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />  </p>
             <p class='links'>
               <span class='btn'>
                 <a href='https://github.com/ko1' target='_blank'>
@@ -218,7 +218,7 @@
             </p></li><li><p class='name'>
               Kouhei Sutou  </p>
             <p class='avatar'>
-              <img alt="Kouhei Sutou" width="100" height="100" src="http://www.gravatar.com/avatar/ee6ffca720cc428d70247dcd7377dd48?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />  </p>
+              <img alt="Kouhei Sutou" width="100" height="100" src="http://www.gravatar.com/avatar/ee6ffca720cc428d70247dcd7377dd48?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />  </p>
             <p class='links'>
               <span class='btn'>
                 <a href='https://github.com/kou' target='_blank'>
@@ -233,7 +233,7 @@
             </p></li><li><p class='name'>
               Shyouhei Urabe  </p>
             <p class='avatar'>
-              <img alt="Shyouhei Urabe" width="100" height="100" src="http://www.gravatar.com/avatar/9d2f78236e45a335301ba1195026105d?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />  </p>
+              <img alt="Shyouhei Urabe" width="100" height="100" src="http://www.gravatar.com/avatar/9d2f78236e45a335301ba1195026105d?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />  </p>
             <p class='links'>
               <span class='btn'>
                 <a href='https://github.com/shyouhei' target='_blank'>
@@ -248,7 +248,7 @@
             </p></li><li><p class='name'>
               Tomoyuki,Chikanaga  </p>
             <p class='avatar'>
-              <img alt="Tomoyuki,Chikanaga" width="100" height="100" src="http://www.gravatar.com/avatar/5cf8f058a4c094bb708174fb43e7a387?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />  </p>
+              <img alt="Tomoyuki,Chikanaga" width="100" height="100" src="http://www.gravatar.com/avatar/5cf8f058a4c094bb708174fb43e7a387?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />  </p>
             <p class='links'>
               <span class='btn'>
                 <a href='https://github.com/nagachika' target='_blank'>
@@ -263,7 +263,7 @@
             </p></li><li><p class='name'>
               nari  </p>
             <p class='avatar'>
-              <img alt="nari" width="100" height="100" src="http://www.gravatar.com/avatar/9f859654c118bcd2f67cc763baf0de7a?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />  </p>
+              <img alt="nari" width="100" height="100" src="http://www.gravatar.com/avatar/9f859654c118bcd2f67cc763baf0de7a?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />  </p>
             <p class='links'>
               <span class='btn'>
                 <a href='https://github.com/authorNari' target='_blank'>
@@ -278,7 +278,7 @@
             </p></li><li><p class='name'>
               okkez  </p>
             <p class='avatar'>
-              <img alt="okkez" width="100" height="100" src="http://www.gravatar.com/avatar/9673ac7770ee09f76ff5d839820db157?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />  </p>
+              <img alt="okkez" width="100" height="100" src="http://www.gravatar.com/avatar/9673ac7770ee09f76ff5d839820db157?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />  </p>
             <p class='links'>
               <span class='btn'>
                 <a href='https://github.com/okkez' target='_blank'>
@@ -293,7 +293,7 @@
             </p></li><li><p class='name'>
               SHIBATA Hiroshi  </p>
             <p class='avatar'>
-              <img alt="SHIBATA Hiroshi" width="100" height="100" src="http://www.gravatar.com/avatar/eabad423977cfc6873b8f5df62b848a6?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />  </p>
+              <img alt="SHIBATA Hiroshi" width="100" height="100" src="http://www.gravatar.com/avatar/eabad423977cfc6873b8f5df62b848a6?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />  </p>
             <p class='links'>
               <span class='btn'>
                 <a href='https://github.com/hsbt' target='_blank'>
@@ -308,7 +308,7 @@
             </p></li><li><p class='name'>
               Zachary Scott  </p>
             <p class='avatar'>
-              <img alt="Zachary Scott" width="100" height="100" src="http://www.gravatar.com/avatar/7fe945668a4fc098e886e20dea71d2ee?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />  </p>
+              <img alt="Zachary Scott" width="100" height="100" src="http://www.gravatar.com/avatar/7fe945668a4fc098e886e20dea71d2ee?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />  </p>
             <p class='links'>
               <span class='btn'>
                 <a href='https://github.com/zzak' target='_blank'>
@@ -323,7 +323,7 @@
             </p></li><li><p class='name'>
               Yusuke Endoh  </p>
             <p class='avatar'>
-              <img alt="Yusuke Endoh" width="100" height="100" src="http://www.gravatar.com/avatar/f24ff61beb80aa5f13371aa22a35619c?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />  </p>
+              <img alt="Yusuke Endoh" width="100" height="100" src="http://www.gravatar.com/avatar/f24ff61beb80aa5f13371aa22a35619c?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />  </p>
             <p class='links'>
               <span class='btn'>
                 <a href='https://github.com/mame' target='_blank'>
@@ -344,7 +344,7 @@
           <ul class='speakers'><li><p class='name'>
               Shozo Arai  </p>
             <p class='avatar'>
-              <img alt="Shozo Arai" width="100" height="100" src="http://www.gravatar.com/avatar/2ace97e3d45d19b4e6aadf89a497f2c9?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />  </p>
+              <img alt="Shozo Arai" width="100" height="100" src="http://www.gravatar.com/avatar/2ace97e3d45d19b4e6aadf89a497f2c9?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />  </p>
             <p class='links'>
               <span class='btnDisabled'>
                 <a>
@@ -359,7 +359,7 @@
             </p></li><li><p class='name'>
               André Arko  </p>
             <p class='avatar'>
-              <img alt="André Arko" width="100" height="100" src="http://www.gravatar.com/avatar/91eeff0aae76794bad5d0eb72d577386?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />  </p>
+              <img alt="André Arko" width="100" height="100" src="http://www.gravatar.com/avatar/91eeff0aae76794bad5d0eb72d577386?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />  </p>
             <p class='links'>
               <span class='btn'>
                 <a href='https://github.com/indirect' target='_blank'>
@@ -374,7 +374,7 @@
             </p></li><li><p class='name'>
               Daniel Bovensiepen  </p>
             <p class='avatar'>
-              <img alt="Daniel Bovensiepen" width="100" height="100" src="http://www.gravatar.com/avatar/49d6f762505615af259534deed94bc54?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />  </p>
+              <img alt="Daniel Bovensiepen" width="100" height="100" src="http://www.gravatar.com/avatar/49d6f762505615af259534deed94bc54?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />  </p>
             <p class='links'>
               <span class='btn'>
                 <a href='https://github.com/bovi' target='_blank'>
@@ -389,7 +389,7 @@
             </p></li><li><p class='name'>
               Sebastian Burkhard  </p>
             <p class='avatar'>
-              <img alt="Sebastian Burkhard" width="100" height="100" src="http://www.gravatar.com/avatar/5a3cdca851be0f6fea2a746b78afa0b8?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />  </p>
+              <img alt="Sebastian Burkhard" width="100" height="100" src="http://www.gravatar.com/avatar/5a3cdca851be0f6fea2a746b78afa0b8?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />  </p>
             <p class='links'>
               <span class='btn'>
                 <a href='https://github.com/hasclass' target='_blank'>
@@ -404,7 +404,7 @@
             </p></li><li><p class='name'>
               Jacob Burkhart  </p>
             <p class='avatar'>
-              <img alt="Jacob Burkhart" width="100" height="100" src="http://www.gravatar.com/avatar/409e4d0bf136e5197eb8ecb8375be8ad?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />  </p>
+              <img alt="Jacob Burkhart" width="100" height="100" src="http://www.gravatar.com/avatar/409e4d0bf136e5197eb8ecb8375be8ad?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />  </p>
             <p class='links'>
               <span class='btn'>
                 <a href='https://github.com/jacobo' target='_blank'>
@@ -419,7 +419,7 @@
             </p></li><li><p class='name'>
               Matthew Conway  </p>
             <p class='avatar'>
-              <img alt="Matthew Conway" width="100" height="100" src="http://www.gravatar.com/avatar/0b30c6aa6b9027d124ca028325b80b15?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />  </p>
+              <img alt="Matthew Conway" width="100" height="100" src="http://www.gravatar.com/avatar/0b30c6aa6b9027d124ca028325b80b15?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />  </p>
             <p class='links'>
               <span class='btn'>
                 <a href='https://github.com/mattonrails' target='_blank'>
@@ -434,7 +434,7 @@
             </p></li><li><p class='name'>
               Ron Evans  </p>
             <p class='avatar'>
-              <img alt="Ron Evans" width="100" height="100" src="http://www.gravatar.com/avatar/2f6254b55c3e1693bd1e64d246cead33?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />  </p>
+              <img alt="Ron Evans" width="100" height="100" src="http://www.gravatar.com/avatar/2f6254b55c3e1693bd1e64d246cead33?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />  </p>
             <p class='links'>
               <span class='btn'>
                 <a href='https://github.com/deadprogram' target='_blank'>
@@ -449,7 +449,7 @@
             </p></li><li><p class='name'>
               Adrian Zankich  </p>
             <p class='avatar'>
-              <img alt="Adrian Zankich" width="100" height="100" src="http://www.gravatar.com/avatar/fbc9c9b33dc1ce68c353b3233ca22bfe?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />  </p>
+              <img alt="Adrian Zankich" width="100" height="100" src="http://www.gravatar.com/avatar/fbc9c9b33dc1ce68c353b3233ca22bfe?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />  </p>
             <p class='links'>
               <span class='btn'>
                 <a href='https://github.com/adzankich' target='_blank'>
@@ -464,7 +464,7 @@
             </p></li><li><p class='name'>
               John Foley  </p>
             <p class='avatar'>
-              <img alt="John Foley" width="100" height="100" src="http://www.gravatar.com/avatar/45001df0297ee307cee788f15c5a8595?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />  </p>
+              <img alt="John Foley" width="100" height="100" src="http://www.gravatar.com/avatar/45001df0297ee307cee788f15c5a8595?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />  </p>
             <p class='links'>
               <span class='btn'>
                 <a href='https://github.com/jfoley' target='_blank'>
@@ -479,7 +479,7 @@
             </p></li><li><p class='name'>
               Laurent Sansonetti  </p>
             <p class='avatar'>
-              <img alt="Laurent Sansonetti" width="100" height="100" src="http://www.gravatar.com/avatar/08eb285fc24c487c7838a6164b845364?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />  </p>
+              <img alt="Laurent Sansonetti" width="100" height="100" src="http://www.gravatar.com/avatar/08eb285fc24c487c7838a6164b845364?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />  </p>
             <p class='links'>
               <span class='btn'>
                 <a href='https://github.com/lrz' target='_blank'>
@@ -494,7 +494,7 @@
             </p></li><li><p class='name'>
               Shizuo Fujita  </p>
             <p class='avatar'>
-              <img alt="Shizuo Fujita" width="100" height="100" src="http://www.gravatar.com/avatar/6e8aca910e7ee095397d3b90acb25f6c?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />  </p>
+              <img alt="Shizuo Fujita" width="100" height="100" src="http://www.gravatar.com/avatar/6e8aca910e7ee095397d3b90acb25f6c?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />  </p>
             <p class='links'>
               <span class='btn'>
                 <a href='https://github.com/watson1978' target='_blank'>
@@ -509,7 +509,7 @@
             </p></li><li><p class='name'>
               Jim Gay  </p>
             <p class='avatar'>
-              <img alt="Jim Gay" width="100" height="100" src="http://www.gravatar.com/avatar/09477c358c5897d44121a248326e16d7?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />  </p>
+              <img alt="Jim Gay" width="100" height="100" src="http://www.gravatar.com/avatar/09477c358c5897d44121a248326e16d7?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />  </p>
             <p class='links'>
               <span class='btn'>
                 <a href='https://github.com/saturnflyer' target='_blank'>
@@ -524,7 +524,7 @@
             </p></li><li><p class='name'>
               Max Gorin  </p>
             <p class='avatar'>
-              <img alt="Max Gorin" width="100" height="100" src="http://www.gravatar.com/avatar/b472b6e2dfd982ec3995cf4471b4c1e4?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />  </p>
+              <img alt="Max Gorin" width="100" height="100" src="http://www.gravatar.com/avatar/b472b6e2dfd982ec3995cf4471b4c1e4?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />  </p>
             <p class='links'>
               <span class='btn'>
                 <a href='https://github.com/nomadcoder' target='_blank'>
@@ -539,7 +539,7 @@
             </p></li><li><p class='name'>
               Konstantin Haase  </p>
             <p class='avatar'>
-              <img alt="Konstantin Haase" width="100" height="100" src="http://www.gravatar.com/avatar/dddf1d0b08d492bbf18d7b865db098d8?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />  </p>
+              <img alt="Konstantin Haase" width="100" height="100" src="http://www.gravatar.com/avatar/dddf1d0b08d492bbf18d7b865db098d8?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />  </p>
             <p class='links'>
               <span class='btn'>
                 <a href='https://github.com/rkh' target='_blank'>
@@ -554,7 +554,7 @@
             </p></li><li><p class='name'>
               Bryan Helmkamp  </p>
             <p class='avatar'>
-              <img alt="Bryan Helmkamp" width="100" height="100" src="http://www.gravatar.com/avatar/b67ae70db4351816ffeaef4f49005667?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />  </p>
+              <img alt="Bryan Helmkamp" width="100" height="100" src="http://www.gravatar.com/avatar/b67ae70db4351816ffeaef4f49005667?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />  </p>
             <p class='links'>
               <span class='btn'>
                 <a href='https://github.com/brynary' target='_blank'>
@@ -569,7 +569,7 @@
             </p></li><li><p class='name'>
               Eddie Kao  </p>
             <p class='avatar'>
-              <img alt="Eddie Kao" width="100" height="100" src="http://www.gravatar.com/avatar/f2dcf6633971844e19ca96ea294ba976?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />  </p>
+              <img alt="Eddie Kao" width="100" height="100" src="http://www.gravatar.com/avatar/f2dcf6633971844e19ca96ea294ba976?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />  </p>
             <p class='links'>
               <span class='btn'>
                 <a href='https://github.com/kaochenlong' target='_blank'>
@@ -584,7 +584,7 @@
             </p></li><li><p class='name'>
               Toru Kawamura  </p>
             <p class='avatar'>
-              <img alt="Toru Kawamura" width="100" height="100" src="http://www.gravatar.com/avatar/4bc8a6fb46ecbd1a5432e58225954ea3?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />  </p>
+              <img alt="Toru Kawamura" width="100" height="100" src="http://www.gravatar.com/avatar/4bc8a6fb46ecbd1a5432e58225954ea3?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />  </p>
             <p class='links'>
               <span class='btn'>
                 <a href='https://github.com/tkawa' target='_blank'>
@@ -599,7 +599,7 @@
             </p></li><li><p class='name'>
               Danish Khan  </p>
             <p class='avatar'>
-              <img alt="Danish Khan" width="100" height="100" src="http://www.gravatar.com/avatar/b801a36049da233e6266a0275568a7cf?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />  </p>
+              <img alt="Danish Khan" width="100" height="100" src="http://www.gravatar.com/avatar/b801a36049da233e6266a0275568a7cf?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />  </p>
             <p class='links'>
               <span class='btn'>
                 <a href='https://github.com/danishkhan' target='_blank'>
@@ -614,7 +614,7 @@
             </p></li><li><p class='name'>
               Terence Lee  </p>
             <p class='avatar'>
-              <img alt="Terence Lee" width="100" height="100" src="http://www.gravatar.com/avatar/ac7f7f050ade421ee11b467c8570a3cd?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />  </p>
+              <img alt="Terence Lee" width="100" height="100" src="http://www.gravatar.com/avatar/ac7f7f050ade421ee11b467c8570a3cd?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />  </p>
             <p class='links'>
               <span class='btn'>
                 <a href='https://github.com/hone' target='_blank'>
@@ -629,7 +629,7 @@
             </p></li><li><p class='name'>
               moro, Kyosuke MOROHASHI  </p>
             <p class='avatar'>
-              <img alt="moro, Kyosuke MOROHASHI" width="100" height="100" src="http://www.gravatar.com/avatar/70e13d9877054026fda46d5a5b53a236?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />  </p>
+              <img alt="moro, Kyosuke MOROHASHI" width="100" height="100" src="http://www.gravatar.com/avatar/70e13d9877054026fda46d5a5b53a236?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />  </p>
             <p class='links'>
               <span class='btn'>
                 <a href='https://github.com/moro' target='_blank'>
@@ -644,7 +644,7 @@
             </p></li><li><p class='name'>
               Matthew Mongeau  </p>
             <p class='avatar'>
-              <img alt="Matthew Mongeau" width="100" height="100" src="http://www.gravatar.com/avatar/b066cb3c505933f832faa83238489a89?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />  </p>
+              <img alt="Matthew Mongeau" width="100" height="100" src="http://www.gravatar.com/avatar/b066cb3c505933f832faa83238489a89?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />  </p>
             <p class='links'>
               <span class='btn'>
                 <a href='https://github.com/halogenandtoast' target='_blank'>
@@ -659,7 +659,7 @@
             </p></li><li><p class='name'>
               Kensuke Nagae  </p>
             <p class='avatar'>
-              <img alt="Kensuke Nagae" width="100" height="100" src="http://www.gravatar.com/avatar/fffd8bf62b842a46803fb07792029fa4?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />  </p>
+              <img alt="Kensuke Nagae" width="100" height="100" src="http://www.gravatar.com/avatar/fffd8bf62b842a46803fb07792029fa4?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />  </p>
             <p class='links'>
               <span class='btn'>
                 <a href='https://github.com/kyanny' target='_blank'>
@@ -674,7 +674,7 @@
             </p></li><li><p class='name'>
               Issei Naruta  </p>
             <p class='avatar'>
-              <img alt="Issei Naruta" width="100" height="100" src="http://www.gravatar.com/avatar/8ed4c28c6567ee259571ab7178159607?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />  </p>
+              <img alt="Issei Naruta" width="100" height="100" src="http://www.gravatar.com/avatar/8ed4c28c6567ee259571ab7178159607?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />  </p>
             <p class='links'>
               <span class='btn'>
                 <a href='https://github.com/mirakui' target='_blank'>
@@ -689,7 +689,7 @@
             </p></li><li><p class='name'>
               Thomas E. Enebo  </p>
             <p class='avatar'>
-              <img alt="Thomas E. Enebo" width="100" height="100" src="http://www.gravatar.com/avatar/13313ac2ec7ba7c43b1b952db034ff3b?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />  </p>
+              <img alt="Thomas E. Enebo" width="100" height="100" src="http://www.gravatar.com/avatar/13313ac2ec7ba7c43b1b952db034ff3b?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />  </p>
             <p class='links'>
               <span class='btn'>
                 <a href='https://github.com/enebo' target='_blank'>
@@ -704,7 +704,7 @@
             </p></li><li><p class='name'>
               Charles O. Nutter  </p>
             <p class='avatar'>
-              <img alt="Charles O. Nutter" width="100" height="100" src="http://www.gravatar.com/avatar/f1d37642fdaa1662ff46e4c65731e9ab?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />  </p>
+              <img alt="Charles O. Nutter" width="100" height="100" src="http://www.gravatar.com/avatar/f1d37642fdaa1662ff46e4c65731e9ab?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />  </p>
             <p class='links'>
               <span class='btn'>
                 <a href='https://github.com/headius' target='_blank'>
@@ -719,7 +719,7 @@
             </p></li><li><p class='name'>
               David Padilla  </p>
             <p class='avatar'>
-              <img alt="David Padilla" width="100" height="100" src="http://www.gravatar.com/avatar/a59cda5de705716cbd18195a4dd68a56?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />  </p>
+              <img alt="David Padilla" width="100" height="100" src="http://www.gravatar.com/avatar/a59cda5de705716cbd18195a4dd68a56?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />  </p>
             <p class='links'>
               <span class='btn'>
                 <a href='https://github.com/dabit' target='_blank'>
@@ -734,7 +734,7 @@
             </p></li><li><p class='name'>
               Prem Sichanugrist  </p>
             <p class='avatar'>
-              <img alt="Prem Sichanugrist" width="100" height="100" src="http://www.gravatar.com/avatar/f1c4a3bb1606cc4a61711e61e2fe6146?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />  </p>
+              <img alt="Prem Sichanugrist" width="100" height="100" src="http://www.gravatar.com/avatar/f1c4a3bb1606cc4a61711e61e2fe6146?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />  </p>
             <p class='links'>
               <span class='btn'>
                 <a href='https://github.com/sikachu' target='_blank'>
@@ -749,7 +749,7 @@
             </p></li><li><p class='name'>
               Christopher Rigor  </p>
             <p class='avatar'>
-              <img alt="Christopher Rigor" width="100" height="100" src="http://www.gravatar.com/avatar/c49ed3ac5bb2c11a7df1aa06bc9cfc96?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />  </p>
+              <img alt="Christopher Rigor" width="100" height="100" src="http://www.gravatar.com/avatar/c49ed3ac5bb2c11a7df1aa06bc9cfc96?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />  </p>
             <p class='links'>
               <span class='btn'>
                 <a href='https://github.com/crigor' target='_blank'>
@@ -764,7 +764,7 @@
             </p></li><li><p class='name'>
               Richard Schneeman  </p>
             <p class='avatar'>
-              <img alt="Richard Schneeman" width="100" height="100" src="http://www.gravatar.com/avatar/db953d125f5cc49756edb6149f1b813e?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />  </p>
+              <img alt="Richard Schneeman" width="100" height="100" src="http://www.gravatar.com/avatar/db953d125f5cc49756edb6149f1b813e?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />  </p>
             <p class='links'>
               <span class='btn'>
                 <a href='https://github.com/schneems' target='_blank'>
@@ -779,7 +779,7 @@
             </p></li><li><p class='name'>
               Ryan Smith  </p>
             <p class='avatar'>
-              <img alt="Ryan Smith" width="100" height="100" src="http://www.gravatar.com/avatar/8964943d31146bd35d3d305ff940beca?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />  </p>
+              <img alt="Ryan Smith" width="100" height="100" src="http://www.gravatar.com/avatar/8964943d31146bd35d3d305ff940beca?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />  </p>
             <p class='links'>
               <span class='btn'>
                 <a href='https://github.com/ryandotsmith' target='_blank'>
@@ -794,7 +794,7 @@
             </p></li><li><p class='name'>
               Masayoshi Takahashi  </p>
             <p class='avatar'>
-              <img alt="Masayoshi Takahashi" width="100" height="100" src="http://www.gravatar.com/avatar/21a4b941766d805333e11c5766be43b4?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />  </p>
+              <img alt="Masayoshi Takahashi" width="100" height="100" src="http://www.gravatar.com/avatar/21a4b941766d805333e11c5766be43b4?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />  </p>
             <p class='links'>
               <span class='btn'>
                 <a href='https://github.com/takahashim' target='_blank'>
@@ -809,7 +809,7 @@
             </p></li><li><p class='name'>
               Kota Uenishi  </p>
             <p class='avatar'>
-              <img alt="Kota Uenishi" width="100" height="100" src="http://www.gravatar.com/avatar/e1923013dacab39eb231a2fffbf7b33c?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />  </p>
+              <img alt="Kota Uenishi" width="100" height="100" src="http://www.gravatar.com/avatar/e1923013dacab39eb231a2fffbf7b33c?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />  </p>
             <p class='links'>
               <span class='btn'>
                 <a href='https://github.com/kuenishi' target='_blank'>
@@ -824,7 +824,7 @@
             </p></li><li><p class='name'>
               Xuejie "Rafael" Xiao  </p>
             <p class='avatar'>
-              <img alt="Xuejie &quot;Rafael&quot; Xiao" width="100" height="100" src="http://www.gravatar.com/avatar/9c85527be213734ed23c2ff233b7b5b8?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />  </p>
+              <img alt="Xuejie &quot;Rafael&quot; Xiao" width="100" height="100" src="http://www.gravatar.com/avatar/9c85527be213734ed23c2ff233b7b5b8?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />  </p>
             <p class='links'>
               <span class='btn'>
                 <a href='https://github.com/xxuejie' target='_blank'>
@@ -839,7 +839,7 @@
             </p></li><li><p class='name'>
               Hiroki Yoshioka  </p>
             <p class='avatar'>
-              <img alt="Hiroki Yoshioka" width="100" height="100" src="http://www.gravatar.com/avatar/f8fbcb02824678dbc843748e8da20d24?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />  </p>
+              <img alt="Hiroki Yoshioka" width="100" height="100" src="http://www.gravatar.com/avatar/f8fbcb02824678dbc843748e8da20d24?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />  </p>
             <p class='links'>
               <span class='btn'>
                 <a href='https://github.com/irohiroki' target='_blank'>
@@ -854,7 +854,7 @@
             </p></li><li><p class='name'>
               tagomoris  </p>
             <p class='avatar'>
-              <img alt="tagomoris" width="100" height="100" src="http://www.gravatar.com/avatar/002525eada5741b7954ce22c1a066d32?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />  </p>
+              <img alt="tagomoris" width="100" height="100" src="http://www.gravatar.com/avatar/002525eada5741b7954ce22c1a066d32?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />  </p>
             <p class='links'>
               <span class='btn'>
                 <a href='https://github.com/tagomoris' target='_blank'>
@@ -869,7 +869,7 @@
             </p></li><li><p class='name'>
               Kevin Triplett  </p>
             <p class='avatar'>
-              <img alt="Kevin Triplett" width="100" height="100" src="http://www.gravatar.com/avatar/2b64274a52355e39ff9fe937cb117a64?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />  </p>
+              <img alt="Kevin Triplett" width="100" height="100" src="http://www.gravatar.com/avatar/2b64274a52355e39ff9fe937cb117a64?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />  </p>
             <p class='links'>
               <span class='btn'>
                 <a href='https://github.com/KevinTriplett' target='_blank'>
@@ -884,7 +884,7 @@
             </p></li><li><p class='name'>
               Shintaro Kakutani  </p>
             <p class='avatar'>
-              <img alt="Shintaro Kakutani" width="100" height="100" src="http://www.gravatar.com/avatar/63a6bff89d692e21de20868202bc8dde?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />  </p>
+              <img alt="Shintaro Kakutani" width="100" height="100" src="http://www.gravatar.com/avatar/63a6bff89d692e21de20868202bc8dde?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />  </p>
             <p class='links'>
               <span class='btn'>
                 <a href='https://github.com/kakutani' target='_blank'>
@@ -899,7 +899,7 @@
             </p></li><li><p class='name'>
               Kazuyoshi Fukuda  </p>
             <p class='avatar'>
-              <img alt="Kazuyoshi Fukuda" width="100" height="100" src="http://www.gravatar.com/avatar/42ebafce7cc89f79b0910b53609ce99b?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />  </p>
+              <img alt="Kazuyoshi Fukuda" width="100" height="100" src="http://www.gravatar.com/avatar/42ebafce7cc89f79b0910b53609ce99b?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />  </p>
             <p class='links'>
               <span class='btnDisabled'>
                 <a>
@@ -914,7 +914,7 @@
             </p></li><li><p class='name'>
               Kenji Sugihara  </p>
             <p class='avatar'>
-              <img alt="Kenji Sugihara" width="100" height="100" src="http://www.gravatar.com/avatar/22d17209eab280d1e1af349d4f9e4300?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />  </p>
+              <img alt="Kenji Sugihara" width="100" height="100" src="http://www.gravatar.com/avatar/22d17209eab280d1e1af349d4f9e4300?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />  </p>
             <p class='links'>
               <span class='btnDisabled'>
                 <a>
@@ -929,7 +929,7 @@
             </p></li><li><p class='name'>
               Daisuke Inoue  </p>
             <p class='avatar'>
-              <img alt="Daisuke Inoue" width="100" height="100" src="http://www.gravatar.com/avatar/?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />  </p>
+              <img alt="Daisuke Inoue" width="100" height="100" src="http://www.gravatar.com/avatar/?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />  </p>
             <p class='links'>
               <span class='btn'>
                 <a href='https://github.com/daisukei' target='_blank'>
@@ -944,7 +944,7 @@
             </p></li><li><p class='name'>
               Joshua Ballanco  </p>
             <p class='avatar'>
-              <img alt="Joshua Ballanco" width="100" height="100" src="http://www.gravatar.com/avatar/da7e5a2c5b1bd8139704db94b37e068d?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />  </p>
+              <img alt="Joshua Ballanco" width="100" height="100" src="http://www.gravatar.com/avatar/da7e5a2c5b1bd8139704db94b37e068d?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />  </p>
             <p class='links'>
               <span class='btn'>
                 <a href='https://github.com/jballanc' target='_blank'>

--- a/2013/talk/S01/index.html
+++ b/2013/talk/S01/index.html
@@ -92,7 +92,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="Daniel Bovensiepen" width="200" height="200" src="http://www.gravatar.com/avatar/49d6f762505615af259534deed94bc54?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="Daniel Bovensiepen" width="200" height="200" src="http://www.gravatar.com/avatar/49d6f762505615af259534deed94bc54?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>

--- a/2013/talk/S05/index.html
+++ b/2013/talk/S05/index.html
@@ -83,7 +83,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="Christopher Rigor" width="200" height="200" src="http://www.gravatar.com/avatar/c49ed3ac5bb2c11a7df1aa06bc9cfc96?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="Christopher Rigor" width="200" height="200" src="http://www.gravatar.com/avatar/c49ed3ac5bb2c11a7df1aa06bc9cfc96?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>

--- a/2013/talk/S06/index.html
+++ b/2013/talk/S06/index.html
@@ -79,7 +79,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="Ryan Smith" width="200" height="200" src="http://www.gravatar.com/avatar/8964943d31146bd35d3d305ff940beca?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="Ryan Smith" width="200" height="200" src="http://www.gravatar.com/avatar/8964943d31146bd35d3d305ff940beca?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>

--- a/2013/talk/S07/index.html
+++ b/2013/talk/S07/index.html
@@ -88,7 +88,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="Xuejie &quot;Rafael&quot; Xiao" width="200" height="200" src="http://www.gravatar.com/avatar/9c85527be213734ed23c2ff233b7b5b8?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="Xuejie &quot;Rafael&quot; Xiao" width="200" height="200" src="http://www.gravatar.com/avatar/9c85527be213734ed23c2ff233b7b5b8?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>

--- a/2013/talk/S08/index.html
+++ b/2013/talk/S08/index.html
@@ -89,7 +89,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="SHIBATA Hiroshi" width="200" height="200" src="http://www.gravatar.com/avatar/eabad423977cfc6873b8f5df62b848a6?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="SHIBATA Hiroshi" width="200" height="200" src="http://www.gravatar.com/avatar/eabad423977cfc6873b8f5df62b848a6?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>

--- a/2013/talk/S09/index.html
+++ b/2013/talk/S09/index.html
@@ -85,7 +85,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="Zachary Scott" width="200" height="200" src="http://www.gravatar.com/avatar/7fe945668a4fc098e886e20dea71d2ee?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="Zachary Scott" width="200" height="200" src="http://www.gravatar.com/avatar/7fe945668a4fc098e886e20dea71d2ee?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>

--- a/2013/talk/S17/index.html
+++ b/2013/talk/S17/index.html
@@ -79,7 +79,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="Richard Schneeman" width="200" height="200" src="http://www.gravatar.com/avatar/db953d125f5cc49756edb6149f1b813e?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="Richard Schneeman" width="200" height="200" src="http://www.gravatar.com/avatar/db953d125f5cc49756edb6149f1b813e?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>

--- a/2013/talk/S19/index.html
+++ b/2013/talk/S19/index.html
@@ -84,7 +84,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="Aaron Patterson" width="200" height="200" src="http://www.gravatar.com/avatar/f29327647a9cff5c69618bae420792ea?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="Aaron Patterson" width="200" height="200" src="http://www.gravatar.com/avatar/f29327647a9cff5c69618bae420792ea?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>

--- a/2013/talk/S20/index.html
+++ b/2013/talk/S20/index.html
@@ -88,7 +88,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="Shyouhei Urabe" width="200" height="200" src="http://www.gravatar.com/avatar/9d2f78236e45a335301ba1195026105d?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="Shyouhei Urabe" width="200" height="200" src="http://www.gravatar.com/avatar/9d2f78236e45a335301ba1195026105d?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>

--- a/2013/talk/S21/index.html
+++ b/2013/talk/S21/index.html
@@ -79,7 +79,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="Jim Gay" width="200" height="200" src="http://www.gravatar.com/avatar/09477c358c5897d44121a248326e16d7?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="Jim Gay" width="200" height="200" src="http://www.gravatar.com/avatar/09477c358c5897d44121a248326e16d7?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>

--- a/2013/talk/S22/index.html
+++ b/2013/talk/S22/index.html
@@ -79,7 +79,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="Laurent Sansonetti" width="200" height="200" src="http://www.gravatar.com/avatar/08eb285fc24c487c7838a6164b845364?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="Laurent Sansonetti" width="200" height="200" src="http://www.gravatar.com/avatar/08eb285fc24c487c7838a6164b845364?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>
@@ -116,7 +116,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="Shizuo Fujita" width="200" height="200" src="http://www.gravatar.com/avatar/6e8aca910e7ee095397d3b90acb25f6c?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="Shizuo Fujita" width="200" height="200" src="http://www.gravatar.com/avatar/6e8aca910e7ee095397d3b90acb25f6c?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>

--- a/2013/talk/S24/index.html
+++ b/2013/talk/S24/index.html
@@ -80,7 +80,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="Matthew Mongeau" width="200" height="200" src="http://www.gravatar.com/avatar/b066cb3c505933f832faa83238489a89?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="Matthew Mongeau" width="200" height="200" src="http://www.gravatar.com/avatar/b066cb3c505933f832faa83238489a89?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>

--- a/2013/talk/S26/index.html
+++ b/2013/talk/S26/index.html
@@ -92,7 +92,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="David Padilla" width="200" height="200" src="http://www.gravatar.com/avatar/a59cda5de705716cbd18195a4dd68a56?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="David Padilla" width="200" height="200" src="http://www.gravatar.com/avatar/a59cda5de705716cbd18195a4dd68a56?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>

--- a/2013/talk/S27/index.html
+++ b/2013/talk/S27/index.html
@@ -81,7 +81,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="Sebastian Burkhard" width="200" height="200" src="http://www.gravatar.com/avatar/5a3cdca851be0f6fea2a746b78afa0b8?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="Sebastian Burkhard" width="200" height="200" src="http://www.gravatar.com/avatar/5a3cdca851be0f6fea2a746b78afa0b8?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>

--- a/2013/talk/S29/index.html
+++ b/2013/talk/S29/index.html
@@ -89,7 +89,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="Martin Bosslet" width="200" height="200" src="http://www.gravatar.com/avatar/1ecef11b3cc6abfda85798858745ef72?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="Martin Bosslet" width="200" height="200" src="http://www.gravatar.com/avatar/1ecef11b3cc6abfda85798858745ef72?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>

--- a/2013/talk/S30/index.html
+++ b/2013/talk/S30/index.html
@@ -93,7 +93,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="Masatoshi SEKI" width="200" height="200" src="http://www.gravatar.com/avatar/40f4d1f2e77078955bd01e9fb4a503ba?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="Masatoshi SEKI" width="200" height="200" src="http://www.gravatar.com/avatar/40f4d1f2e77078955bd01e9fb4a503ba?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>

--- a/2013/talk/S32/index.html
+++ b/2013/talk/S32/index.html
@@ -83,7 +83,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="Bryan Helmkamp" width="200" height="200" src="http://www.gravatar.com/avatar/b67ae70db4351816ffeaef4f49005667?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="Bryan Helmkamp" width="200" height="200" src="http://www.gravatar.com/avatar/b67ae70db4351816ffeaef4f49005667?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>

--- a/2013/talk/S34/index.html
+++ b/2013/talk/S34/index.html
@@ -88,7 +88,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="Max Gorin" width="200" height="200" src="http://www.gravatar.com/avatar/b472b6e2dfd982ec3995cf4471b4c1e4?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="Max Gorin" width="200" height="200" src="http://www.gravatar.com/avatar/b472b6e2dfd982ec3995cf4471b4c1e4?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>

--- a/2013/talk/S39/index.html
+++ b/2013/talk/S39/index.html
@@ -81,7 +81,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="Thomas E. Enebo" width="200" height="200" src="http://www.gravatar.com/avatar/13313ac2ec7ba7c43b1b952db034ff3b?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="Thomas E. Enebo" width="200" height="200" src="http://www.gravatar.com/avatar/13313ac2ec7ba7c43b1b952db034ff3b?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>
@@ -115,7 +115,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="Charles O. Nutter" width="200" height="200" src="http://www.gravatar.com/avatar/f1d37642fdaa1662ff46e4c65731e9ab?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="Charles O. Nutter" width="200" height="200" src="http://www.gravatar.com/avatar/f1d37642fdaa1662ff46e4c65731e9ab?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>

--- a/2013/talk/S41/index.html
+++ b/2013/talk/S41/index.html
@@ -88,7 +88,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="Eddie Kao" width="200" height="200" src="http://www.gravatar.com/avatar/f2dcf6633971844e19ca96ea294ba976?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="Eddie Kao" width="200" height="200" src="http://www.gravatar.com/avatar/f2dcf6633971844e19ca96ea294ba976?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>

--- a/2013/talk/S42/index.html
+++ b/2013/talk/S42/index.html
@@ -88,7 +88,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="Hiroki Yoshioka" width="200" height="200" src="http://www.gravatar.com/avatar/f8fbcb02824678dbc843748e8da20d24?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="Hiroki Yoshioka" width="200" height="200" src="http://www.gravatar.com/avatar/f8fbcb02824678dbc843748e8da20d24?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>

--- a/2013/talk/S43/index.html
+++ b/2013/talk/S43/index.html
@@ -88,7 +88,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="André Arko" width="200" height="200" src="http://www.gravatar.com/avatar/91eeff0aae76794bad5d0eb72d577386?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="André Arko" width="200" height="200" src="http://www.gravatar.com/avatar/91eeff0aae76794bad5d0eb72d577386?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>

--- a/2013/talk/S48/index.html
+++ b/2013/talk/S48/index.html
@@ -90,7 +90,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="tagomoris" width="200" height="200" src="http://www.gravatar.com/avatar/002525eada5741b7954ce22c1a066d32?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="tagomoris" width="200" height="200" src="http://www.gravatar.com/avatar/002525eada5741b7954ce22c1a066d32?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>

--- a/2013/talk/S49/index.html
+++ b/2013/talk/S49/index.html
@@ -89,7 +89,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="nari" width="200" height="200" src="http://www.gravatar.com/avatar/9f859654c118bcd2f67cc763baf0de7a?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="nari" width="200" height="200" src="http://www.gravatar.com/avatar/9f859654c118bcd2f67cc763baf0de7a?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>

--- a/2013/talk/S50/index.html
+++ b/2013/talk/S50/index.html
@@ -87,7 +87,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="Konstantin Haase" width="200" height="200" src="http://www.gravatar.com/avatar/dddf1d0b08d492bbf18d7b865db098d8?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="Konstantin Haase" width="200" height="200" src="http://www.gravatar.com/avatar/dddf1d0b08d492bbf18d7b865db098d8?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>

--- a/2013/talk/S51/index.html
+++ b/2013/talk/S51/index.html
@@ -73,7 +73,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="Kevin Triplett" width="200" height="200" src="http://www.gravatar.com/avatar/2b64274a52355e39ff9fe937cb117a64?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="Kevin Triplett" width="200" height="200" src="http://www.gravatar.com/avatar/2b64274a52355e39ff9fe937cb117a64?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>
@@ -107,7 +107,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="Shintaro Kakutani" width="200" height="200" src="http://www.gravatar.com/avatar/63a6bff89d692e21de20868202bc8dde?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="Shintaro Kakutani" width="200" height="200" src="http://www.gravatar.com/avatar/63a6bff89d692e21de20868202bc8dde?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>

--- a/2013/talk/S52/index.html
+++ b/2013/talk/S52/index.html
@@ -77,7 +77,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="Kazuyoshi Fukuda" width="200" height="200" src="http://www.gravatar.com/avatar/42ebafce7cc89f79b0910b53609ce99b?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="Kazuyoshi Fukuda" width="200" height="200" src="http://www.gravatar.com/avatar/42ebafce7cc89f79b0910b53609ce99b?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>
@@ -109,7 +109,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="Kenji Sugihara" width="200" height="200" src="http://www.gravatar.com/avatar/22d17209eab280d1e1af349d4f9e4300?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="Kenji Sugihara" width="200" height="200" src="http://www.gravatar.com/avatar/22d17209eab280d1e1af349d4f9e4300?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>
@@ -143,7 +143,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="Masayoshi Takahashi" width="200" height="200" src="http://www.gravatar.com/avatar/21a4b941766d805333e11c5766be43b4?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="Masayoshi Takahashi" width="200" height="200" src="http://www.gravatar.com/avatar/21a4b941766d805333e11c5766be43b4?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>
@@ -177,7 +177,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="Shintaro Kakutani" width="200" height="200" src="http://www.gravatar.com/avatar/63a6bff89d692e21de20868202bc8dde?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="Shintaro Kakutani" width="200" height="200" src="http://www.gravatar.com/avatar/63a6bff89d692e21de20868202bc8dde?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>

--- a/2013/talk/S53/index.html
+++ b/2013/talk/S53/index.html
@@ -94,7 +94,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="Yusuke Endoh" width="200" height="200" src="http://www.gravatar.com/avatar/f24ff61beb80aa5f13371aa22a35619c?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="Yusuke Endoh" width="200" height="200" src="http://www.gravatar.com/avatar/f24ff61beb80aa5f13371aa22a35619c?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>
@@ -128,7 +128,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="Koichiro Eto" width="200" height="200" src="http://www.gravatar.com/avatar/ee67564a1a0e290cccf3c4a415e51c48?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="Koichiro Eto" width="200" height="200" src="http://www.gravatar.com/avatar/ee67564a1a0e290cccf3c4a415e51c48?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>
@@ -162,7 +162,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="Shinichiro Hamaji" width="200" height="200" src="http://www.gravatar.com/avatar/?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="Shinichiro Hamaji" width="200" height="200" src="http://www.gravatar.com/avatar/?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>
@@ -196,7 +196,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="Yutaka Hara" width="200" height="200" src="http://www.gravatar.com/avatar/2138d86b0e501db78d41d71b2c24382e?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="Yutaka Hara" width="200" height="200" src="http://www.gravatar.com/avatar/2138d86b0e501db78d41d71b2c24382e?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>
@@ -230,7 +230,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="Yukihiro &quot;Matz&quot; Matsumoto" width="200" height="200" src="http://www.gravatar.com/avatar/0ec4920185b657a03edf01fff96b4e9b?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="Yukihiro &quot;Matz&quot; Matsumoto" width="200" height="200" src="http://www.gravatar.com/avatar/0ec4920185b657a03edf01fff96b4e9b?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>
@@ -264,7 +264,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="eban" width="200" height="200" src="http://www.gravatar.com/avatar/?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="eban" width="200" height="200" src="http://www.gravatar.com/avatar/?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>

--- a/2013/talk/S54/index.html
+++ b/2013/talk/S54/index.html
@@ -85,7 +85,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="Terence Lee" width="200" height="200" src="http://www.gravatar.com/avatar/ac7f7f050ade421ee11b467c8570a3cd?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="Terence Lee" width="200" height="200" src="http://www.gravatar.com/avatar/ac7f7f050ade421ee11b467c8570a3cd?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>

--- a/2013/talk/S55/index.html
+++ b/2013/talk/S55/index.html
@@ -92,7 +92,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="Danish Khan" width="200" height="200" src="http://www.gravatar.com/avatar/b801a36049da233e6266a0275568a7cf?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="Danish Khan" width="200" height="200" src="http://www.gravatar.com/avatar/b801a36049da233e6266a0275568a7cf?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>

--- a/2013/talk/S57/index.html
+++ b/2013/talk/S57/index.html
@@ -88,7 +88,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="Masayoshi Takahashi" width="200" height="200" src="http://www.gravatar.com/avatar/21a4b941766d805333e11c5766be43b4?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="Masayoshi Takahashi" width="200" height="200" src="http://www.gravatar.com/avatar/21a4b941766d805333e11c5766be43b4?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>

--- a/2013/talk/S58/index.html
+++ b/2013/talk/S58/index.html
@@ -88,7 +88,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="Shugo Maeda" width="200" height="200" src="http://www.gravatar.com/avatar/18a797893e6768e048c1d15429f96bb4?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="Shugo Maeda" width="200" height="200" src="http://www.gravatar.com/avatar/18a797893e6768e048c1d15429f96bb4?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>

--- a/2013/talk/S59/index.html
+++ b/2013/talk/S59/index.html
@@ -88,7 +88,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="Prem Sichanugrist" width="200" height="200" src="http://www.gravatar.com/avatar/f1c4a3bb1606cc4a61711e61e2fe6146?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="Prem Sichanugrist" width="200" height="200" src="http://www.gravatar.com/avatar/f1c4a3bb1606cc4a61711e61e2fe6146?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>

--- a/2013/talk/S61/index.html
+++ b/2013/talk/S61/index.html
@@ -83,7 +83,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="moro, Kyosuke MOROHASHI" width="200" height="200" src="http://www.gravatar.com/avatar/70e13d9877054026fda46d5a5b53a236?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="moro, Kyosuke MOROHASHI" width="200" height="200" src="http://www.gravatar.com/avatar/70e13d9877054026fda46d5a5b53a236?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>

--- a/2013/talk/S62/index.html
+++ b/2013/talk/S62/index.html
@@ -100,7 +100,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="Takeshi Yabe" width="200" height="200" src="http://www.gravatar.com/avatar/2c246b10eca87568dda9f431c1134cb3?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="Takeshi Yabe" width="200" height="200" src="http://www.gravatar.com/avatar/2c246b10eca87568dda9f431c1134cb3?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>
@@ -134,7 +134,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="Toshiaki Koshiba" width="200" height="200" src="http://www.gravatar.com/avatar/9d2d4c8b739b1b4d7882ba49dcf1d276?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="Toshiaki Koshiba" width="200" height="200" src="http://www.gravatar.com/avatar/9d2d4c8b739b1b4d7882ba49dcf1d276?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>

--- a/2013/talk/S64/index.html
+++ b/2013/talk/S64/index.html
@@ -93,7 +93,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="Ron Evans" width="200" height="200" src="http://www.gravatar.com/avatar/2f6254b55c3e1693bd1e64d246cead33?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="Ron Evans" width="200" height="200" src="http://www.gravatar.com/avatar/2f6254b55c3e1693bd1e64d246cead33?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>
@@ -136,7 +136,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="Adrian Zankich" width="200" height="200" src="http://www.gravatar.com/avatar/fbc9c9b33dc1ce68c353b3233ca22bfe?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="Adrian Zankich" width="200" height="200" src="http://www.gravatar.com/avatar/fbc9c9b33dc1ce68c353b3233ca22bfe?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>

--- a/2013/talk/S66/index.html
+++ b/2013/talk/S66/index.html
@@ -88,7 +88,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="Usaku NAKAMURA" width="200" height="200" src="http://www.gravatar.com/avatar/8cbb39dadafaf2287a83a13ee4981ec9?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="Usaku NAKAMURA" width="200" height="200" src="http://www.gravatar.com/avatar/8cbb39dadafaf2287a83a13ee4981ec9?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>

--- a/2013/talk/S67/index.html
+++ b/2013/talk/S67/index.html
@@ -86,7 +86,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="Daisuke Inoue" width="200" height="200" src="http://www.gravatar.com/avatar/?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="Daisuke Inoue" width="200" height="200" src="http://www.gravatar.com/avatar/?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>

--- a/2013/talk/S68/index.html
+++ b/2013/talk/S68/index.html
@@ -79,7 +79,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="John Foley" width="200" height="200" src="http://www.gravatar.com/avatar/45001df0297ee307cee788f15c5a8595?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="John Foley" width="200" height="200" src="http://www.gravatar.com/avatar/45001df0297ee307cee788f15c5a8595?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>

--- a/2013/talk/S69/index.html
+++ b/2013/talk/S69/index.html
@@ -102,7 +102,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="okkez" width="200" height="200" src="http://www.gravatar.com/avatar/9673ac7770ee09f76ff5d839820db157?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="okkez" width="200" height="200" src="http://www.gravatar.com/avatar/9673ac7770ee09f76ff5d839820db157?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>

--- a/2013/talk/S70/index.html
+++ b/2013/talk/S70/index.html
@@ -93,7 +93,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="Kota Uenishi" width="200" height="200" src="http://www.gravatar.com/avatar/e1923013dacab39eb231a2fffbf7b33c?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="Kota Uenishi" width="200" height="200" src="http://www.gravatar.com/avatar/e1923013dacab39eb231a2fffbf7b33c?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>

--- a/2013/talk/S72/index.html
+++ b/2013/talk/S72/index.html
@@ -108,7 +108,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="Kensuke Nagae" width="200" height="200" src="http://www.gravatar.com/avatar/fffd8bf62b842a46803fb07792029fa4?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="Kensuke Nagae" width="200" height="200" src="http://www.gravatar.com/avatar/fffd8bf62b842a46803fb07792029fa4?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>

--- a/2013/talk/S73/index.html
+++ b/2013/talk/S73/index.html
@@ -83,7 +83,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="Koichi Sasada" width="200" height="200" src="http://www.gravatar.com/avatar/?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="Koichi Sasada" width="200" height="200" src="http://www.gravatar.com/avatar/?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>

--- a/2013/talk/S76/index.html
+++ b/2013/talk/S76/index.html
@@ -96,7 +96,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="Issei Naruta" width="200" height="200" src="http://www.gravatar.com/avatar/8ed4c28c6567ee259571ab7178159607?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="Issei Naruta" width="200" height="200" src="http://www.gravatar.com/avatar/8ed4c28c6567ee259571ab7178159607?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>

--- a/2013/talk/S78/index.html
+++ b/2013/talk/S78/index.html
@@ -92,7 +92,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="Toru Kawamura" width="200" height="200" src="http://www.gravatar.com/avatar/4bc8a6fb46ecbd1a5432e58225954ea3?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="Toru Kawamura" width="200" height="200" src="http://www.gravatar.com/avatar/4bc8a6fb46ecbd1a5432e58225954ea3?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>

--- a/2013/talk/S79/index.html
+++ b/2013/talk/S79/index.html
@@ -89,7 +89,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="Tomoyuki,Chikanaga" width="200" height="200" src="http://www.gravatar.com/avatar/5cf8f058a4c094bb708174fb43e7a387?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="Tomoyuki,Chikanaga" width="200" height="200" src="http://www.gravatar.com/avatar/5cf8f058a4c094bb708174fb43e7a387?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>

--- a/2013/talk/S80/index.html
+++ b/2013/talk/S80/index.html
@@ -88,7 +88,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="José Valim" width="200" height="200" src="http://www.gravatar.com/avatar/e837f6b7fd146ab16ed3d663476c063e?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="José Valim" width="200" height="200" src="http://www.gravatar.com/avatar/e837f6b7fd146ab16ed3d663476c063e?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>

--- a/2013/talk/S81/index.html
+++ b/2013/talk/S81/index.html
@@ -79,7 +79,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="Yukihiro &quot;Matz&quot; Matsumoto" width="200" height="200" src="http://www.gravatar.com/avatar/0ec4920185b657a03edf01fff96b4e9b?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="Yukihiro &quot;Matz&quot; Matsumoto" width="200" height="200" src="http://www.gravatar.com/avatar/0ec4920185b657a03edf01fff96b4e9b?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>

--- a/2013/talk/S82/index.html
+++ b/2013/talk/S82/index.html
@@ -92,7 +92,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="Akira “akr” Tanaka" width="200" height="200" src="http://www.gravatar.com/avatar/b11f10c4cd9d53970e7be20caa43f940?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="Akira “akr” Tanaka" width="200" height="200" src="http://www.gravatar.com/avatar/b11f10c4cd9d53970e7be20caa43f940?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>

--- a/2013/talk/S84/index.html
+++ b/2013/talk/S84/index.html
@@ -88,7 +88,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="Akira Matsuda" width="200" height="200" src="http://www.gravatar.com/avatar/76a777ff80f30bd3b390e275cce625bc?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="Akira Matsuda" width="200" height="200" src="http://www.gravatar.com/avatar/76a777ff80f30bd3b390e275cce625bc?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>

--- a/2013/talk/S85/index.html
+++ b/2013/talk/S85/index.html
@@ -88,7 +88,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="Matthew Conway" width="200" height="200" src="http://www.gravatar.com/avatar/0b30c6aa6b9027d124ca028325b80b15?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="Matthew Conway" width="200" height="200" src="http://www.gravatar.com/avatar/0b30c6aa6b9027d124ca028325b80b15?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>

--- a/2013/talk/S89/index.html
+++ b/2013/talk/S89/index.html
@@ -71,7 +71,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="Joshua Ballanco" width="200" height="200" src="http://www.gravatar.com/avatar/da7e5a2c5b1bd8139704db94b37e068d?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="Joshua Ballanco" width="200" height="200" src="http://www.gravatar.com/avatar/da7e5a2c5b1bd8139704db94b37e068d?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>

--- a/2013/talk/S91/index.html
+++ b/2013/talk/S91/index.html
@@ -98,7 +98,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="Jacob Burkhart" width="200" height="200" src="http://www.gravatar.com/avatar/409e4d0bf136e5197eb8ecb8375be8ad?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="Jacob Burkhart" width="200" height="200" src="http://www.gravatar.com/avatar/409e4d0bf136e5197eb8ecb8375be8ad?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>

--- a/2013/talk/S93/index.html
+++ b/2013/talk/S93/index.html
@@ -77,7 +77,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="Keiju Ishitsuka" width="200" height="200" src="http://www.gravatar.com/avatar/?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="Keiju Ishitsuka" width="200" height="200" src="http://www.gravatar.com/avatar/?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>

--- a/2013/talk/S94/index.html
+++ b/2013/talk/S94/index.html
@@ -116,7 +116,7 @@
           </h3>
           <div class='speakerProfile'>
             <p class='avatar'>
-              <img alt="Kouhei Sutou" width="200" height="200" src="http://www.gravatar.com/avatar/ee6ffca720cc428d70247dcd7377dd48?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />
+              <img alt="Kouhei Sutou" width="200" height="200" src="http://www.gravatar.com/avatar/ee6ffca720cc428d70247dcd7377dd48?s=200&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />
             </p>
             <dl>
               <dt>Company</dt>

--- a/2013/team/index.html
+++ b/2013/team/index.html
@@ -46,122 +46,122 @@
             <p class='role'>
               organizing director      </p>
             <p class='avatar'>
-              <img alt="Shintaro Kakutani" width="100" height="100" src="http://www.gravatar.com/avatar/63a6bff89d692e21de20868202bc8dde?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />      </p></li><li><p class='name'>
+              <img alt="Shintaro Kakutani" width="100" height="100" src="http://www.gravatar.com/avatar/63a6bff89d692e21de20868202bc8dde?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />      </p></li><li><p class='name'>
               Masayoshi Takahashi      </p>
             <p class='role'>
               organizer      </p>
             <p class='avatar'>
-              <img alt="Masayoshi Takahashi" width="100" height="100" src="http://www.gravatar.com/avatar/21a4b941766d805333e11c5766be43b4?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />      </p></li><li><p class='name'>
+              <img alt="Masayoshi Takahashi" width="100" height="100" src="http://www.gravatar.com/avatar/21a4b941766d805333e11c5766be43b4?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />      </p></li><li><p class='name'>
               Akira Matsuda      </p>
             <p class='role'>
               organizer      </p>
             <p class='avatar'>
-              <img alt="Akira Matsuda" width="100" height="100" src="http://www.gravatar.com/avatar/76a777ff80f30bd3b390e275cce625bc?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />      </p></li><li><p class='name'>
+              <img alt="Akira Matsuda" width="100" height="100" src="http://www.gravatar.com/avatar/76a777ff80f30bd3b390e275cce625bc?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />      </p></li><li><p class='name'>
               Koji Shimada      </p>
             <p class='role'>
               organizer      </p>
             <p class='avatar'>
-              <img alt="Koji Shimada" width="100" height="100" src="http://www.gravatar.com/avatar/941b170e5a115a295cccb5f5cdf0a800?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />      </p></li><li><p class='name'>
+              <img alt="Koji Shimada" width="100" height="100" src="http://www.gravatar.com/avatar/941b170e5a115a295cccb5f5cdf0a800?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />      </p></li><li><p class='name'>
               Urabe Shyouhei      </p>
             <p class='role'>
               organizer      </p>
             <p class='avatar'>
-              <img alt="Urabe Shyouhei" width="100" height="100" src="http://www.gravatar.com/avatar/9d2f78236e45a335301ba1195026105d?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />      </p></li><li><p class='name'>
+              <img alt="Urabe Shyouhei" width="100" height="100" src="http://www.gravatar.com/avatar/9d2f78236e45a335301ba1195026105d?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />      </p></li><li><p class='name'>
               Paul McMahon      </p>
             <p class='role'>
               organizer      </p>
             <p class='avatar'>
-              <img alt="Paul McMahon" width="100" height="100" src="http://www.gravatar.com/avatar/dd24adb5a3a430fed83a33ed552fe1b5?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />      </p></li><li><p class='name'>
+              <img alt="Paul McMahon" width="100" height="100" src="http://www.gravatar.com/avatar/dd24adb5a3a430fed83a33ed552fe1b5?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />      </p></li><li><p class='name'>
               Yoji Shidara      </p>
             <p class='role'>
               kaigifreaks honcho      </p>
             <p class='avatar'>
-              <img alt="Yoji Shidara" width="100" height="100" src="http://www.gravatar.com/avatar/817b7699ccbd3a6664de66eee8c2cbd2?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />      </p></li><li><p class='name'>
+              <img alt="Yoji Shidara" width="100" height="100" src="http://www.gravatar.com/avatar/817b7699ccbd3a6664de66eee8c2cbd2?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />      </p></li><li><p class='name'>
               Norio Suzuki      </p>
             <p class='role'>
               kaigifreaks      </p>
             <p class='avatar'>
-              <img alt="Norio Suzuki" width="100" height="100" src="http://www.gravatar.com/avatar/8e528456ff66ec543952daa815353a01?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />      </p></li><li><p class='name'>
+              <img alt="Norio Suzuki" width="100" height="100" src="http://www.gravatar.com/avatar/8e528456ff66ec543952daa815353a01?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />      </p></li><li><p class='name'>
               Jun Ohwada      </p>
             <p class='role'>
               kaigifreaks,<br/>communication honcho      </p>
             <p class='avatar'>
-              <img alt="Jun Ohwada" width="100" height="100" src="http://www.gravatar.com/avatar/6fd9be5cd0196df5ad62a5a5f2be3c55?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />      </p></li><li><p class='name'>
+              <img alt="Jun Ohwada" width="100" height="100" src="http://www.gravatar.com/avatar/6fd9be5cd0196df5ad62a5a5f2be3c55?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />      </p></li><li><p class='name'>
               Koiwa Hidekazu      </p>
             <p class='role'>
               kaigifreaks,<br/>networking honcho      </p>
             <p class='avatar'>
-              <img alt="Koiwa Hidekazu" width="100" height="100" src="http://www.gravatar.com/avatar/256838377ddbe600e85d8f446aae224d?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />      </p></li><li><p class='name'>
+              <img alt="Koiwa Hidekazu" width="100" height="100" src="http://www.gravatar.com/avatar/256838377ddbe600e85d8f446aae224d?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />      </p></li><li><p class='name'>
               Ippei Ogiwara      </p>
             <p class='role'>
               kaigifreaks      </p>
             <p class='avatar'>
-              <img alt="Ippei Ogiwara" width="100" height="100" src="http://www.gravatar.com/avatar/111c7cc8b41b3153858a9c145cec2686?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />      </p></li><li><p class='name'>
+              <img alt="Ippei Ogiwara" width="100" height="100" src="http://www.gravatar.com/avatar/111c7cc8b41b3153858a9c145cec2686?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />      </p></li><li><p class='name'>
               Mayuko Sekiya      </p>
             <p class='role'>
               designer      </p>
             <p class='avatar'>
-              <img alt="Mayuko Sekiya" width="100" height="100" src="http://www.gravatar.com/avatar/00575484b5d4489619bfc52e9775ee3b?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />      </p></li><li><p class='name'>
+              <img alt="Mayuko Sekiya" width="100" height="100" src="http://www.gravatar.com/avatar/00575484b5d4489619bfc52e9775ee3b?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />      </p></li><li><p class='name'>
               Gentaro Terada      </p>
             <p class='role'>
               rubykaigi.org      </p>
             <p class='avatar'>
-              <img alt="Gentaro Terada" width="100" height="100" src="http://www.gravatar.com/avatar/de0df5acda15a9c7eeb6c28a5e5d4e8e?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />      </p></li><li><p class='name'>
+              <img alt="Gentaro Terada" width="100" height="100" src="http://www.gravatar.com/avatar/de0df5acda15a9c7eeb6c28a5e5d4e8e?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />      </p></li><li><p class='name'>
               Ryunosuke Sato      </p>
             <p class='role'>
               rubykaigi.org      </p>
             <p class='avatar'>
-              <img alt="Ryunosuke Sato" width="100" height="100" src="http://www.gravatar.com/avatar/dc03a27ae31ba428c560c00c9128cd75?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />      </p></li><li><p class='name'>
+              <img alt="Ryunosuke Sato" width="100" height="100" src="http://www.gravatar.com/avatar/dc03a27ae31ba428c560c00c9128cd75?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />      </p></li><li><p class='name'>
               Yutaka Tachibana      </p>
             <p class='role'>
               Staff      </p>
             <p class='avatar'>
-              <img alt="Yutaka Tachibana" width="100" height="100" src="http://www.gravatar.com/avatar/276ea48e047cc4e4cab27db9681bc362?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />      </p></li><li><p class='name'>
+              <img alt="Yutaka Tachibana" width="100" height="100" src="http://www.gravatar.com/avatar/276ea48e047cc4e4cab27db9681bc362?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />      </p></li><li><p class='name'>
               Hiroshi Yoshida      </p>
             <p class='role'>
               Staff      </p>
             <p class='avatar'>
-              <img alt="Hiroshi Yoshida" width="100" height="100" src="http://www.gravatar.com/avatar/bbbf8523dd2997a04cef5b857f2e2445?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />      </p></li><li><p class='name'>
+              <img alt="Hiroshi Yoshida" width="100" height="100" src="http://www.gravatar.com/avatar/bbbf8523dd2997a04cef5b857f2e2445?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />      </p></li><li><p class='name'>
               Asami Imazu      </p>
             <p class='role'>
               Staff      </p>
             <p class='avatar'>
-              <img alt="Asami Imazu" width="100" height="100" src="http://www.gravatar.com/avatar/c4661e356b1ea4bc77bce3aaf9426bc6?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />      </p></li><li><p class='name'>
+              <img alt="Asami Imazu" width="100" height="100" src="http://www.gravatar.com/avatar/c4661e356b1ea4bc77bce3aaf9426bc6?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />      </p></li><li><p class='name'>
               Chris Salzberg      </p>
             <p class='role'>
               Staff      </p>
             <p class='avatar'>
-              <img alt="Chris Salzberg" width="100" height="100" src="http://www.gravatar.com/avatar/b30130824fb515fb4c69c6101aca32fb?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />      </p></li><li><p class='name'>
+              <img alt="Chris Salzberg" width="100" height="100" src="http://www.gravatar.com/avatar/b30130824fb515fb4c69c6101aca32fb?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />      </p></li><li><p class='name'>
               Hironori Oba      </p>
             <p class='role'>
               Staff      </p>
             <p class='avatar'>
-              <img alt="Hironori Oba" width="100" height="100" src="http://www.gravatar.com/avatar/91511c7e075e2c82793601019c779914?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />      </p></li><li><p class='name'>
+              <img alt="Hironori Oba" width="100" height="100" src="http://www.gravatar.com/avatar/91511c7e075e2c82793601019c779914?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />      </p></li><li><p class='name'>
               Aki Tagaki      </p>
             <p class='role'>
               Staff      </p>
             <p class='avatar'>
-              <img alt="Aki Tagaki" width="100" height="100" src="http://www.gravatar.com/avatar/f863c30e6f1cfe9b26b73f707729da22?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />      </p></li><li><p class='name'>
+              <img alt="Aki Tagaki" width="100" height="100" src="http://www.gravatar.com/avatar/f863c30e6f1cfe9b26b73f707729da22?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />      </p></li><li><p class='name'>
               Mahito Ogura      </p>
             <p class='role'>
               Staff      </p>
             <p class='avatar'>
-              <img alt="Mahito Ogura" width="100" height="100" src="http://www.gravatar.com/avatar/d6fc8a819afa94f464fe322032a6687f?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />      </p></li><li><p class='name'>
+              <img alt="Mahito Ogura" width="100" height="100" src="http://www.gravatar.com/avatar/d6fc8a819afa94f464fe322032a6687f?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />      </p></li><li><p class='name'>
               Ma      </p>
             <p class='role'>
               KaigiFreaks      </p>
             <p class='avatar'>
-              <img alt="Ma" width="100" height="100" src="http://www.gravatar.com/avatar/1ffed6f5d89d26481f173c71011acdb8?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />      </p></li><li><p class='name'>
+              <img alt="Ma" width="100" height="100" src="http://www.gravatar.com/avatar/1ffed6f5d89d26481f173c71011acdb8?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />      </p></li><li><p class='name'>
               Yusuke Takahashi      </p>
             <p class='role'>
               Staff      </p>
             <p class='avatar'>
-              <img alt="Yusuke Takahashi" width="100" height="100" src="http://www.gravatar.com/avatar/c98343afa12691f86f21018e0d4efd62?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />      </p></li><li><p class='name'>
+              <img alt="Yusuke Takahashi" width="100" height="100" src="http://www.gravatar.com/avatar/c98343afa12691f86f21018e0d4efd62?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />      </p></li><li><p class='name'>
               Wakana Odagiri      </p>
             <p class='role'>
               Staff      </p>
             <p class='avatar'>
-              <img alt="Wakana Odagiri" width="100" height="100" src="http://www.gravatar.com/avatar/bd7d2803fdabab09e601924e18c2c662?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2FcommonNoImage.png" />      </p></li></ul>
+              <img alt="Wakana Odagiri" width="100" height="100" src="http://www.gravatar.com/avatar/bd7d2803fdabab09e601924e18c2c662?s=100&d=http%3A%2F%2Frubykaigi.org%2F2013%2Fimages%2FcommonNoImage-3c2c9259.png" />      </p></li></ul>
         </div>
       </article>
       <div id='socialButtons'>


### PR DESCRIPTION
2013のサイトで画像が正しく表示されていなかったのを修正しました。
ソースの修正はこんな感じで、 https://github.com/ruby-no-kai/rubykaigi2013/commit/7ab145c17c0aae5a00e850481c220c7a8a886e75 もしかしたら昔のSprocketsならこれでも表示されてたのが、いつからか表示できなくなったのかもしれないですね。
まあ経緯はよくわからないけど、とにかくこれで直ってそうです。