### PR TITLE
2011: Request gravatar via HTTPS

### DIFF
--- a/2011/en/about/index.html
+++ b/2011/en/about/index.html
@@ -220,28 +220,28 @@ Photos provided by
 kakutani
 <br>
 <a href="http://www.flickr.com/photos/kakutani" target="_blank">
-<img alt="kakutani" src="http://www.gravatar.com/avatar/63a6bff89d692e21de20868202bc8dde?s=32">
+<img alt="kakutani" src="https://www.gravatar.com/avatar/63a6bff89d692e21de20868202bc8dde?s=32">
 </a>
 </p>
 <p>
 snoozer05
 <br>
 <a href="http://www.flickr.com/photos/snoozer/" target="_blank">
-<img alt="" src="http://www.gravatar.com/avatar/941b170e5a115a295cccb5f5cdf0a800?s=32">
+<img alt="" src="https://www.gravatar.com/avatar/941b170e5a115a295cccb5f5cdf0a800?s=32">
 </a>
 </p>
 <p>
 tmaeda_japan
 <br>
 <a href="http://www.flickr.com/photos/tmaedax/" target="_blank">
-<img alt="" src="http://www.gravatar.com/avatar/f482a467d8202cf35b3aa7df192d3efb?s=32">
+<img alt="" src="https://www.gravatar.com/avatar/f482a467d8202cf35b3aa7df192d3efb?s=32">
 </a>
 </p>
 <p>
 Naoto Takai
 <br>
 <a href="http://www.flickr.com/photos/recompile_net/" target="_blank">
-<img alt="" src="http://www.gravatar.com/avatar/cf7b553387b247d737c60cfceabb2cea?s=32">
+<img alt="" src="https://www.gravatar.com/avatar/cf7b553387b247d737c60cfceabb2cea?s=32">
 </a>
 </p>
 </article>

--- a/2011/en/index.html
+++ b/2011/en/index.html
@@ -469,55 +469,39 @@ Gold Sponsor
 </h2>
 <ul>
 <li>
-<a href="http://shyouhei.tumblr.com"><img alt="Urabe, Shyouhei" height="32" src="http://www.gravatar.com/avatar/9d2f78236e45a335301ba1195026105d?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Urabe, Shyouhei" width="32"></a>
+<a href="http://shyouhei.tumblr.com"><img alt="Urabe, Shyouhei" height="32" src="https://www.gravatar.com/avatar/9d2f78236e45a335301ba1195026105d?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Urabe, Shyouhei" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/noplans"><img alt="TANIGUCHI Fumitake" height="32" src="http://www.gravatar.com/avatar/e514ae09c9b84e04231af57f1d1946b8?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TANIGUCHI Fumitake" width="32"></a>
+<a href="http://twitter.com/noplans"><img alt="TANIGUCHI Fumitake" height="32" src="https://www.gravatar.com/avatar/e514ae09c9b84e04231af57f1d1946b8?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TANIGUCHI Fumitake" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://jmettraux.wordpress.com"><img alt="John Mettraux" height="32" src="http://www.gravatar.com/avatar/8d96626e52beb1ff90f57a8e189e1e6f?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="John Mettraux" width="32"></a>
+<a href="http://jmettraux.wordpress.com"><img alt="John Mettraux" height="32" src="https://www.gravatar.com/avatar/8d96626e52beb1ff90f57a8e189e1e6f?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="John Mettraux" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/japanrock"><img alt="Shintaro Nozaki" height="32" src="http://www.gravatar.com/avatar/b31a258dd8f615f61b2d355297f82dc9?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shintaro Nozaki" width="32"></a>
+<a href="http://twitter.com/japanrock"><img alt="Shintaro Nozaki" height="32" src="https://www.gravatar.com/avatar/b31a258dd8f615f61b2d355297f82dc9?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shintaro Nozaki" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://blog.dio.jp"><img alt="Akira Matsuda" height="32" src="http://www.gravatar.com/avatar/76a777ff80f30bd3b390e275cce625bc?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Akira Matsuda" width="32"></a>
+<a href="http://blog.dio.jp"><img alt="Akira Matsuda" height="32" src="https://www.gravatar.com/avatar/76a777ff80f30bd3b390e275cce625bc?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Akira Matsuda" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.bovensiepen.net"><img alt="Daniel Bovensiepen" height="32" src="http://www.gravatar.com/avatar/49d6f762505615af259534deed94bc54?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Daniel Bovensiepen" width="32"></a>
+<a href="http://www.bovensiepen.net"><img alt="Daniel Bovensiepen" height="32" src="https://www.gravatar.com/avatar/49d6f762505615af259534deed94bc54?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Daniel Bovensiepen" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://firn.jp/"><img alt="Dai Akatsuka" height="32" src="http://www.gravatar.com/avatar/4efe7b5cdbe97df84e6e607948171eef?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Dai Akatsuka" width="32"></a>
+<a href="http://firn.jp/"><img alt="Dai Akatsuka" height="32" src="https://www.gravatar.com/avatar/4efe7b5cdbe97df84e6e607948171eef?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Dai Akatsuka" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.din.or.jp/~shinodas/"><img alt="Yoshihiko Hara" height="32" src="http://www.gravatar.com/avatar/8055fbffa700065178460bb7e3b8ee24?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yoshihiko Hara" width="32"></a>
+<a href="http://www.din.or.jp/~shinodas/"><img alt="Yoshihiko Hara" height="32" src="https://www.gravatar.com/avatar/8055fbffa700065178460bb7e3b8ee24?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yoshihiko Hara" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://benhoskin.gs"><img alt="Ben Hoskings" height="32" src="http://www.gravatar.com/avatar/7ed99cb90a060539d729e2491442a603?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ben Hoskings" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<img alt="Anonymous" height="32" src="/2011/images/bow_face.png?1359134037" title="Anonymous" width="32">
-<a href="#"></a>
-</li>
-<li>
-<a href="http://www.nextseed.jp/"><img alt="Hitoshi Kurokawa" height="32" src="http://www.gravatar.com/avatar/11e89e3c85d9998b2c73933bde77c71e?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hitoshi Kurokawa" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://d.hatena.ne.jp/kinpoco/"><img alt="Yutaka Kanemoto" height="32" src="http://www.gravatar.com/avatar/0e728bf538d1848bc253d80a8626bbc2?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yutaka Kanemoto" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://d.hatena.ne.jp/yuichi_katahira"><img alt="Yuichi Katahira " height="32" src="http://www.gravatar.com/avatar/3072ae08f580fc8474b47652a3d8dd0f?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yuichi Katahira " width="32"></a>
+<a href="http://benhoskin.gs"><img alt="Ben Hoskings" height="32" src="https://www.gravatar.com/avatar/7ed99cb90a060539d729e2491442a603?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ben Hoskings" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
@@ -525,87 +509,15 @@ Gold Sponsor
 <a href="#"></a>
 </li>
 <li>
-<a href="http://kitaj.no-ip.com/tdiary/"><img alt="Junichiro Kita" height="32" src="http://www.gravatar.com/avatar/70405ca68e6f8779be65e75b1a90525b?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Junichiro Kita" width="32"></a>
+<a href="http://www.nextseed.jp/"><img alt="Hitoshi Kurokawa" height="32" src="https://www.gravatar.com/avatar/11e89e3c85d9998b2c73933bde77c71e?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hitoshi Kurokawa" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/idesaku"><img alt="Daisuke Goto" height="32" src="http://www.gravatar.com/avatar/85c8086344e5f31b2a4d22f163660536?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Daisuke Goto" width="32"></a>
+<a href="http://d.hatena.ne.jp/kinpoco/"><img alt="Yutaka Kanemoto" height="32" src="https://www.gravatar.com/avatar/0e728bf538d1848bc253d80a8626bbc2?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yutaka Kanemoto" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<img alt="Anonymous" height="32" src="/2011/images/bow_face.png?1359134037" title="Anonymous" width="32">
-<a href="#"></a>
-</li>
-<li>
-<a href="http://www.on-sky.net/~hs/"><img alt="Hideki SAKAMOTO" height="32" src="http://www.gravatar.com/avatar/7038a6cfc30b8c3b00b5c08d70cda2f1?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hideki SAKAMOTO" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://twitter.com/agilekawabata"><img alt="Kawabata Mitsuyoshi" height="32" src="http://www.gravatar.com/avatar/5236eb3ad498b3c5336a4575408fb1b1?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kawabata Mitsuyoshi" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://www.kt.rim.or.jp/~kbk/"><img alt="KIMURA Koichi" height="32" src="http://www.gravatar.com/avatar/04c1a31d1e33e7fc25a7ca99930e4c70?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="KIMURA Koichi" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://d.hatena.ne.jp/takkaw/"><img alt="Takayoshi Kawada" height="32" src="http://www.gravatar.com/avatar/38bf2ca557d9cc20dcdcbd773a68664b?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takayoshi Kawada" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://www.suchi.org/"><img alt="Shigeru UCHIYAMA" height="32" src="http://www.gravatar.com/avatar/398e2dd764d43aad735c6e5bca92c3b6?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shigeru UCHIYAMA" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://twitter.com/#!/andrewjgrimm"><img alt="Andrew Grimm" height="32" src="http://www.gravatar.com/avatar/01bbb59a1c3ef9960f25a97afe7e920f?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Andrew Grimm" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://twitter.com/kimuraw"><img alt="kimura wataru" height="32" src="http://www.gravatar.com/avatar/e298234a6e5a2c159287476abd76504a?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="kimura wataru" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://saikyoline.jp/"><img alt="MIKAMI Yoshiyuki" height="32" src="http://www.gravatar.com/avatar/e0920f5f813ae29ba7859f950a7f0df3?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MIKAMI Yoshiyuki" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://jp.rubyist.net/?KansaiWorkshop"><img alt="HIGAKI Masaru" height="32" src="http://www.gravatar.com/avatar/a8192f5a7b25ef32a983740ee8593bd3?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="HIGAKI Masaru" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://twitter.com/ayumin"><img alt="Ayumu AIZAWA" height="32" src="http://www.gravatar.com/avatar/2e9a2dbe335e0111e4879a9d65dcbae0?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ayumu AIZAWA" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://shunichi-arai.blogspot.com/"><img alt="Shunichi Arai" height="32" src="http://www.gravatar.com/avatar/74daf3516e33a75968ec0f933954b5a8?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shunichi Arai" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://www.tokyodev.com"><img alt="Paul McMahon" height="32" src="http://www.gravatar.com/avatar/dd24adb5a3a430fed83a33ed552fe1b5?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Paul McMahon" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://d.hatena.ne.jp/hs9587/"><img alt="Hiroyuki Shimura" height="32" src="http://www.gravatar.com/avatar/287a899c91a7a14535188d7e4784050e?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hiroyuki Shimura" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://kakutani.com"><img alt="Kakutani Shintaro" height="32" src="http://www.gravatar.com/avatar/34fcd5f1deeb25b1138e9845137feb6e?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kakutani Shintaro" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://d.hatena.ne.jp/mrkn"><img alt="Kenta Murata" height="32" src="http://www.gravatar.com/avatar/819b3c0a25f9708fd32261b8ae2d23f6?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kenta Murata" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://rails.to"><img alt="Masatoshi Itagaki" height="32" src="http://www.gravatar.com/avatar/f8865f41777ef3caced0e4e6801ff83a?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masatoshi Itagaki" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://spring-aki.com/"><img alt="Aki" height="32" src="http://www.gravatar.com/avatar/81f2122b45f48829be4507bf972666e9?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Aki" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://twitter.com/shin_asou"><img alt="Shinichi Okada" height="32" src="http://www.gravatar.com/avatar/20805358592bd93f92bf15aa10137251?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shinichi Okada" width="32"></a>
+<a href="http://d.hatena.ne.jp/yuichi_katahira"><img alt="Yuichi Katahira " height="32" src="https://www.gravatar.com/avatar/3072ae08f580fc8474b47652a3d8dd0f?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yuichi Katahira " width="32"></a>
 <a href="#"></a>
 </li>
 <li>
@@ -613,35 +525,11 @@ Gold Sponsor
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.kumaryu.net/"><img alt="Ryuichi Sakamoto" height="32" src="http://www.gravatar.com/avatar/1b2ca00132480422c75c1f2c61e84e26?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ryuichi Sakamoto" width="32"></a>
+<a href="http://kitaj.no-ip.com/tdiary/"><img alt="Junichiro Kita" height="32" src="https://www.gravatar.com/avatar/70405ca68e6f8779be65e75b1a90525b?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Junichiro Kita" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<img alt="Eito Katagiri" height="32" src="http://www.gravatar.com/avatar/b5852cf79505d7ba513f8f16ef95a50f?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Eito Katagiri" width="32">
-<a href="#"></a>
-</li>
-<li>
-<a href="http://ukstudio.jp/"><img alt="AKAMATSU Yuki" height="32" src="http://www.gravatar.com/avatar/0c471249ee93ab17a011f3e8d2b1057a?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="AKAMATSU Yuki" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://hisashim.org"><img alt="Hisashi Morita" height="32" src="http://www.gravatar.com/avatar/b3fba7af93cd27e6ed28e7eae88a9585?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hisashi Morita" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://d.hatena.ne.jp/muryoImpl/"><img alt="Ken muryoi" height="32" src="http://www.gravatar.com/avatar/ac6dba8ce93944d17714de362ca17e54?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ken muryoi" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://d.hatena.ne.jp/nagachika/"><img alt="Tomoyuki Chikanaga" height="32" src="http://www.gravatar.com/avatar/5cf8f058a4c094bb708174fb43e7a387?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomoyuki Chikanaga" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://d.hatena.ne.jp/takeshinoda/"><img alt="Takeshi SHINODA" height="32" src="http://www.gravatar.com/avatar/06febd004d7cc9c9f6a4e0272b686bc7?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takeshi SHINODA" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://twitter.com/knsmr"><img alt="Ken Nishimura" height="32" src="http://www.gravatar.com/avatar/91fb4852880d1727cca911036e2fef5f?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ken Nishimura" width="32"></a>
+<a href="http://d.hatena.ne.jp/idesaku"><img alt="Daisuke Goto" height="32" src="https://www.gravatar.com/avatar/85c8086344e5f31b2a4d22f163660536?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Daisuke Goto" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
@@ -649,35 +537,75 @@ Gold Sponsor
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/koko_u/"><img alt="Kozaki Tsuneaki" height="32" src="http://www.gravatar.com/avatar/5b1b558d563288da615a9ea2889afdd5?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kozaki Tsuneaki" width="32"></a>
+<a href="http://www.on-sky.net/~hs/"><img alt="Hideki SAKAMOTO" height="32" src="https://www.gravatar.com/avatar/7038a6cfc30b8c3b00b5c08d70cda2f1?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hideki SAKAMOTO" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/adzuki34"><img alt="SUZUKI Miho" height="32" src="http://www.gravatar.com/avatar/f37b9a968b2326062190677906a93080?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="SUZUKI Miho" width="32"></a>
+<a href="http://twitter.com/agilekawabata"><img alt="Kawabata Mitsuyoshi" height="32" src="https://www.gravatar.com/avatar/5236eb3ad498b3c5336a4575408fb1b1?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kawabata Mitsuyoshi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/lchin"><img alt="Leonard Chin" height="32" src="http://www.gravatar.com/avatar/70762059db0218c6f0ff48042ca0756a?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Leonard Chin" width="32"></a>
+<a href="http://www.kt.rim.or.jp/~kbk/"><img alt="KIMURA Koichi" height="32" src="https://www.gravatar.com/avatar/04c1a31d1e33e7fc25a7ca99930e4c70?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="KIMURA Koichi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/suzumura_ss/"><img alt="Toshiyuki Terashita" height="32" src="http://www.gravatar.com/avatar/bb8b58cab667163b6ee53aad0e5f0414?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Toshiyuki Terashita" width="32"></a>
+<a href="http://d.hatena.ne.jp/takkaw/"><img alt="Takayoshi Kawada" height="32" src="https://www.gravatar.com/avatar/38bf2ca557d9cc20dcdcbd773a68664b?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takayoshi Kawada" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://sites.google.com/site/akihikohashimoto/"><img alt="Akihiko Hashimoto" height="32" src="http://www.gravatar.com/avatar/c8803a4130c3238e34b605d0a0cffe94?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Akihiko Hashimoto" width="32"></a>
+<a href="http://www.suchi.org/"><img alt="Shigeru UCHIYAMA" height="32" src="https://www.gravatar.com/avatar/398e2dd764d43aad735c6e5bca92c3b6?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shigeru UCHIYAMA" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<img alt="OZAWA Sakuro" height="32" src="http://www.gravatar.com/avatar/a1cbed8bf64473e2acdd0c7066cc5b29?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="OZAWA Sakuro" width="32">
+<a href="http://twitter.com/#!/andrewjgrimm"><img alt="Andrew Grimm" height="32" src="https://www.gravatar.com/avatar/01bbb59a1c3ef9960f25a97afe7e920f?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Andrew Grimm" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://fkmn.exblog.jp/"><img alt="Arinobu FUKUHARA" height="32" src="http://www.gravatar.com/avatar/85319f2b72d7b37ddef5c25a2dd40d30?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Arinobu FUKUHARA" width="32"></a>
+<a href="http://twitter.com/kimuraw"><img alt="kimura wataru" height="32" src="https://www.gravatar.com/avatar/e298234a6e5a2c159287476abd76504a?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="kimura wataru" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/shachi"><img alt="Kazuyuki Koizuka-shachi" height="32" src="http://www.gravatar.com/avatar/f51ee84097a72a8d91bee9bb98736541?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kazuyuki Koizuka-shachi" width="32"></a>
+<a href="http://saikyoline.jp/"><img alt="MIKAMI Yoshiyuki" height="32" src="https://www.gravatar.com/avatar/e0920f5f813ae29ba7859f950a7f0df3?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MIKAMI Yoshiyuki" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://jp.rubyist.net/?KansaiWorkshop"><img alt="HIGAKI Masaru" height="32" src="https://www.gravatar.com/avatar/a8192f5a7b25ef32a983740ee8593bd3?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="HIGAKI Masaru" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://twitter.com/ayumin"><img alt="Ayumu AIZAWA" height="32" src="https://www.gravatar.com/avatar/2e9a2dbe335e0111e4879a9d65dcbae0?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ayumu AIZAWA" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://shunichi-arai.blogspot.com/"><img alt="Shunichi Arai" height="32" src="https://www.gravatar.com/avatar/74daf3516e33a75968ec0f933954b5a8?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shunichi Arai" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://www.tokyodev.com"><img alt="Paul McMahon" height="32" src="https://www.gravatar.com/avatar/dd24adb5a3a430fed83a33ed552fe1b5?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Paul McMahon" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://d.hatena.ne.jp/hs9587/"><img alt="Hiroyuki Shimura" height="32" src="https://www.gravatar.com/avatar/287a899c91a7a14535188d7e4784050e?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hiroyuki Shimura" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://kakutani.com"><img alt="Kakutani Shintaro" height="32" src="https://www.gravatar.com/avatar/34fcd5f1deeb25b1138e9845137feb6e?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kakutani Shintaro" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://d.hatena.ne.jp/mrkn"><img alt="Kenta Murata" height="32" src="https://www.gravatar.com/avatar/819b3c0a25f9708fd32261b8ae2d23f6?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kenta Murata" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://rails.to"><img alt="Masatoshi Itagaki" height="32" src="https://www.gravatar.com/avatar/f8865f41777ef3caced0e4e6801ff83a?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masatoshi Itagaki" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://spring-aki.com/"><img alt="Aki" height="32" src="https://www.gravatar.com/avatar/81f2122b45f48829be4507bf972666e9?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Aki" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://twitter.com/shin_asou"><img alt="Shinichi Okada" height="32" src="https://www.gravatar.com/avatar/20805358592bd93f92bf15aa10137251?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shinichi Okada" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
@@ -685,103 +613,175 @@ Gold Sponsor
 <a href="#"></a>
 </li>
 <li>
-<a href="http://atakigu.tumblr.com/"><img alt="atakig" height="32" src="http://www.gravatar.com/avatar/8a949c60e450d226de776072273a1ffc?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="atakig" width="32"></a>
+<a href="http://www.kumaryu.net/"><img alt="Ryuichi Sakamoto" height="32" src="https://www.gravatar.com/avatar/1b2ca00132480422c75c1f2c61e84e26?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ryuichi Sakamoto" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<img alt="TSUTSUI Toshinori" height="32" src="http://www.gravatar.com/avatar/ad66fd981c429c12e0f76c436da3337e?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TSUTSUI Toshinori" width="32">
+<img alt="Eito Katagiri" height="32" src="https://www.gravatar.com/avatar/b5852cf79505d7ba513f8f16ef95a50f?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Eito Katagiri" width="32">
 <a href="#"></a>
 </li>
 <li>
-<a href="http://yugui.jp"><img alt="Yuki Sonoda (Yugui)" height="32" src="http://www.gravatar.com/avatar/1e7e007723cfe59320d994a7db4ab4cf?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yuki Sonoda (Yugui)" width="32"></a>
+<a href="http://ukstudio.jp/"><img alt="AKAMATSU Yuki" height="32" src="https://www.gravatar.com/avatar/0c471249ee93ab17a011f3e8d2b1057a?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="AKAMATSU Yuki" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/seiunsky"><img alt="sugamasao" height="32" src="http://www.gravatar.com/avatar/961126d9892ae4df45249529a0721571?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="sugamasao" width="32"></a>
+<a href="http://hisashim.org"><img alt="Hisashi Morita" height="32" src="https://www.gravatar.com/avatar/b3fba7af93cd27e6ed28e7eae88a9585?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hisashi Morita" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/mkgin/"><img alt="Makoto Kouno" height="32" src="http://www.gravatar.com/avatar/06e6dcde277cbe5c614baf5d25871025?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Makoto Kouno" width="32"></a>
+<a href="http://d.hatena.ne.jp/muryoImpl/"><img alt="Ken muryoi" height="32" src="https://www.gravatar.com/avatar/ac6dba8ce93944d17714de362ca17e54?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ken muryoi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/suzuki"><img alt="Norio Suzuki" height="32" src="http://www.gravatar.com/avatar/8e528456ff66ec543952daa815353a01?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Norio Suzuki" width="32"></a>
+<a href="http://d.hatena.ne.jp/nagachika/"><img alt="Tomoyuki Chikanaga" height="32" src="https://www.gravatar.com/avatar/5cf8f058a4c094bb708174fb43e7a387?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomoyuki Chikanaga" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.artonx.org"><img alt="Akio Tajima" height="32" src="http://www.gravatar.com/avatar/0441ff038018e53a35bb207e81105a5c?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Akio Tajima" width="32"></a>
+<a href="http://d.hatena.ne.jp/takeshinoda/"><img alt="Takeshi SHINODA" height="32" src="https://www.gravatar.com/avatar/06febd004d7cc9c9f6a4e0272b686bc7?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takeshi SHINODA" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://moonrock.jp/~don/"><img alt="Hiroyuki Iwatsuki" height="32" src="http://www.gravatar.com/avatar/cb1f0f80c3fe2729ba593656772c266d?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hiroyuki Iwatsuki" width="32"></a>
+<a href="http://twitter.com/knsmr"><img alt="Ken Nishimura" height="32" src="https://www.gravatar.com/avatar/91fb4852880d1727cca911036e2fef5f?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ken Nishimura" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/monyakata/"><img alt="MUNAKATA Akiko" height="32" src="http://www.gravatar.com/avatar/55a6db4b079c962f72adb014055e9a28?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MUNAKATA Akiko" width="32"></a>
+<img alt="Anonymous" height="32" src="/2011/images/bow_face.png?1359134037" title="Anonymous" width="32">
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.bawdo.com"><img alt="Keith Bawden" height="32" src="http://www.gravatar.com/avatar/a6cc567a6b77ee09f7363d175455593b?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Keith Bawden" width="32"></a>
+<a href="http://d.hatena.ne.jp/koko_u/"><img alt="Kozaki Tsuneaki" height="32" src="https://www.gravatar.com/avatar/5b1b558d563288da615a9ea2889afdd5?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kozaki Tsuneaki" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<img alt="Norihito Yoshioka" height="32" src="http://www.gravatar.com/avatar/c6033734a5b01f43cca06773ea9ff1fe?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Norihito Yoshioka" width="32">
+<a href="http://twitter.com/adzuki34"><img alt="SUZUKI Miho" height="32" src="https://www.gravatar.com/avatar/f37b9a968b2326062190677906a93080?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="SUZUKI Miho" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/vestige/"><img alt="makoto yonezawa" height="32" src="http://www.gravatar.com/avatar/8da7ceb361c63bd6622fe33153a0293b?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="makoto yonezawa" width="32"></a>
+<a href="http://twitter.com/lchin"><img alt="Leonard Chin" height="32" src="https://www.gravatar.com/avatar/70762059db0218c6f0ff48042ca0756a?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Leonard Chin" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="https://twitter.com/tsuboi"><img alt="Sougo TSUBOI" height="32" src="http://www.gravatar.com/avatar/847bf4e3766b2e17cafef8e83b046db1?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Sougo TSUBOI" width="32"></a>
+<a href="http://d.hatena.ne.jp/suzumura_ss/"><img alt="Toshiyuki Terashita" height="32" src="https://www.gravatar.com/avatar/bb8b58cab667163b6ee53aad0e5f0414?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Toshiyuki Terashita" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/#!/mojamoja_mixi"><img alt="MojaMoja" height="32" src="http://www.gravatar.com/avatar/7b0d6fc806322376d65cbb95d40bc176?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MojaMoja" width="32"></a>
+<a href="http://sites.google.com/site/akihikohashimoto/"><img alt="Akihiko Hashimoto" height="32" src="https://www.gravatar.com/avatar/c8803a4130c3238e34b605d0a0cffe94?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Akihiko Hashimoto" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/takkanm"><img alt="mitsutaka mimura" height="32" src="http://www.gravatar.com/avatar/8f39a252784d5a99589be6e20c4553fb?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="mitsutaka mimura" width="32"></a>
+<img alt="OZAWA Sakuro" height="32" src="https://www.gravatar.com/avatar/a1cbed8bf64473e2acdd0c7066cc5b29?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="OZAWA Sakuro" width="32">
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/dan5ya"><img alt="Dan Yamamoto" height="32" src="http://www.gravatar.com/avatar/ffaa5dad365d5bb5025f4126bb54676c?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Dan Yamamoto" width="32"></a>
+<a href="http://fkmn.exblog.jp/"><img alt="Arinobu FUKUHARA" height="32" src="https://www.gravatar.com/avatar/85319f2b72d7b37ddef5c25a2dd40d30?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Arinobu FUKUHARA" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.hsbt.org/"><img alt="SHIBATA Hiroshi" height="32" src="http://www.gravatar.com/avatar/eabad423977cfc6873b8f5df62b848a6?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="SHIBATA Hiroshi" width="32"></a>
+<a href="http://twitter.com/shachi"><img alt="Kazuyuki Koizuka-shachi" height="32" src="https://www.gravatar.com/avatar/f51ee84097a72a8d91bee9bb98736541?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kazuyuki Koizuka-shachi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/moro/"><img alt="MOROHASHI Kyosuke" height="32" src="http://www.gravatar.com/avatar/70e13d9877054026fda46d5a5b53a236?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MOROHASHI Kyosuke" width="32"></a>
+<img alt="Anonymous" height="32" src="/2011/images/bow_face.png?1359134037" title="Anonymous" width="32">
 <a href="#"></a>
 </li>
 <li>
-<a href="http://rsss.be/hibariya"><img alt="Hibariya Hi" height="32" src="http://www.gravatar.com/avatar/de0df5acda15a9c7eeb6c28a5e5d4e8e?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hibariya Hi" width="32"></a>
+<a href="http://atakigu.tumblr.com/"><img alt="atakig" height="32" src="https://www.gravatar.com/avatar/8a949c60e450d226de776072273a1ffc?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="atakig" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/kyanny"><img alt="Kensuke Nagae" height="32" src="http://www.gravatar.com/avatar/fffd8bf62b842a46803fb07792029fa4?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kensuke Nagae" width="32"></a>
+<img alt="TSUTSUI Toshinori" height="32" src="https://www.gravatar.com/avatar/ad66fd981c429c12e0f76c436da3337e?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TSUTSUI Toshinori" width="32">
 <a href="#"></a>
 </li>
 <li>
-<img alt="oku23" height="32" src="http://www.gravatar.com/avatar/3725ec1dce281fb187d798a9b9ddc9d3?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="oku23" width="32">
+<a href="http://yugui.jp"><img alt="Yuki Sonoda (Yugui)" height="32" src="https://www.gravatar.com/avatar/1e7e007723cfe59320d994a7db4ab4cf?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yuki Sonoda (Yugui)" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://ko.meadowy.net/~koichiro/diary/"><img alt="Koichiro Ohba" height="32" src="http://www.gravatar.com/avatar/1ce18b10bd8f911566c5577042b6a44c?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Koichiro Ohba" width="32"></a>
+<a href="http://d.hatena.ne.jp/seiunsky"><img alt="sugamasao" height="32" src="https://www.gravatar.com/avatar/961126d9892ae4df45249529a0721571?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="sugamasao" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.flickr.com/photos/t-seto"><img alt="せとん" height="32" src="http://www.gravatar.com/avatar/ac007a5b84f817d8cc80a3c208ea0181?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="せとん" width="32"></a>
+<a href="http://d.hatena.ne.jp/mkgin/"><img alt="Makoto Kouno" height="32" src="https://www.gravatar.com/avatar/06e6dcde277cbe5c614baf5d25871025?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Makoto Kouno" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/#!/tsuyoshikawa"><img alt="Tsuyoshi Yoshikawa" height="32" src="http://www.gravatar.com/avatar/6969ade78c1eaff0d08c76020fc80e83?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tsuyoshi Yoshikawa" width="32"></a>
+<a href="http://twitter.com/suzuki"><img alt="Norio Suzuki" height="32" src="https://www.gravatar.com/avatar/8e528456ff66ec543952daa815353a01?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Norio Suzuki" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.water-lily.biz/"><img alt="Water Lily LLC" height="32" src="http://www.gravatar.com/avatar/0734b8ec5eed71892e5db432856f4f40?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Water Lily LLC" width="32"></a>
+<a href="http://www.artonx.org"><img alt="Akio Tajima" height="32" src="https://www.gravatar.com/avatar/0441ff038018e53a35bb207e81105a5c?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Akio Tajima" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://moonrock.jp/~don/"><img alt="Hiroyuki Iwatsuki" height="32" src="https://www.gravatar.com/avatar/cb1f0f80c3fe2729ba593656772c266d?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hiroyuki Iwatsuki" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://d.hatena.ne.jp/monyakata/"><img alt="MUNAKATA Akiko" height="32" src="https://www.gravatar.com/avatar/55a6db4b079c962f72adb014055e9a28?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MUNAKATA Akiko" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://www.bawdo.com"><img alt="Keith Bawden" height="32" src="https://www.gravatar.com/avatar/a6cc567a6b77ee09f7363d175455593b?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Keith Bawden" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<img alt="Norihito Yoshioka" height="32" src="https://www.gravatar.com/avatar/c6033734a5b01f43cca06773ea9ff1fe?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Norihito Yoshioka" width="32">
+<a href="#"></a>
+</li>
+<li>
+<a href="http://d.hatena.ne.jp/vestige/"><img alt="makoto yonezawa" height="32" src="https://www.gravatar.com/avatar/8da7ceb361c63bd6622fe33153a0293b?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="makoto yonezawa" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="https://twitter.com/tsuboi"><img alt="Sougo TSUBOI" height="32" src="https://www.gravatar.com/avatar/847bf4e3766b2e17cafef8e83b046db1?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Sougo TSUBOI" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://twitter.com/#!/mojamoja_mixi"><img alt="MojaMoja" height="32" src="https://www.gravatar.com/avatar/7b0d6fc806322376d65cbb95d40bc176?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MojaMoja" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://twitter.com/takkanm"><img alt="mitsutaka mimura" height="32" src="https://www.gravatar.com/avatar/8f39a252784d5a99589be6e20c4553fb?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="mitsutaka mimura" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://twitter.com/dan5ya"><img alt="Dan Yamamoto" height="32" src="https://www.gravatar.com/avatar/ffaa5dad365d5bb5025f4126bb54676c?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Dan Yamamoto" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://www.hsbt.org/"><img alt="SHIBATA Hiroshi" height="32" src="https://www.gravatar.com/avatar/eabad423977cfc6873b8f5df62b848a6?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="SHIBATA Hiroshi" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://d.hatena.ne.jp/moro/"><img alt="MOROHASHI Kyosuke" height="32" src="https://www.gravatar.com/avatar/70e13d9877054026fda46d5a5b53a236?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MOROHASHI Kyosuke" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://rsss.be/hibariya"><img alt="Hibariya Hi" height="32" src="https://www.gravatar.com/avatar/de0df5acda15a9c7eeb6c28a5e5d4e8e?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hibariya Hi" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://twitter.com/kyanny"><img alt="Kensuke Nagae" height="32" src="https://www.gravatar.com/avatar/fffd8bf62b842a46803fb07792029fa4?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kensuke Nagae" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<img alt="oku23" height="32" src="https://www.gravatar.com/avatar/3725ec1dce281fb187d798a9b9ddc9d3?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="oku23" width="32">
+<a href="#"></a>
+</li>
+<li>
+<a href="http://ko.meadowy.net/~koichiro/diary/"><img alt="Koichiro Ohba" height="32" src="https://www.gravatar.com/avatar/1ce18b10bd8f911566c5577042b6a44c?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Koichiro Ohba" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://www.flickr.com/photos/t-seto"><img alt="せとん" height="32" src="https://www.gravatar.com/avatar/ac007a5b84f817d8cc80a3c208ea0181?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="せとん" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://twitter.com/#!/tsuyoshikawa"><img alt="Tsuyoshi Yoshikawa" height="32" src="https://www.gravatar.com/avatar/6969ade78c1eaff0d08c76020fc80e83?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tsuyoshi Yoshikawa" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://www.water-lily.biz/"><img alt="Water Lily LLC" height="32" src="https://www.gravatar.com/avatar/0734b8ec5eed71892e5db432856f4f40?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Water Lily LLC" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
@@ -789,115 +789,99 @@ Gold Sponsor
 <a href="#"></a>
 </li>
 <li>
-<a href="http://web-engineer.buyuden.net/blog/kawai/"><img alt="Takeshi Kawai" height="32" src="http://www.gravatar.com/avatar/6b53e472c9200f5ed61d7a6db0a28986?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takeshi Kawai" width="32"></a>
+<a href="http://web-engineer.buyuden.net/blog/kawai/"><img alt="Takeshi Kawai" height="32" src="https://www.gravatar.com/avatar/6b53e472c9200f5ed61d7a6db0a28986?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takeshi Kawai" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/k3c/"><img alt="KANEKO Seiji" height="32" src="http://www.gravatar.com/avatar/63d3818b5c107a6483a1d2e2767be4c5?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="KANEKO Seiji" width="32"></a>
+<a href="http://d.hatena.ne.jp/k3c/"><img alt="KANEKO Seiji" height="32" src="https://www.gravatar.com/avatar/63d3818b5c107a6483a1d2e2767be4c5?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="KANEKO Seiji" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.famlog.jp/"><img alt="Atsushi Matsuo" height="32" src="http://www.gravatar.com/avatar/0a4da00dbfd37e7f06ef8dceb58ca0c1?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Atsushi Matsuo" width="32"></a>
+<a href="http://www.famlog.jp/"><img alt="Atsushi Matsuo" height="32" src="https://www.gravatar.com/avatar/0a4da00dbfd37e7f06ef8dceb58ca0c1?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Atsushi Matsuo" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://m.igrs.jp/"><img alt="Masato Igarashi" height="32" src="http://www.gravatar.com/avatar/6fd2e23d73c26ccbd7df9e3eefacd3ae?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masato Igarashi" width="32"></a>
+<a href="http://m.igrs.jp/"><img alt="Masato Igarashi" height="32" src="https://www.gravatar.com/avatar/6fd2e23d73c26ccbd7df9e3eefacd3ae?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masato Igarashi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://resume.github.com/?walf443"><img alt="Keiji Yoshimi" height="32" src="http://www.gravatar.com/avatar/dea4fe079aec284744ad02eb3d2594f5?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Keiji Yoshimi" width="32"></a>
+<a href="http://resume.github.com/?walf443"><img alt="Keiji Yoshimi" height="32" src="https://www.gravatar.com/avatar/dea4fe079aec284744ad02eb3d2594f5?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Keiji Yoshimi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://gunjisatoshi.appspot.com/"><img alt="GUNJI Satoshi" height="32" src="http://www.gravatar.com/avatar/e6980e09fdff8f481b70f2e1f241231d?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="GUNJI Satoshi" width="32"></a>
+<a href="http://gunjisatoshi.appspot.com/"><img alt="GUNJI Satoshi" height="32" src="https://www.gravatar.com/avatar/e6980e09fdff8f481b70f2e1f241231d?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="GUNJI Satoshi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<img alt="Hisashi Yamaeda" height="32" src="http://www.gravatar.com/avatar/01ca4ebeee47c9b4d6ba9ad58db694a0?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hisashi Yamaeda" width="32">
+<img alt="Hisashi Yamaeda" height="32" src="https://www.gravatar.com/avatar/01ca4ebeee47c9b4d6ba9ad58db694a0?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hisashi Yamaeda" width="32">
 <a href="#"></a>
 </li>
 <li>
-<img alt="gekidanyonin" height="32" src="http://www.gravatar.com/avatar/2b196f1723fdbcbf7bd297b3e7f8cd3c?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="gekidanyonin" width="32">
+<img alt="gekidanyonin" height="32" src="https://www.gravatar.com/avatar/2b196f1723fdbcbf7bd297b3e7f8cd3c?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="gekidanyonin" width="32">
 <a href="#"></a>
 </li>
 <li>
-<a href="http://jp.linkedin.com/in/nakaomitsuteru"><img alt="Mitsuteru Nakao" height="32" src="http://www.gravatar.com/avatar/9090e122cba40b90124ea8eb4859bf8e?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Mitsuteru Nakao" width="32"></a>
+<a href="http://jp.linkedin.com/in/nakaomitsuteru"><img alt="Mitsuteru Nakao" height="32" src="https://www.gravatar.com/avatar/9090e122cba40b90124ea8eb4859bf8e?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Mitsuteru Nakao" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://zaki.asia"><img alt="Dezso Zoltan" height="32" src="http://www.gravatar.com/avatar/a771de8e1e49a9da61e2a602a2af42bc?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Dezso Zoltan" width="32"></a>
+<a href="http://zaki.asia"><img alt="Dezso Zoltan" height="32" src="https://www.gravatar.com/avatar/a771de8e1e49a9da61e2a602a2af42bc?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Dezso Zoltan" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.twitter.com/ope"><img alt="Takanori Nakanowatari" height="32" src="http://www.gravatar.com/avatar/55bcf6eb5de45a70e76f8a2678822ecb?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takanori Nakanowatari" width="32"></a>
+<a href="http://www.twitter.com/ope"><img alt="Takanori Nakanowatari" height="32" src="https://www.gravatar.com/avatar/55bcf6eb5de45a70e76f8a2678822ecb?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takanori Nakanowatari" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="https://github.com/zev"><img alt="Zev Blut" height="32" src="http://www.gravatar.com/avatar/1c77ad9f35746369dd1f4dd69b9f8b18?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Zev Blut" width="32"></a>
+<a href="https://github.com/zev"><img alt="Zev Blut" height="32" src="https://www.gravatar.com/avatar/1c77ad9f35746369dd1f4dd69b9f8b18?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Zev Blut" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://tako3.com/http://rubykaigi.org/rubyists/kei-s"><img alt="kei-s" height="32" src="http://www.gravatar.com/avatar/bf7ce9b68bbb0058721906b4db15b9b5?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="kei-s" width="32"></a>
+<a href="http://tako3.com/http://rubykaigi.org/rubyists/kei-s"><img alt="kei-s" height="32" src="https://www.gravatar.com/avatar/bf7ce9b68bbb0058721906b4db15b9b5?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="kei-s" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/bobbyjam99"><img alt="Tomokazu IMAI" height="32" src="http://www.gravatar.com/avatar/33814e72445b35ad3b65b1b05e699adc?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomokazu IMAI" width="32"></a>
+<a href="http://twitter.com/bobbyjam99"><img alt="Tomokazu IMAI" height="32" src="https://www.gravatar.com/avatar/33814e72445b35ad3b65b1b05e699adc?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomokazu IMAI" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/hasimo"><img alt="Tohru Hashimoto" height="32" src="http://www.gravatar.com/avatar/6e3d1578114e5d3951a7f90579fff74c?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tohru Hashimoto" width="32"></a>
+<a href="http://twitter.com/hasimo"><img alt="Tohru Hashimoto" height="32" src="https://www.gravatar.com/avatar/6e3d1578114e5d3951a7f90579fff74c?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tohru Hashimoto" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.mobalean.com/founders/michael"><img alt="Michael Reinsch" height="32" src="http://www.gravatar.com/avatar/c7915a424cbb28fdd6c1cce270be6b58?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Michael Reinsch" width="32"></a>
+<a href="http://www.mobalean.com/founders/michael"><img alt="Michael Reinsch" height="32" src="https://www.gravatar.com/avatar/c7915a424cbb28fdd6c1cce270be6b58?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Michael Reinsch" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/sandinist"><img alt="Tsuyoshi MAEHANA" height="32" src="http://www.gravatar.com/avatar/e8ebe7d4ec09c5dd77ee064706836f23?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tsuyoshi MAEHANA" width="32"></a>
+<a href="http://twitter.com/sandinist"><img alt="Tsuyoshi MAEHANA" height="32" src="https://www.gravatar.com/avatar/e8ebe7d4ec09c5dd77ee064706836f23?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tsuyoshi MAEHANA" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://sane.jp"><img alt="Murahashi Sanemat Kenichi" height="32" src="http://www.gravatar.com/avatar/5b1d016f87f05ff645ae572ccbbf0448?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Murahashi Sanemat Kenichi" width="32"></a>
+<a href="http://sane.jp"><img alt="Murahashi Sanemat Kenichi" height="32" src="https://www.gravatar.com/avatar/5b1d016f87f05ff645ae572ccbbf0448?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Murahashi Sanemat Kenichi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://aerial.st"><img alt="Masato Ikeda" height="32" src="http://www.gravatar.com/avatar/03abf5741b7bbd28670af5ec92b6141d?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masato Ikeda" width="32"></a>
+<a href="http://aerial.st"><img alt="Masato Ikeda" height="32" src="https://www.gravatar.com/avatar/03abf5741b7bbd28670af5ec92b6141d?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masato Ikeda" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/tex314"><img alt="OKAZAKI Takurou" height="32" src="http://www.gravatar.com/avatar/45c2cc1a731924edf1045d9146ca4a78?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="OKAZAKI Takurou" width="32"></a>
+<a href="http://twitter.com/tex314"><img alt="OKAZAKI Takurou" height="32" src="https://www.gravatar.com/avatar/45c2cc1a731924edf1045d9146ca4a78?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="OKAZAKI Takurou" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="https://twitter.com/toshi3221"><img alt="Toshiharu Takematsu" height="32" src="http://www.gravatar.com/avatar/3ca4621fbbb03278d4550f89e2f723ba?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Toshiharu Takematsu" width="32"></a>
+<a href="https://twitter.com/toshi3221"><img alt="Toshiharu Takematsu" height="32" src="https://www.gravatar.com/avatar/3ca4621fbbb03278d4550f89e2f723ba?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Toshiharu Takematsu" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://tdtds.jp"><img alt="TADA Tadashi" height="32" src="http://www.gravatar.com/avatar/846a80b9bf7ea7becb6c4ecd67bedd6f?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TADA Tadashi" width="32"></a>
+<a href="http://tdtds.jp"><img alt="TADA Tadashi" height="32" src="https://www.gravatar.com/avatar/846a80b9bf7ea7becb6c4ecd67bedd6f?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TADA Tadashi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://hisano.com"><img alt="HISANO Kozo" height="32" src="http://www.gravatar.com/avatar/b8fa07639c3b720c33ffdcaf89299dda?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="HISANO Kozo" width="32"></a>
+<a href="http://hisano.com"><img alt="HISANO Kozo" height="32" src="https://www.gravatar.com/avatar/b8fa07639c3b720c33ffdcaf89299dda?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="HISANO Kozo" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/kouma31/"><img alt="kmuroi" height="32" src="http://www.gravatar.com/avatar/165599097b8533c91af2aad5d7b31449?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="kmuroi" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<img alt="Anonymous" height="32" src="/2011/images/bow_face.png?1359134037" title="Anonymous" width="32">
-<a href="#"></a>
-</li>
-<li>
-<a href="http://twitter.com/h4n"><img alt="Han Kessels" height="32" src="http://www.gravatar.com/avatar/f0bd4ed83708d0af0e0d1374fc7e605b?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Han Kessels" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://twitter.com/takagi"><img alt="TAKAGI Masahiro" height="32" src="http://www.gravatar.com/avatar/c3f5a6e729b57f99cb9e7b3ca60152aa?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TAKAGI Masahiro" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://d.hatena.ne.jp/tmtms/"><img alt="TOMITA Masahiro" height="32" src="http://www.gravatar.com/avatar/e4763acee4cf0377437f614fc372a061?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TOMITA Masahiro" width="32"></a>
+<a href="http://d.hatena.ne.jp/kouma31/"><img alt="kmuroi" height="32" src="https://www.gravatar.com/avatar/165599097b8533c91af2aad5d7b31449?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="kmuroi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
@@ -905,79 +889,95 @@ Gold Sponsor
 <a href="#"></a>
 </li>
 <li>
-<a href="http://kmuto.jp/"><img alt="Kenshi Muto" height="32" src="http://www.gravatar.com/avatar/43d44fbc12adcf80c9fc24e235f48234?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kenshi Muto" width="32"></a>
+<a href="http://twitter.com/h4n"><img alt="Han Kessels" height="32" src="https://www.gravatar.com/avatar/f0bd4ed83708d0af0e0d1374fc7e605b?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Han Kessels" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<img alt="1syo" height="32" src="http://www.gravatar.com/avatar/83899fe2d00874176098a3bb71b043be?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="1syo" width="32">
+<a href="http://twitter.com/takagi"><img alt="TAKAGI Masahiro" height="32" src="https://www.gravatar.com/avatar/c3f5a6e729b57f99cb9e7b3ca60152aa?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TAKAGI Masahiro" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://fkino.net"><img alt="Fumihiko Kinoshita" height="32" src="http://www.gravatar.com/avatar/f301c0275838d562c72ea9177e7ddc68?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Fumihiko Kinoshita" width="32"></a>
+<a href="http://d.hatena.ne.jp/tmtms/"><img alt="TOMITA Masahiro" height="32" src="https://www.gravatar.com/avatar/e4763acee4cf0377437f614fc372a061?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TOMITA Masahiro" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://blog.masuidrive.jp/"><img alt="Yuichiro MASUI" height="32" src="http://www.gravatar.com/avatar/0ec58a040e1e4e959c8566484b4bba19?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yuichiro MASUI" width="32"></a>
+<img alt="Anonymous" height="32" src="/2011/images/bow_face.png?1359134037" title="Anonymous" width="32">
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/t2os/"><img alt="tatsuoSakurai" height="32" src="http://www.gravatar.com/avatar/092404bdf9897eba9ab16e61f56592db?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="tatsuoSakurai" width="32"></a>
+<a href="http://kmuto.jp/"><img alt="Kenshi Muto" height="32" src="https://www.gravatar.com/avatar/43d44fbc12adcf80c9fc24e235f48234?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kenshi Muto" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://ogijun.org"><img alt="Junya Ogino" height="32" src="http://www.gravatar.com/avatar/3a82321f68500d9691a9e190979ac2f0?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Junya Ogino" width="32"></a>
+<img alt="1syo" height="32" src="https://www.gravatar.com/avatar/83899fe2d00874176098a3bb71b043be?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="1syo" width="32">
 <a href="#"></a>
 </li>
 <li>
-<a href="http://about.me/mackato"><img alt="Masakuni Kato" height="32" src="http://www.gravatar.com/avatar/28347314c7fc698b4ac0e01113545e25?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masakuni Kato" width="32"></a>
+<a href="http://fkino.net"><img alt="Fumihiko Kinoshita" height="32" src="https://www.gravatar.com/avatar/f301c0275838d562c72ea9177e7ddc68?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Fumihiko Kinoshita" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/IWAKIRI"><img alt="IWAKIRI,Akiko" height="32" src="http://www.gravatar.com/avatar/2a02258781c7592d0da1cd5cffa627a8?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="IWAKIRI,Akiko" width="32"></a>
+<a href="http://blog.masuidrive.jp/"><img alt="Yuichiro MASUI" height="32" src="https://www.gravatar.com/avatar/0ec58a040e1e4e959c8566484b4bba19?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yuichiro MASUI" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://june29.jp/"><img alt="june29" height="32" src="http://www.gravatar.com/avatar/6fd9be5cd0196df5ad62a5a5f2be3c55?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="june29" width="32"></a>
+<a href="http://d.hatena.ne.jp/t2os/"><img alt="tatsuoSakurai" height="32" src="https://www.gravatar.com/avatar/092404bdf9897eba9ab16e61f56592db?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="tatsuoSakurai" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.socialtoprunners.jp/"><img alt="tomokazuhattanda" height="32" src="http://www.gravatar.com/avatar/19798587cb27b5220a5dcdbaa9a50d57?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="tomokazuhattanda" width="32"></a>
+<a href="http://ogijun.org"><img alt="Junya Ogino" height="32" src="https://www.gravatar.com/avatar/3a82321f68500d9691a9e190979ac2f0?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Junya Ogino" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.jamboree.jp/"><img alt="TOYOSHI, Ryuichiro" height="32" src="http://www.gravatar.com/avatar/203c324392b6c51241da5b42bbf888bd?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TOYOSHI, Ryuichiro" width="32"></a>
+<a href="http://about.me/mackato"><img alt="Masakuni Kato" height="32" src="https://www.gravatar.com/avatar/28347314c7fc698b4ac0e01113545e25?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masakuni Kato" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/takano32"><img alt="たかのみつひろ" height="32" src="http://www.gravatar.com/avatar/eba4a40bdae5edfe1589601c050a2b96?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="たかのみつひろ" width="32"></a>
+<a href="http://d.hatena.ne.jp/IWAKIRI"><img alt="IWAKIRI,Akiko" height="32" src="https://www.gravatar.com/avatar/2a02258781c7592d0da1cd5cffa627a8?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="IWAKIRI,Akiko" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/tyabe"><img alt="tyabe" height="32" src="http://www.gravatar.com/avatar/d21900444f5548d9329861593321b5a6?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="tyabe" width="32"></a>
+<a href="http://june29.jp/"><img alt="june29" height="32" src="https://www.gravatar.com/avatar/6fd9be5cd0196df5ad62a5a5f2be3c55?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="june29" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/#!/maxyz"><img alt="Masafumi Fujiwara" height="32" src="http://www.gravatar.com/avatar/4dd4d13d27559db2fb64ad069f2c49ba?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masafumi Fujiwara" width="32"></a>
+<a href="http://www.socialtoprunners.jp/"><img alt="tomokazuhattanda" height="32" src="https://www.gravatar.com/avatar/19798587cb27b5220a5dcdbaa9a50d57?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="tomokazuhattanda" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/kdmsnr"><img alt="Masanori Kado" height="32" src="http://www.gravatar.com/avatar/70b07e6b7fe7d921d7ac542d0ccb3b2c?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masanori Kado" width="32"></a>
+<a href="http://www.jamboree.jp/"><img alt="TOYOSHI, Ryuichiro" height="32" src="https://www.gravatar.com/avatar/203c324392b6c51241da5b42bbf888bd?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TOYOSHI, Ryuichiro" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.jitu.org/~tko"><img alt="Tomoyuki Kosimizu" height="32" src="http://www.gravatar.com/avatar/3585181753c22a9531e70a8297771b01?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomoyuki Kosimizu" width="32"></a>
+<a href="http://twitter.com/takano32"><img alt="たかのみつひろ" height="32" src="https://www.gravatar.com/avatar/eba4a40bdae5edfe1589601c050a2b96?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="たかのみつひろ" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/chinmo"><img alt="Tomonori Fukuta" height="32" src="http://www.gravatar.com/avatar/7977a0896e60587b2690550891be2ea7?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomonori Fukuta" width="32"></a>
+<a href="http://twitter.com/tyabe"><img alt="tyabe" height="32" src="https://www.gravatar.com/avatar/d21900444f5548d9329861593321b5a6?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="tyabe" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<img alt="YOKOTA Akiko" height="32" src="http://www.gravatar.com/avatar/03e548747e667fc94cc8495868bfd85e?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="YOKOTA Akiko" width="32">
+<a href="http://twitter.com/#!/maxyz"><img alt="Masafumi Fujiwara" height="32" src="https://www.gravatar.com/avatar/4dd4d13d27559db2fb64ad069f2c49ba?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masafumi Fujiwara" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://nov.tdiary.net/"><img alt="Nobuhiro IMAI" height="32" src="http://www.gravatar.com/avatar/e49ab9f0774711c473660019728cde95?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Nobuhiro IMAI" width="32"></a>
+<a href="http://twitter.com/kdmsnr"><img alt="Masanori Kado" height="32" src="https://www.gravatar.com/avatar/70b07e6b7fe7d921d7ac542d0ccb3b2c?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masanori Kado" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://www.jitu.org/~tko"><img alt="Tomoyuki Kosimizu" height="32" src="https://www.gravatar.com/avatar/3585181753c22a9531e70a8297771b01?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomoyuki Kosimizu" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://twitter.com/chinmo"><img alt="Tomonori Fukuta" height="32" src="https://www.gravatar.com/avatar/7977a0896e60587b2690550891be2ea7?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomonori Fukuta" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<img alt="YOKOTA Akiko" height="32" src="https://www.gravatar.com/avatar/03e548747e667fc94cc8495868bfd85e?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="YOKOTA Akiko" width="32">
+<a href="#"></a>
+</li>
+<li>
+<a href="http://nov.tdiary.net/"><img alt="Nobuhiro IMAI" height="32" src="https://www.gravatar.com/avatar/e49ab9f0774711c473660019728cde95?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Nobuhiro IMAI" width="32"></a>
 <a href="#"></a>
 </li>
 </ul>

--- a/2011/en/schedule/details/16M01/index.html
+++ b/2011/en/schedule/details/16M01/index.html
@@ -136,7 +136,7 @@ Speaker(s)
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/f29327647a9cff5c69618bae420792ea?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/f29327647a9cff5c69618bae420792ea?s=32" width="32">
 </a>
 <h4>
 Aaron Patterson (tenderlove)

--- a/2011/en/schedule/details/16M03/index.html
+++ b/2011/en/schedule/details/16M03/index.html
@@ -132,7 +132,7 @@ Speaker(s)
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/2997ec7879942bd0415690c85731e328?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/2997ec7879942bd0415690c85731e328?s=32" width="32">
 </a>
 <h4>
 Yuichi Tateno

--- a/2011/en/schedule/details/16M06/index.html
+++ b/2011/en/schedule/details/16M06/index.html
@@ -138,7 +138,7 @@ Speaker(s)
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/2e9a2dbe335e0111e4879a9d65dcbae0?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/2e9a2dbe335e0111e4879a9d65dcbae0?s=32" width="32">
 </a>
 <h4>
 Ayumu AIZAWA

--- a/2011/en/schedule/details/16M08/index.html
+++ b/2011/en/schedule/details/16M08/index.html
@@ -134,7 +134,7 @@ Speaker(s)
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/5c72a69ad460347a01aa05de9915c3e0?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/5c72a69ad460347a01aa05de9915c3e0?s=32" width="32">
 </a>
 <h4>
 MayumiI EMORI(emorima)

--- a/2011/en/schedule/details/16S01/index.html
+++ b/2011/en/schedule/details/16S01/index.html
@@ -137,7 +137,7 @@ Speaker(s)
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/b99311b48290f8ee37311890a8edfb1d?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/b99311b48290f8ee37311890a8edfb1d?s=32" width="32">
 </a>
 <h4>
 Shota Fukumori (sora_h)

--- a/2011/en/schedule/details/16S04/index.html
+++ b/2011/en/schedule/details/16S04/index.html
@@ -144,7 +144,7 @@ Developers of Lightweight Ruby and Ruby chip for embedded systems
 </div>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/0ec4920185b657a03edf01fff96b4e9b?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/0ec4920185b657a03edf01fff96b4e9b?s=32" width="32">
 </a>
 <h4>
 Yukihiro Matsumoto

--- a/2011/en/schedule/details/16S05/index.html
+++ b/2011/en/schedule/details/16S05/index.html
@@ -137,7 +137,7 @@ Speaker(s)
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/9f859654c118bcd2f67cc763baf0de7a?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/9f859654c118bcd2f67cc763baf0de7a?s=32" width="32">
 </a>
 <h4>
 nari

--- a/2011/en/schedule/details/17M01/index.html
+++ b/2011/en/schedule/details/17M01/index.html
@@ -132,7 +132,7 @@ Speaker(s)
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/8e497efbe99e2fa051316337d03624d9?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/8e497efbe99e2fa051316337d03624d9?s=32" width="32">
 </a>
 <h4>
 Kazuhiro NISHIYAMA

--- a/2011/en/schedule/details/17M02/index.html
+++ b/2011/en/schedule/details/17M02/index.html
@@ -132,7 +132,7 @@ Speaker(s)
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/d458733ada0c2ca6937f84c67a9e3fff?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/d458733ada0c2ca6937f84c67a9e3fff?s=32" width="32">
 </a>
 <h4>
 Shin-ichiro OGAWA

--- a/2011/en/schedule/details/17M03/index.html
+++ b/2011/en/schedule/details/17M03/index.html
@@ -140,7 +140,7 @@ Speaker(s)
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/76a777ff80f30bd3b390e275cce625bc?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/76a777ff80f30bd3b390e275cce625bc?s=32" width="32">
 </a>
 <h4>
 Akira Matsuda

--- a/2011/en/schedule/details/17M04/index.html
+++ b/2011/en/schedule/details/17M04/index.html
@@ -132,7 +132,7 @@ Speaker(s)
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/22270b6a4e909f6b926fa272596d41b9?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/22270b6a4e909f6b926fa272596d41b9?s=32" width="32">
 </a>
 <h4>
 Yutaka Hara

--- a/2011/en/schedule/details/17M05/index.html
+++ b/2011/en/schedule/details/17M05/index.html
@@ -134,7 +134,7 @@ Speaker(s)
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/c38fd9074fb072551c0ff80ccd90d24e?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/c38fd9074fb072551c0ff80ccd90d24e?s=32" width="32">
 </a>
 <h4>
 Wen-Tien Chang

--- a/2011/en/schedule/details/17M06/index.html
+++ b/2011/en/schedule/details/17M06/index.html
@@ -138,7 +138,7 @@ Speaker(s)
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/70e13d9877054026fda46d5a5b53a236?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/70e13d9877054026fda46d5a5b53a236?s=32" width="32">
 </a>
 <h4>
 Kyosuke MOROHASHI

--- a/2011/en/schedule/details/17M07/index.html
+++ b/2011/en/schedule/details/17M07/index.html
@@ -132,7 +132,7 @@ Speaker(s)
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/16c772a254c53065066116ccd04ae146?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/16c772a254c53065066116ccd04ae146?s=32" width="32">
 </a>
 <h4>
 Chris Kowalik

--- a/2011/en/schedule/details/17M08/index.html
+++ b/2011/en/schedule/details/17M08/index.html
@@ -133,7 +133,7 @@ Speaker(s)
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/428167a3ec72235ba971162924492609?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/428167a3ec72235ba971162924492609?s=32" width="32">
 </a>
 <h4>
 Yehuda Katz

--- a/2011/en/schedule/details/17M09/index.html
+++ b/2011/en/schedule/details/17M09/index.html
@@ -132,7 +132,7 @@ Speaker(s)
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/63a6bff89d692e21de20868202bc8dde?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/63a6bff89d692e21de20868202bc8dde?s=32" width="32">
 </a>
 <h4>
 Kakutani Shintaro

--- a/2011/en/schedule/details/17M10/index.html
+++ b/2011/en/schedule/details/17M10/index.html
@@ -257,7 +257,7 @@ Paul McMahon
 </div>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/947a39212bd81f6f17d3ff1291432c5d?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/947a39212bd81f6f17d3ff1291432c5d?s=32" width="32">
 </a>
 <h4>
 Joseph Wilk
@@ -297,7 +297,7 @@ Masafui Oyamada
 </div>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/cd07d1d30d4edcc5d5c5fbdd21eb45af?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/cd07d1d30d4edcc5d5c5fbdd21eb45af?s=32" width="32">
 </a>
 <h4>
 Ryoichi SEKIGUCHI

--- a/2011/en/schedule/details/17M10_04/index.html
+++ b/2011/en/schedule/details/17M10_04/index.html
@@ -134,7 +134,7 @@ Speaker(s)
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/947a39212bd81f6f17d3ff1291432c5d?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/947a39212bd81f6f17d3ff1291432c5d?s=32" width="32">
 </a>
 <h4>
 Joseph Wilk

--- a/2011/en/schedule/details/17M10_09/index.html
+++ b/2011/en/schedule/details/17M10_09/index.html
@@ -132,7 +132,7 @@ Speaker(s)
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/cd07d1d30d4edcc5d5c5fbdd21eb45af?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/cd07d1d30d4edcc5d5c5fbdd21eb45af?s=32" width="32">
 </a>
 <h4>
 Ryoichi SEKIGUCHI

--- a/2011/en/schedule/details/17S01/index.html
+++ b/2011/en/schedule/details/17S01/index.html
@@ -133,7 +133,7 @@ Speaker(s)
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/c89aa4bb4813720b76ac499d98d850f2?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/c89aa4bb4813720b76ac499d98d850f2?s=32" width="32">
 </a>
 <h4>
 Elise Huard

--- a/2011/en/schedule/details/17S03/index.html
+++ b/2011/en/schedule/details/17S03/index.html
@@ -132,7 +132,7 @@ Speaker(s)
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/58479f76374a3ba3c69b9804163f39f4?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/58479f76374a3ba3c69b9804163f39f4?s=32" width="32">
 </a>
 <h4>
 Eric Hodel

--- a/2011/en/schedule/details/17S06/index.html
+++ b/2011/en/schedule/details/17S06/index.html
@@ -132,7 +132,7 @@ Speaker(s)
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/18a797893e6768e048c1d15429f96bb4?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/18a797893e6768e048c1d15429f96bb4?s=32" width="32">
 </a>
 <h4>
 Shugo Maeda

--- a/2011/en/schedule/details/17S07/index.html
+++ b/2011/en/schedule/details/17S07/index.html
@@ -141,7 +141,7 @@ Speaker(s)
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/13313ac2ec7ba7c43b1b952db034ff3b?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/13313ac2ec7ba7c43b1b952db034ff3b?s=32" width="32">
 </a>
 <h4>
 Thomas E Enebo
@@ -153,7 +153,7 @@ Thomas Enebo has been a practitioner of Java for over a decade and he is the co-
 </div>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/1ce18b10bd8f911566c5577042b6a44c?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/1ce18b10bd8f911566c5577042b6a44c?s=32" width="32">
 </a>
 <h4>
 Koichiro Ohba

--- a/2011/en/schedule/details/17S08/index.html
+++ b/2011/en/schedule/details/17S08/index.html
@@ -134,7 +134,7 @@ Speaker(s)
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/0680ae0d795607a6d9d7fb24698710bd?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/0680ae0d795607a6d9d7fb24698710bd?s=32" width="32">
 </a>
 <h4>
 Kouji Takao

--- a/2011/en/schedule/details/17S09/index.html
+++ b/2011/en/schedule/details/17S09/index.html
@@ -139,7 +139,7 @@ Speaker(s)
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/a129af622d3faa2c90d448401a3f6faa?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/a129af622d3faa2c90d448401a3f6faa?s=32" width="32">
 </a>
 <h4>
 Shumpei Akai

--- a/2011/en/schedule/details/17S10/index.html
+++ b/2011/en/schedule/details/17S10/index.html
@@ -136,7 +136,7 @@ Speaker(s)
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/02da662c083396641da96c1d32fc86ed?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/02da662c083396641da96c1d32fc86ed?s=32" width="32">
 </a>
 <h4>
 KOSAKI Motohiro

--- a/2011/en/schedule/details/18M01/index.html
+++ b/2011/en/schedule/details/18M01/index.html
@@ -132,7 +132,7 @@ Speaker(s)
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/21a4b941766d805333e11c5766be43b4?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/21a4b941766d805333e11c5766be43b4?s=32" width="32">
 </a>
 <h4>
 Masayoshi Takahashi
@@ -144,7 +144,7 @@ Masayoshi Takahashi
 </div>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/9673ac7770ee09f76ff5d839820db157?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/9673ac7770ee09f76ff5d839820db157?s=32" width="32">
 </a>
 <h4>
 okkez
@@ -156,7 +156,7 @@ A Rubyist.
 </div>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/77a29c830c1974513a335accf5cf41a1?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/77a29c830c1974513a335accf5cf41a1?s=32" width="32">
 </a>
 <h4>
 Sunao Tanabe

--- a/2011/en/schedule/details/18M03/index.html
+++ b/2011/en/schedule/details/18M03/index.html
@@ -132,7 +132,7 @@ Speaker(s)
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/941b170e5a115a295cccb5f5cdf0a800?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/941b170e5a115a295cccb5f5cdf0a800?s=32" width="32">
 </a>
 <h4>
 Koji Shimada
@@ -146,7 +146,7 @@ Wrote the book "Ruby逆引きレシピ" (with other authors, published by SHOEIS
 </div>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/9d2d4c8b739b1b4d7882ba49dcf1d276?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/9d2d4c8b739b1b4d7882ba49dcf1d276?s=32" width="32">
 </a>
 <h4>
 Toshiaki KOSHIBA
@@ -158,7 +158,7 @@ Software Engineer. like: Excel, Ruby, UML, DFD, Agile Development, Project Facil
 </div>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/63a6bff89d692e21de20868202bc8dde?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/63a6bff89d692e21de20868202bc8dde?s=32" width="32">
 </a>
 <h4>
 Kakutani Shintaro

--- a/2011/en/schedule/details/18M05/index.html
+++ b/2011/en/schedule/details/18M05/index.html
@@ -136,7 +136,7 @@ Speaker(s)
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/eabad423977cfc6873b8f5df62b848a6?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/eabad423977cfc6873b8f5df62b848a6?s=32" width="32">
 </a>
 <h4>
 SHIBATA Hiroshi

--- a/2011/en/schedule/details/18M06/index.html
+++ b/2011/en/schedule/details/18M06/index.html
@@ -132,7 +132,7 @@ Speaker(s)
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/2d9386b1504e581be390af978e05a8b9?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/2d9386b1504e581be390af978e05a8b9?s=32" width="32">
 </a>
 <h4>
 Kouhei Sutou

--- a/2011/en/schedule/details/18M07/index.html
+++ b/2011/en/schedule/details/18M07/index.html
@@ -132,7 +132,7 @@ Speaker(s)
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/40e5e9fe36a1f85166493faac2c17499?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/40e5e9fe36a1f85166493faac2c17499?s=32" width="32">
 </a>
 <h4>
 Hirotsugu Asari

--- a/2011/en/schedule/details/18M08/index.html
+++ b/2011/en/schedule/details/18M08/index.html
@@ -133,7 +133,7 @@ Speaker(s)
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/941b170e5a115a295cccb5f5cdf0a800?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/941b170e5a115a295cccb5f5cdf0a800?s=32" width="32">
 </a>
 <h4>
 Koji Shimada

--- a/2011/en/schedule/details/18M09/index.html
+++ b/2011/en/schedule/details/18M09/index.html
@@ -303,7 +303,7 @@ Tomita Masahiro
 </div>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/7e7733a4e42faad9f8072afd85134b48?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/7e7733a4e42faad9f8072afd85134b48?s=32" width="32">
 </a>
 <h4>
 Hiromu Shioya

--- a/2011/en/schedule/details/18M09_10/index.html
+++ b/2011/en/schedule/details/18M09_10/index.html
@@ -132,7 +132,7 @@ Speaker(s)
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/7e7733a4e42faad9f8072afd85134b48?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/7e7733a4e42faad9f8072afd85134b48?s=32" width="32">
 </a>
 <h4>
 Hiromu Shioya

--- a/2011/en/schedule/details/18M10/index.html
+++ b/2011/en/schedule/details/18M10/index.html
@@ -132,7 +132,7 @@ Speaker(s)
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/0ec4920185b657a03edf01fff96b4e9b?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/0ec4920185b657a03edf01fff96b4e9b?s=32" width="32">
 </a>
 <h4>
 Yukihiro "Matz" Matsumoto

--- a/2011/en/schedule/details/18S01/index.html
+++ b/2011/en/schedule/details/18S01/index.html
@@ -132,7 +132,7 @@ Speaker(s)
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/9c35bab0739fc8762adf30de13d8c053?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/9c35bab0739fc8762adf30de13d8c053?s=32" width="32">
 </a>
 <h4>
 ANDO Yasushi

--- a/2011/en/schedule/details/18S02/index.html
+++ b/2011/en/schedule/details/18S02/index.html
@@ -138,7 +138,7 @@ Speaker(s)
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/8c98a756a956b459da8cc616ad8f9d90?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/8c98a756a956b459da8cc616ad8f9d90?s=32" width="32">
 </a>
 <h4>
 ucnv

--- a/2011/en/schedule/details/18S03/index.html
+++ b/2011/en/schedule/details/18S03/index.html
@@ -136,7 +136,7 @@ Speaker(s)
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/01bbb59a1c3ef9960f25a97afe7e920f?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/01bbb59a1c3ef9960f25a97afe7e920f?s=32" width="32">
 </a>
 <h4>
 Andrew Grimm

--- a/2011/en/schedule/details/18S06/index.html
+++ b/2011/en/schedule/details/18S06/index.html
@@ -133,7 +133,7 @@ Speaker(s)
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/98c2fb4c31fae25fe0b618f1c994c1f3?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/98c2fb4c31fae25fe0b618f1c994c1f3?s=32" width="32">
 </a>
 <h4>
 Fabio Akita

--- a/2011/en/schedule/grid/index.html
+++ b/2011/en/schedule/grid/index.html
@@ -141,7 +141,7 @@ for continued success.</span>
 </h3>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/f29327647a9cff5c69618bae420792ea?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/f29327647a9cff5c69618bae420792ea?s=24" width="24">
 Aaron Patterson (tenderlove)
 </li>
 </ul>
@@ -218,7 +218,7 @@ Large-scale web service and operations with Ruby
 </h3>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/2997ec7879942bd0415690c85731e328?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/2997ec7879942bd0415690c85731e328?s=24" width="24">
 Yuichi Tateno
 </li>
 </ul>
@@ -261,7 +261,7 @@ to listening.</span>
 </h3>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/b99311b48290f8ee37311890a8edfb1d?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/b99311b48290f8ee37311890a8edfb1d?s=24" width="24">
 Shota Fukumori (sora_h)
 </li>
 </ul>
@@ -338,7 +338,7 @@ developers and project managers based on a case in Accenture.</span>
 </h3>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/2e9a2dbe335e0111e4879a9d65dcbae0?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/2e9a2dbe335e0111e4879a9d65dcbae0?s=24" width="24">
 Ayumu AIZAWA
 </li>
 </ul>
@@ -384,7 +384,7 @@ Koutaro Okabe
 </ul>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/0ec4920185b657a03edf01fff96b4e9b?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/0ec4920185b657a03edf01fff96b4e9b?s=24" width="24">
 Yukihiro Matsumoto
 </li>
 </ul>
@@ -442,7 +442,7 @@ while implementing mission-critical system in Ruby.</span>
 </h3>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/5c72a69ad460347a01aa05de9915c3e0?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/5c72a69ad460347a01aa05de9915c3e0?s=24" width="24">
 MayumiI EMORI(emorima)
 </li>
 </ul>
@@ -467,7 +467,7 @@ In my presentation, I talk Parallel Mark Algorithm and Implemention, Resutl of b
 </h3>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/9f859654c118bcd2f67cc763baf0de7a?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/9f859654c118bcd2f67cc763baf0de7a?s=24" width="24">
 nari
 </li>
 </ul>
@@ -575,7 +575,7 @@ How to make secure program
 </h3>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/8e497efbe99e2fa051316337d03624d9?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/8e497efbe99e2fa051316337d03624d9?s=24" width="24">
 Kazuhiro NISHIYAMA
 </li>
 </ul>
@@ -593,7 +593,7 @@ The best practice of building mobile website with jpmobile
 </h3>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/d458733ada0c2ca6937f84c67a9e3fff?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/d458733ada0c2ca6937f84c67a9e3fff?s=24" width="24">
 Shin-ichiro OGAWA
 </li>
 </ul>
@@ -614,7 +614,7 @@ This talk discusses several options to use actors in Ruby.</span>
 </h3>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/c89aa4bb4813720b76ac499d98d850f2?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/c89aa4bb4813720b76ac499d98d850f2?s=24" width="24">
 Elise Huard
 </li>
 </ul>
@@ -675,7 +675,7 @@ So, here are some hints and tips to get over these problems and make your Rails 
 </h3>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/76a777ff80f30bd3b390e275cce625bc?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/76a777ff80f30bd3b390e275cce625bc?s=24" width="24">
 Akira Matsuda
 </li>
 </ul>
@@ -693,7 +693,7 @@ Road to the Ruby Master
 </h3>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/22270b6a4e909f6b926fa272596d41b9?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/22270b6a4e909f6b926fa272596d41b9?s=24" width="24">
 Yutaka Hara
 </li>
 </ul>
@@ -713,7 +713,7 @@ Writing Friendly Libraries
 </h3>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/58479f76374a3ba3c69b9804163f39f4?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/58479f76374a3ba3c69b9804163f39f4?s=24" width="24">
 Eric Hodel
 </li>
 </ul>
@@ -768,7 +768,7 @@ This talk will introduce their BDD syntax and its mocks feature. More important,
 </h3>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/c38fd9074fb072551c0ff80ccd90d24e?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/c38fd9074fb072551c0ff80ccd90d24e?s=24" width="24">
 Wen-Tien Chang
 </li>
 </ul>
@@ -792,7 +792,7 @@ I will talk about such know-how acquired through 5 years real world Rails projec
 </h3>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/70e13d9877054026fda46d5a5b53a236?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/70e13d9877054026fda46d5a5b53a236?s=24" width="24">
 Kyosuke MOROHASHI
 </li>
 </ul>
@@ -830,7 +830,7 @@ How to read JIS X 3017
 </h3>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/18a797893e6768e048c1d15429f96bb4?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/18a797893e6768e048c1d15429f96bb4?s=24" width="24">
 Shugo Maeda
 </li>
 </ul>
@@ -865,7 +865,7 @@ Efficient JavaScript integration testing with Ruby and V8 engine.
 </h3>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/16c772a254c53065066116ccd04ae146?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/16c772a254c53065066116ccd04ae146?s=24" width="24">
 Chris Kowalik
 </li>
 </ul>
@@ -884,7 +884,7 @@ I will also talk about how nonblocking IO and network libraries can be used with
 </h3>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/428167a3ec72235ba971162924492609?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/428167a3ec72235ba971162924492609?s=24" width="24">
 Yehuda Katz
 </li>
 </ul>
@@ -913,13 +913,13 @@ By the end of this talk you should be able to effectively consume Java libraries
 </h3>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/13313ac2ec7ba7c43b1b952db034ff3b?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/13313ac2ec7ba7c43b1b952db034ff3b?s=24" width="24">
 Thomas E Enebo
 </li>
 </ul>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/1ce18b10bd8f911566c5577042b6a44c?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/1ce18b10bd8f911566c5577042b6a44c?s=24" width="24">
 Koichiro Ohba
 </li>
 </ul>
@@ -939,7 +939,7 @@ In my presentation, I will explain how I modified MacRuby to make it a suitable 
 </h3>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/0680ae0d795607a6d9d7fb24698710bd?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/0680ae0d795607a6d9d7fb24698710bd?s=24" width="24">
 Kouji Takao
 </li>
 </ul>
@@ -974,7 +974,7 @@ The Gate
 </h3>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/63a6bff89d692e21de20868202bc8dde?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/63a6bff89d692e21de20868202bc8dde?s=24" width="24">
 Kakutani Shintaro
 </li>
 </ul>
@@ -1001,7 +1001,7 @@ shows difference between Method Shelters and other systems.</span>
 </h3>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/a129af622d3faa2c90d448401a3f6faa?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/a129af622d3faa2c90d448401a3f6faa?s=24" width="24">
 Shumpei Akai
 </li>
 </ul>
@@ -1023,7 +1023,7 @@ design in CRuby and talk an advance plan.</span>
 </h3>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/02da662c083396641da96c1d32fc86ed?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/02da662c083396641da96c1d32fc86ed?s=24" width="24">
 KOSAKI Motohiro
 </li>
 </ul>
@@ -1130,19 +1130,19 @@ Ruby-no-kai Itself and Some Related Projects.
 </h3>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/21a4b941766d805333e11c5766be43b4?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/21a4b941766d805333e11c5766be43b4?s=24" width="24">
 Masayoshi Takahashi
 </li>
 </ul>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/9673ac7770ee09f76ff5d839820db157?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/9673ac7770ee09f76ff5d839820db157?s=24" width="24">
 okkez
 </li>
 </ul>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/77a29c830c1974513a335accf5cf41a1?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/77a29c830c1974513a335accf5cf41a1?s=24" width="24">
 Sunao Tanabe
 </li>
 </ul>
@@ -1162,7 +1162,7 @@ Parse.y Famtour
 </h3>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/9c35bab0739fc8762adf30de13d8c053?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/9c35bab0739fc8762adf30de13d8c053?s=24" width="24">
 ANDO Yasushi
 </li>
 </ul>
@@ -1186,7 +1186,7 @@ will show you how to generate glitched images/videos.</span>
 </h3>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/8c98a756a956b459da8cc616ad8f9d90?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/8c98a756a956b459da8cc616ad8f9d90?s=24" width="24">
 ucnv
 </li>
 </ul>
@@ -1221,19 +1221,19 @@ All About RubyKaigi Ecosystem
 </h3>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/941b170e5a115a295cccb5f5cdf0a800?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/941b170e5a115a295cccb5f5cdf0a800?s=24" width="24">
 Koji Shimada
 </li>
 </ul>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/9d2d4c8b739b1b4d7882ba49dcf1d276?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/9d2d4c8b739b1b4d7882ba49dcf1d276?s=24" width="24">
 Toshiaki KOSHIBA
 </li>
 </ul>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/63a6bff89d692e21de20868202bc8dde?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/63a6bff89d692e21de20868202bc8dde?s=24" width="24">
 Kakutani Shintaro
 </li>
 </ul>
@@ -1257,7 +1257,7 @@ So accelerate your Rubies towards the speed of light and see what gets produced.
 </h3>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/01bbb59a1c3ef9960f25a97afe7e920f?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/01bbb59a1c3ef9960f25a97afe7e920f?s=24" width="24">
 Andrew Grimm
 </li>
 </ul>
@@ -1320,7 +1320,7 @@ In my talk, I discuss to continuous maintenance technique and methodology for pa
 </h3>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/eabad423977cfc6873b8f5df62b848a6?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/eabad423977cfc6873b8f5df62b848a6?s=24" width="24">
 SHIBATA Hiroshi
 </li>
 </ul>
@@ -1338,7 +1338,7 @@ How to create a testing framework
 </h3>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/2d9386b1504e581be390af978e05a8b9?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/2d9386b1504e581be390af978e05a8b9?s=24" width="24">
 Kouhei Sutou
 </li>
 </ul>
@@ -1377,7 +1377,7 @@ In this talk I'd like to explain why I like Ruby and how it enabled us to grow a
 </h3>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/98c2fb4c31fae25fe0b618f1c994c1f3?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/98c2fb4c31fae25fe0b618f1c994c1f3?s=24" width="24">
 Fabio Akita
 </li>
 </ul>
@@ -1412,7 +1412,7 @@ Know Ruby, will travel
 </h3>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/40e5e9fe36a1f85166493faac2c17499?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/40e5e9fe36a1f85166493faac2c17499?s=24" width="24">
 Hirotsugu Asari
 </li>
 </ul>
@@ -1431,7 +1431,7 @@ This talk explains about the theme again in the place of RubyKaigi that kept giv
 </h3>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/941b170e5a115a295cccb5f5cdf0a800?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/941b170e5a115a295cccb5f5cdf0a800?s=24" width="24">
 Koji Shimada
 </li>
 </ul>
@@ -1531,7 +1531,7 @@ Pendulum, PG, and the hundred year language
 </h3>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/0ec4920185b657a03edf01fff96b4e9b?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/0ec4920185b657a03edf01fff96b4e9b?s=24" width="24">
 Yukihiro "Matz" Matsumoto
 </li>
 </ul>
@@ -1710,55 +1710,39 @@ Gold Sponsor
 </h2>
 <ul>
 <li>
-<a href="http://shyouhei.tumblr.com"><img alt="Urabe, Shyouhei" height="32" src="http://www.gravatar.com/avatar/9d2f78236e45a335301ba1195026105d?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Urabe, Shyouhei" width="32"></a>
+<a href="http://shyouhei.tumblr.com"><img alt="Urabe, Shyouhei" height="32" src="https://www.gravatar.com/avatar/9d2f78236e45a335301ba1195026105d?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Urabe, Shyouhei" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/noplans"><img alt="TANIGUCHI Fumitake" height="32" src="http://www.gravatar.com/avatar/e514ae09c9b84e04231af57f1d1946b8?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TANIGUCHI Fumitake" width="32"></a>
+<a href="http://twitter.com/noplans"><img alt="TANIGUCHI Fumitake" height="32" src="https://www.gravatar.com/avatar/e514ae09c9b84e04231af57f1d1946b8?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TANIGUCHI Fumitake" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://jmettraux.wordpress.com"><img alt="John Mettraux" height="32" src="http://www.gravatar.com/avatar/8d96626e52beb1ff90f57a8e189e1e6f?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="John Mettraux" width="32"></a>
+<a href="http://jmettraux.wordpress.com"><img alt="John Mettraux" height="32" src="https://www.gravatar.com/avatar/8d96626e52beb1ff90f57a8e189e1e6f?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="John Mettraux" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/japanrock"><img alt="Shintaro Nozaki" height="32" src="http://www.gravatar.com/avatar/b31a258dd8f615f61b2d355297f82dc9?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shintaro Nozaki" width="32"></a>
+<a href="http://twitter.com/japanrock"><img alt="Shintaro Nozaki" height="32" src="https://www.gravatar.com/avatar/b31a258dd8f615f61b2d355297f82dc9?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shintaro Nozaki" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://blog.dio.jp"><img alt="Akira Matsuda" height="32" src="http://www.gravatar.com/avatar/76a777ff80f30bd3b390e275cce625bc?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Akira Matsuda" width="32"></a>
+<a href="http://blog.dio.jp"><img alt="Akira Matsuda" height="32" src="https://www.gravatar.com/avatar/76a777ff80f30bd3b390e275cce625bc?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Akira Matsuda" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.bovensiepen.net"><img alt="Daniel Bovensiepen" height="32" src="http://www.gravatar.com/avatar/49d6f762505615af259534deed94bc54?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Daniel Bovensiepen" width="32"></a>
+<a href="http://www.bovensiepen.net"><img alt="Daniel Bovensiepen" height="32" src="https://www.gravatar.com/avatar/49d6f762505615af259534deed94bc54?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Daniel Bovensiepen" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://firn.jp/"><img alt="Dai Akatsuka" height="32" src="http://www.gravatar.com/avatar/4efe7b5cdbe97df84e6e607948171eef?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Dai Akatsuka" width="32"></a>
+<a href="http://firn.jp/"><img alt="Dai Akatsuka" height="32" src="https://www.gravatar.com/avatar/4efe7b5cdbe97df84e6e607948171eef?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Dai Akatsuka" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.din.or.jp/~shinodas/"><img alt="Yoshihiko Hara" height="32" src="http://www.gravatar.com/avatar/8055fbffa700065178460bb7e3b8ee24?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yoshihiko Hara" width="32"></a>
+<a href="http://www.din.or.jp/~shinodas/"><img alt="Yoshihiko Hara" height="32" src="https://www.gravatar.com/avatar/8055fbffa700065178460bb7e3b8ee24?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yoshihiko Hara" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://benhoskin.gs"><img alt="Ben Hoskings" height="32" src="http://www.gravatar.com/avatar/7ed99cb90a060539d729e2491442a603?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ben Hoskings" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<img alt="Anonymous" height="32" src="/2011/images/bow_face.png?1359134037" title="Anonymous" width="32">
-<a href="#"></a>
-</li>
-<li>
-<a href="http://www.nextseed.jp/"><img alt="Hitoshi Kurokawa" height="32" src="http://www.gravatar.com/avatar/11e89e3c85d9998b2c73933bde77c71e?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hitoshi Kurokawa" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://d.hatena.ne.jp/kinpoco/"><img alt="Yutaka Kanemoto" height="32" src="http://www.gravatar.com/avatar/0e728bf538d1848bc253d80a8626bbc2?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yutaka Kanemoto" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://d.hatena.ne.jp/yuichi_katahira"><img alt="Yuichi Katahira " height="32" src="http://www.gravatar.com/avatar/3072ae08f580fc8474b47652a3d8dd0f?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yuichi Katahira " width="32"></a>
+<a href="http://benhoskin.gs"><img alt="Ben Hoskings" height="32" src="https://www.gravatar.com/avatar/7ed99cb90a060539d729e2491442a603?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ben Hoskings" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
@@ -1766,87 +1750,15 @@ Gold Sponsor
 <a href="#"></a>
 </li>
 <li>
-<a href="http://kitaj.no-ip.com/tdiary/"><img alt="Junichiro Kita" height="32" src="http://www.gravatar.com/avatar/70405ca68e6f8779be65e75b1a90525b?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Junichiro Kita" width="32"></a>
+<a href="http://www.nextseed.jp/"><img alt="Hitoshi Kurokawa" height="32" src="https://www.gravatar.com/avatar/11e89e3c85d9998b2c73933bde77c71e?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hitoshi Kurokawa" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/idesaku"><img alt="Daisuke Goto" height="32" src="http://www.gravatar.com/avatar/85c8086344e5f31b2a4d22f163660536?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Daisuke Goto" width="32"></a>
+<a href="http://d.hatena.ne.jp/kinpoco/"><img alt="Yutaka Kanemoto" height="32" src="https://www.gravatar.com/avatar/0e728bf538d1848bc253d80a8626bbc2?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yutaka Kanemoto" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<img alt="Anonymous" height="32" src="/2011/images/bow_face.png?1359134037" title="Anonymous" width="32">
-<a href="#"></a>
-</li>
-<li>
-<a href="http://www.on-sky.net/~hs/"><img alt="Hideki SAKAMOTO" height="32" src="http://www.gravatar.com/avatar/7038a6cfc30b8c3b00b5c08d70cda2f1?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hideki SAKAMOTO" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://twitter.com/agilekawabata"><img alt="Kawabata Mitsuyoshi" height="32" src="http://www.gravatar.com/avatar/5236eb3ad498b3c5336a4575408fb1b1?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kawabata Mitsuyoshi" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://www.kt.rim.or.jp/~kbk/"><img alt="KIMURA Koichi" height="32" src="http://www.gravatar.com/avatar/04c1a31d1e33e7fc25a7ca99930e4c70?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="KIMURA Koichi" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://d.hatena.ne.jp/takkaw/"><img alt="Takayoshi Kawada" height="32" src="http://www.gravatar.com/avatar/38bf2ca557d9cc20dcdcbd773a68664b?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takayoshi Kawada" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://www.suchi.org/"><img alt="Shigeru UCHIYAMA" height="32" src="http://www.gravatar.com/avatar/398e2dd764d43aad735c6e5bca92c3b6?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shigeru UCHIYAMA" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://twitter.com/#!/andrewjgrimm"><img alt="Andrew Grimm" height="32" src="http://www.gravatar.com/avatar/01bbb59a1c3ef9960f25a97afe7e920f?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Andrew Grimm" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://twitter.com/kimuraw"><img alt="kimura wataru" height="32" src="http://www.gravatar.com/avatar/e298234a6e5a2c159287476abd76504a?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="kimura wataru" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://saikyoline.jp/"><img alt="MIKAMI Yoshiyuki" height="32" src="http://www.gravatar.com/avatar/e0920f5f813ae29ba7859f950a7f0df3?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MIKAMI Yoshiyuki" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://jp.rubyist.net/?KansaiWorkshop"><img alt="HIGAKI Masaru" height="32" src="http://www.gravatar.com/avatar/a8192f5a7b25ef32a983740ee8593bd3?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="HIGAKI Masaru" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://twitter.com/ayumin"><img alt="Ayumu AIZAWA" height="32" src="http://www.gravatar.com/avatar/2e9a2dbe335e0111e4879a9d65dcbae0?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ayumu AIZAWA" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://shunichi-arai.blogspot.com/"><img alt="Shunichi Arai" height="32" src="http://www.gravatar.com/avatar/74daf3516e33a75968ec0f933954b5a8?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shunichi Arai" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://www.tokyodev.com"><img alt="Paul McMahon" height="32" src="http://www.gravatar.com/avatar/dd24adb5a3a430fed83a33ed552fe1b5?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Paul McMahon" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://d.hatena.ne.jp/hs9587/"><img alt="Hiroyuki Shimura" height="32" src="http://www.gravatar.com/avatar/287a899c91a7a14535188d7e4784050e?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hiroyuki Shimura" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://kakutani.com"><img alt="Kakutani Shintaro" height="32" src="http://www.gravatar.com/avatar/34fcd5f1deeb25b1138e9845137feb6e?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kakutani Shintaro" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://d.hatena.ne.jp/mrkn"><img alt="Kenta Murata" height="32" src="http://www.gravatar.com/avatar/819b3c0a25f9708fd32261b8ae2d23f6?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kenta Murata" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://rails.to"><img alt="Masatoshi Itagaki" height="32" src="http://www.gravatar.com/avatar/f8865f41777ef3caced0e4e6801ff83a?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masatoshi Itagaki" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://spring-aki.com/"><img alt="Aki" height="32" src="http://www.gravatar.com/avatar/81f2122b45f48829be4507bf972666e9?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Aki" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://twitter.com/shin_asou"><img alt="Shinichi Okada" height="32" src="http://www.gravatar.com/avatar/20805358592bd93f92bf15aa10137251?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shinichi Okada" width="32"></a>
+<a href="http://d.hatena.ne.jp/yuichi_katahira"><img alt="Yuichi Katahira " height="32" src="https://www.gravatar.com/avatar/3072ae08f580fc8474b47652a3d8dd0f?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yuichi Katahira " width="32"></a>
 <a href="#"></a>
 </li>
 <li>
@@ -1854,35 +1766,11 @@ Gold Sponsor
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.kumaryu.net/"><img alt="Ryuichi Sakamoto" height="32" src="http://www.gravatar.com/avatar/1b2ca00132480422c75c1f2c61e84e26?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ryuichi Sakamoto" width="32"></a>
+<a href="http://kitaj.no-ip.com/tdiary/"><img alt="Junichiro Kita" height="32" src="https://www.gravatar.com/avatar/70405ca68e6f8779be65e75b1a90525b?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Junichiro Kita" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<img alt="Eito Katagiri" height="32" src="http://www.gravatar.com/avatar/b5852cf79505d7ba513f8f16ef95a50f?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Eito Katagiri" width="32">
-<a href="#"></a>
-</li>
-<li>
-<a href="http://ukstudio.jp/"><img alt="AKAMATSU Yuki" height="32" src="http://www.gravatar.com/avatar/0c471249ee93ab17a011f3e8d2b1057a?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="AKAMATSU Yuki" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://hisashim.org"><img alt="Hisashi Morita" height="32" src="http://www.gravatar.com/avatar/b3fba7af93cd27e6ed28e7eae88a9585?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hisashi Morita" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://d.hatena.ne.jp/muryoImpl/"><img alt="Ken muryoi" height="32" src="http://www.gravatar.com/avatar/ac6dba8ce93944d17714de362ca17e54?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ken muryoi" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://d.hatena.ne.jp/nagachika/"><img alt="Tomoyuki Chikanaga" height="32" src="http://www.gravatar.com/avatar/5cf8f058a4c094bb708174fb43e7a387?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomoyuki Chikanaga" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://d.hatena.ne.jp/takeshinoda/"><img alt="Takeshi SHINODA" height="32" src="http://www.gravatar.com/avatar/06febd004d7cc9c9f6a4e0272b686bc7?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takeshi SHINODA" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://twitter.com/knsmr"><img alt="Ken Nishimura" height="32" src="http://www.gravatar.com/avatar/91fb4852880d1727cca911036e2fef5f?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ken Nishimura" width="32"></a>
+<a href="http://d.hatena.ne.jp/idesaku"><img alt="Daisuke Goto" height="32" src="https://www.gravatar.com/avatar/85c8086344e5f31b2a4d22f163660536?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Daisuke Goto" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
@@ -1890,35 +1778,75 @@ Gold Sponsor
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/koko_u/"><img alt="Kozaki Tsuneaki" height="32" src="http://www.gravatar.com/avatar/5b1b558d563288da615a9ea2889afdd5?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kozaki Tsuneaki" width="32"></a>
+<a href="http://www.on-sky.net/~hs/"><img alt="Hideki SAKAMOTO" height="32" src="https://www.gravatar.com/avatar/7038a6cfc30b8c3b00b5c08d70cda2f1?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hideki SAKAMOTO" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/adzuki34"><img alt="SUZUKI Miho" height="32" src="http://www.gravatar.com/avatar/f37b9a968b2326062190677906a93080?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="SUZUKI Miho" width="32"></a>
+<a href="http://twitter.com/agilekawabata"><img alt="Kawabata Mitsuyoshi" height="32" src="https://www.gravatar.com/avatar/5236eb3ad498b3c5336a4575408fb1b1?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kawabata Mitsuyoshi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/lchin"><img alt="Leonard Chin" height="32" src="http://www.gravatar.com/avatar/70762059db0218c6f0ff48042ca0756a?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Leonard Chin" width="32"></a>
+<a href="http://www.kt.rim.or.jp/~kbk/"><img alt="KIMURA Koichi" height="32" src="https://www.gravatar.com/avatar/04c1a31d1e33e7fc25a7ca99930e4c70?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="KIMURA Koichi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/suzumura_ss/"><img alt="Toshiyuki Terashita" height="32" src="http://www.gravatar.com/avatar/bb8b58cab667163b6ee53aad0e5f0414?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Toshiyuki Terashita" width="32"></a>
+<a href="http://d.hatena.ne.jp/takkaw/"><img alt="Takayoshi Kawada" height="32" src="https://www.gravatar.com/avatar/38bf2ca557d9cc20dcdcbd773a68664b?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takayoshi Kawada" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://sites.google.com/site/akihikohashimoto/"><img alt="Akihiko Hashimoto" height="32" src="http://www.gravatar.com/avatar/c8803a4130c3238e34b605d0a0cffe94?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Akihiko Hashimoto" width="32"></a>
+<a href="http://www.suchi.org/"><img alt="Shigeru UCHIYAMA" height="32" src="https://www.gravatar.com/avatar/398e2dd764d43aad735c6e5bca92c3b6?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shigeru UCHIYAMA" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<img alt="OZAWA Sakuro" height="32" src="http://www.gravatar.com/avatar/a1cbed8bf64473e2acdd0c7066cc5b29?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="OZAWA Sakuro" width="32">
+<a href="http://twitter.com/#!/andrewjgrimm"><img alt="Andrew Grimm" height="32" src="https://www.gravatar.com/avatar/01bbb59a1c3ef9960f25a97afe7e920f?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Andrew Grimm" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://fkmn.exblog.jp/"><img alt="Arinobu FUKUHARA" height="32" src="http://www.gravatar.com/avatar/85319f2b72d7b37ddef5c25a2dd40d30?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Arinobu FUKUHARA" width="32"></a>
+<a href="http://twitter.com/kimuraw"><img alt="kimura wataru" height="32" src="https://www.gravatar.com/avatar/e298234a6e5a2c159287476abd76504a?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="kimura wataru" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/shachi"><img alt="Kazuyuki Koizuka-shachi" height="32" src="http://www.gravatar.com/avatar/f51ee84097a72a8d91bee9bb98736541?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kazuyuki Koizuka-shachi" width="32"></a>
+<a href="http://saikyoline.jp/"><img alt="MIKAMI Yoshiyuki" height="32" src="https://www.gravatar.com/avatar/e0920f5f813ae29ba7859f950a7f0df3?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MIKAMI Yoshiyuki" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://jp.rubyist.net/?KansaiWorkshop"><img alt="HIGAKI Masaru" height="32" src="https://www.gravatar.com/avatar/a8192f5a7b25ef32a983740ee8593bd3?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="HIGAKI Masaru" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://twitter.com/ayumin"><img alt="Ayumu AIZAWA" height="32" src="https://www.gravatar.com/avatar/2e9a2dbe335e0111e4879a9d65dcbae0?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ayumu AIZAWA" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://shunichi-arai.blogspot.com/"><img alt="Shunichi Arai" height="32" src="https://www.gravatar.com/avatar/74daf3516e33a75968ec0f933954b5a8?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shunichi Arai" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://www.tokyodev.com"><img alt="Paul McMahon" height="32" src="https://www.gravatar.com/avatar/dd24adb5a3a430fed83a33ed552fe1b5?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Paul McMahon" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://d.hatena.ne.jp/hs9587/"><img alt="Hiroyuki Shimura" height="32" src="https://www.gravatar.com/avatar/287a899c91a7a14535188d7e4784050e?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hiroyuki Shimura" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://kakutani.com"><img alt="Kakutani Shintaro" height="32" src="https://www.gravatar.com/avatar/34fcd5f1deeb25b1138e9845137feb6e?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kakutani Shintaro" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://d.hatena.ne.jp/mrkn"><img alt="Kenta Murata" height="32" src="https://www.gravatar.com/avatar/819b3c0a25f9708fd32261b8ae2d23f6?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kenta Murata" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://rails.to"><img alt="Masatoshi Itagaki" height="32" src="https://www.gravatar.com/avatar/f8865f41777ef3caced0e4e6801ff83a?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masatoshi Itagaki" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://spring-aki.com/"><img alt="Aki" height="32" src="https://www.gravatar.com/avatar/81f2122b45f48829be4507bf972666e9?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Aki" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://twitter.com/shin_asou"><img alt="Shinichi Okada" height="32" src="https://www.gravatar.com/avatar/20805358592bd93f92bf15aa10137251?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shinichi Okada" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
@@ -1926,103 +1854,175 @@ Gold Sponsor
 <a href="#"></a>
 </li>
 <li>
-<a href="http://atakigu.tumblr.com/"><img alt="atakig" height="32" src="http://www.gravatar.com/avatar/8a949c60e450d226de776072273a1ffc?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="atakig" width="32"></a>
+<a href="http://www.kumaryu.net/"><img alt="Ryuichi Sakamoto" height="32" src="https://www.gravatar.com/avatar/1b2ca00132480422c75c1f2c61e84e26?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ryuichi Sakamoto" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<img alt="TSUTSUI Toshinori" height="32" src="http://www.gravatar.com/avatar/ad66fd981c429c12e0f76c436da3337e?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TSUTSUI Toshinori" width="32">
+<img alt="Eito Katagiri" height="32" src="https://www.gravatar.com/avatar/b5852cf79505d7ba513f8f16ef95a50f?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Eito Katagiri" width="32">
 <a href="#"></a>
 </li>
 <li>
-<a href="http://yugui.jp"><img alt="Yuki Sonoda (Yugui)" height="32" src="http://www.gravatar.com/avatar/1e7e007723cfe59320d994a7db4ab4cf?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yuki Sonoda (Yugui)" width="32"></a>
+<a href="http://ukstudio.jp/"><img alt="AKAMATSU Yuki" height="32" src="https://www.gravatar.com/avatar/0c471249ee93ab17a011f3e8d2b1057a?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="AKAMATSU Yuki" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/seiunsky"><img alt="sugamasao" height="32" src="http://www.gravatar.com/avatar/961126d9892ae4df45249529a0721571?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="sugamasao" width="32"></a>
+<a href="http://hisashim.org"><img alt="Hisashi Morita" height="32" src="https://www.gravatar.com/avatar/b3fba7af93cd27e6ed28e7eae88a9585?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hisashi Morita" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/mkgin/"><img alt="Makoto Kouno" height="32" src="http://www.gravatar.com/avatar/06e6dcde277cbe5c614baf5d25871025?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Makoto Kouno" width="32"></a>
+<a href="http://d.hatena.ne.jp/muryoImpl/"><img alt="Ken muryoi" height="32" src="https://www.gravatar.com/avatar/ac6dba8ce93944d17714de362ca17e54?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ken muryoi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/suzuki"><img alt="Norio Suzuki" height="32" src="http://www.gravatar.com/avatar/8e528456ff66ec543952daa815353a01?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Norio Suzuki" width="32"></a>
+<a href="http://d.hatena.ne.jp/nagachika/"><img alt="Tomoyuki Chikanaga" height="32" src="https://www.gravatar.com/avatar/5cf8f058a4c094bb708174fb43e7a387?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomoyuki Chikanaga" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.artonx.org"><img alt="Akio Tajima" height="32" src="http://www.gravatar.com/avatar/0441ff038018e53a35bb207e81105a5c?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Akio Tajima" width="32"></a>
+<a href="http://d.hatena.ne.jp/takeshinoda/"><img alt="Takeshi SHINODA" height="32" src="https://www.gravatar.com/avatar/06febd004d7cc9c9f6a4e0272b686bc7?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takeshi SHINODA" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://moonrock.jp/~don/"><img alt="Hiroyuki Iwatsuki" height="32" src="http://www.gravatar.com/avatar/cb1f0f80c3fe2729ba593656772c266d?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hiroyuki Iwatsuki" width="32"></a>
+<a href="http://twitter.com/knsmr"><img alt="Ken Nishimura" height="32" src="https://www.gravatar.com/avatar/91fb4852880d1727cca911036e2fef5f?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ken Nishimura" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/monyakata/"><img alt="MUNAKATA Akiko" height="32" src="http://www.gravatar.com/avatar/55a6db4b079c962f72adb014055e9a28?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MUNAKATA Akiko" width="32"></a>
+<img alt="Anonymous" height="32" src="/2011/images/bow_face.png?1359134037" title="Anonymous" width="32">
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.bawdo.com"><img alt="Keith Bawden" height="32" src="http://www.gravatar.com/avatar/a6cc567a6b77ee09f7363d175455593b?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Keith Bawden" width="32"></a>
+<a href="http://d.hatena.ne.jp/koko_u/"><img alt="Kozaki Tsuneaki" height="32" src="https://www.gravatar.com/avatar/5b1b558d563288da615a9ea2889afdd5?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kozaki Tsuneaki" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<img alt="Norihito Yoshioka" height="32" src="http://www.gravatar.com/avatar/c6033734a5b01f43cca06773ea9ff1fe?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Norihito Yoshioka" width="32">
+<a href="http://twitter.com/adzuki34"><img alt="SUZUKI Miho" height="32" src="https://www.gravatar.com/avatar/f37b9a968b2326062190677906a93080?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="SUZUKI Miho" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/vestige/"><img alt="makoto yonezawa" height="32" src="http://www.gravatar.com/avatar/8da7ceb361c63bd6622fe33153a0293b?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="makoto yonezawa" width="32"></a>
+<a href="http://twitter.com/lchin"><img alt="Leonard Chin" height="32" src="https://www.gravatar.com/avatar/70762059db0218c6f0ff48042ca0756a?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Leonard Chin" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="https://twitter.com/tsuboi"><img alt="Sougo TSUBOI" height="32" src="http://www.gravatar.com/avatar/847bf4e3766b2e17cafef8e83b046db1?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Sougo TSUBOI" width="32"></a>
+<a href="http://d.hatena.ne.jp/suzumura_ss/"><img alt="Toshiyuki Terashita" height="32" src="https://www.gravatar.com/avatar/bb8b58cab667163b6ee53aad0e5f0414?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Toshiyuki Terashita" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/#!/mojamoja_mixi"><img alt="MojaMoja" height="32" src="http://www.gravatar.com/avatar/7b0d6fc806322376d65cbb95d40bc176?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MojaMoja" width="32"></a>
+<a href="http://sites.google.com/site/akihikohashimoto/"><img alt="Akihiko Hashimoto" height="32" src="https://www.gravatar.com/avatar/c8803a4130c3238e34b605d0a0cffe94?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Akihiko Hashimoto" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/takkanm"><img alt="mitsutaka mimura" height="32" src="http://www.gravatar.com/avatar/8f39a252784d5a99589be6e20c4553fb?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="mitsutaka mimura" width="32"></a>
+<img alt="OZAWA Sakuro" height="32" src="https://www.gravatar.com/avatar/a1cbed8bf64473e2acdd0c7066cc5b29?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="OZAWA Sakuro" width="32">
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/dan5ya"><img alt="Dan Yamamoto" height="32" src="http://www.gravatar.com/avatar/ffaa5dad365d5bb5025f4126bb54676c?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Dan Yamamoto" width="32"></a>
+<a href="http://fkmn.exblog.jp/"><img alt="Arinobu FUKUHARA" height="32" src="https://www.gravatar.com/avatar/85319f2b72d7b37ddef5c25a2dd40d30?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Arinobu FUKUHARA" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.hsbt.org/"><img alt="SHIBATA Hiroshi" height="32" src="http://www.gravatar.com/avatar/eabad423977cfc6873b8f5df62b848a6?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="SHIBATA Hiroshi" width="32"></a>
+<a href="http://twitter.com/shachi"><img alt="Kazuyuki Koizuka-shachi" height="32" src="https://www.gravatar.com/avatar/f51ee84097a72a8d91bee9bb98736541?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kazuyuki Koizuka-shachi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/moro/"><img alt="MOROHASHI Kyosuke" height="32" src="http://www.gravatar.com/avatar/70e13d9877054026fda46d5a5b53a236?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MOROHASHI Kyosuke" width="32"></a>
+<img alt="Anonymous" height="32" src="/2011/images/bow_face.png?1359134037" title="Anonymous" width="32">
 <a href="#"></a>
 </li>
 <li>
-<a href="http://rsss.be/hibariya"><img alt="Hibariya Hi" height="32" src="http://www.gravatar.com/avatar/de0df5acda15a9c7eeb6c28a5e5d4e8e?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hibariya Hi" width="32"></a>
+<a href="http://atakigu.tumblr.com/"><img alt="atakig" height="32" src="https://www.gravatar.com/avatar/8a949c60e450d226de776072273a1ffc?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="atakig" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/kyanny"><img alt="Kensuke Nagae" height="32" src="http://www.gravatar.com/avatar/fffd8bf62b842a46803fb07792029fa4?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kensuke Nagae" width="32"></a>
+<img alt="TSUTSUI Toshinori" height="32" src="https://www.gravatar.com/avatar/ad66fd981c429c12e0f76c436da3337e?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TSUTSUI Toshinori" width="32">
 <a href="#"></a>
 </li>
 <li>
-<img alt="oku23" height="32" src="http://www.gravatar.com/avatar/3725ec1dce281fb187d798a9b9ddc9d3?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="oku23" width="32">
+<a href="http://yugui.jp"><img alt="Yuki Sonoda (Yugui)" height="32" src="https://www.gravatar.com/avatar/1e7e007723cfe59320d994a7db4ab4cf?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yuki Sonoda (Yugui)" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://ko.meadowy.net/~koichiro/diary/"><img alt="Koichiro Ohba" height="32" src="http://www.gravatar.com/avatar/1ce18b10bd8f911566c5577042b6a44c?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Koichiro Ohba" width="32"></a>
+<a href="http://d.hatena.ne.jp/seiunsky"><img alt="sugamasao" height="32" src="https://www.gravatar.com/avatar/961126d9892ae4df45249529a0721571?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="sugamasao" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.flickr.com/photos/t-seto"><img alt="せとん" height="32" src="http://www.gravatar.com/avatar/ac007a5b84f817d8cc80a3c208ea0181?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="せとん" width="32"></a>
+<a href="http://d.hatena.ne.jp/mkgin/"><img alt="Makoto Kouno" height="32" src="https://www.gravatar.com/avatar/06e6dcde277cbe5c614baf5d25871025?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Makoto Kouno" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/#!/tsuyoshikawa"><img alt="Tsuyoshi Yoshikawa" height="32" src="http://www.gravatar.com/avatar/6969ade78c1eaff0d08c76020fc80e83?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tsuyoshi Yoshikawa" width="32"></a>
+<a href="http://twitter.com/suzuki"><img alt="Norio Suzuki" height="32" src="https://www.gravatar.com/avatar/8e528456ff66ec543952daa815353a01?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Norio Suzuki" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.water-lily.biz/"><img alt="Water Lily LLC" height="32" src="http://www.gravatar.com/avatar/0734b8ec5eed71892e5db432856f4f40?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Water Lily LLC" width="32"></a>
+<a href="http://www.artonx.org"><img alt="Akio Tajima" height="32" src="https://www.gravatar.com/avatar/0441ff038018e53a35bb207e81105a5c?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Akio Tajima" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://moonrock.jp/~don/"><img alt="Hiroyuki Iwatsuki" height="32" src="https://www.gravatar.com/avatar/cb1f0f80c3fe2729ba593656772c266d?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hiroyuki Iwatsuki" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://d.hatena.ne.jp/monyakata/"><img alt="MUNAKATA Akiko" height="32" src="https://www.gravatar.com/avatar/55a6db4b079c962f72adb014055e9a28?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MUNAKATA Akiko" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://www.bawdo.com"><img alt="Keith Bawden" height="32" src="https://www.gravatar.com/avatar/a6cc567a6b77ee09f7363d175455593b?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Keith Bawden" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<img alt="Norihito Yoshioka" height="32" src="https://www.gravatar.com/avatar/c6033734a5b01f43cca06773ea9ff1fe?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Norihito Yoshioka" width="32">
+<a href="#"></a>
+</li>
+<li>
+<a href="http://d.hatena.ne.jp/vestige/"><img alt="makoto yonezawa" height="32" src="https://www.gravatar.com/avatar/8da7ceb361c63bd6622fe33153a0293b?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="makoto yonezawa" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="https://twitter.com/tsuboi"><img alt="Sougo TSUBOI" height="32" src="https://www.gravatar.com/avatar/847bf4e3766b2e17cafef8e83b046db1?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Sougo TSUBOI" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://twitter.com/#!/mojamoja_mixi"><img alt="MojaMoja" height="32" src="https://www.gravatar.com/avatar/7b0d6fc806322376d65cbb95d40bc176?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MojaMoja" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://twitter.com/takkanm"><img alt="mitsutaka mimura" height="32" src="https://www.gravatar.com/avatar/8f39a252784d5a99589be6e20c4553fb?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="mitsutaka mimura" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://twitter.com/dan5ya"><img alt="Dan Yamamoto" height="32" src="https://www.gravatar.com/avatar/ffaa5dad365d5bb5025f4126bb54676c?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Dan Yamamoto" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://www.hsbt.org/"><img alt="SHIBATA Hiroshi" height="32" src="https://www.gravatar.com/avatar/eabad423977cfc6873b8f5df62b848a6?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="SHIBATA Hiroshi" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://d.hatena.ne.jp/moro/"><img alt="MOROHASHI Kyosuke" height="32" src="https://www.gravatar.com/avatar/70e13d9877054026fda46d5a5b53a236?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MOROHASHI Kyosuke" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://rsss.be/hibariya"><img alt="Hibariya Hi" height="32" src="https://www.gravatar.com/avatar/de0df5acda15a9c7eeb6c28a5e5d4e8e?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hibariya Hi" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://twitter.com/kyanny"><img alt="Kensuke Nagae" height="32" src="https://www.gravatar.com/avatar/fffd8bf62b842a46803fb07792029fa4?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kensuke Nagae" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<img alt="oku23" height="32" src="https://www.gravatar.com/avatar/3725ec1dce281fb187d798a9b9ddc9d3?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="oku23" width="32">
+<a href="#"></a>
+</li>
+<li>
+<a href="http://ko.meadowy.net/~koichiro/diary/"><img alt="Koichiro Ohba" height="32" src="https://www.gravatar.com/avatar/1ce18b10bd8f911566c5577042b6a44c?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Koichiro Ohba" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://www.flickr.com/photos/t-seto"><img alt="せとん" height="32" src="https://www.gravatar.com/avatar/ac007a5b84f817d8cc80a3c208ea0181?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="せとん" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://twitter.com/#!/tsuyoshikawa"><img alt="Tsuyoshi Yoshikawa" height="32" src="https://www.gravatar.com/avatar/6969ade78c1eaff0d08c76020fc80e83?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tsuyoshi Yoshikawa" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://www.water-lily.biz/"><img alt="Water Lily LLC" height="32" src="https://www.gravatar.com/avatar/0734b8ec5eed71892e5db432856f4f40?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Water Lily LLC" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
@@ -2030,115 +2030,99 @@ Gold Sponsor
 <a href="#"></a>
 </li>
 <li>
-<a href="http://web-engineer.buyuden.net/blog/kawai/"><img alt="Takeshi Kawai" height="32" src="http://www.gravatar.com/avatar/6b53e472c9200f5ed61d7a6db0a28986?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takeshi Kawai" width="32"></a>
+<a href="http://web-engineer.buyuden.net/blog/kawai/"><img alt="Takeshi Kawai" height="32" src="https://www.gravatar.com/avatar/6b53e472c9200f5ed61d7a6db0a28986?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takeshi Kawai" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/k3c/"><img alt="KANEKO Seiji" height="32" src="http://www.gravatar.com/avatar/63d3818b5c107a6483a1d2e2767be4c5?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="KANEKO Seiji" width="32"></a>
+<a href="http://d.hatena.ne.jp/k3c/"><img alt="KANEKO Seiji" height="32" src="https://www.gravatar.com/avatar/63d3818b5c107a6483a1d2e2767be4c5?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="KANEKO Seiji" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.famlog.jp/"><img alt="Atsushi Matsuo" height="32" src="http://www.gravatar.com/avatar/0a4da00dbfd37e7f06ef8dceb58ca0c1?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Atsushi Matsuo" width="32"></a>
+<a href="http://www.famlog.jp/"><img alt="Atsushi Matsuo" height="32" src="https://www.gravatar.com/avatar/0a4da00dbfd37e7f06ef8dceb58ca0c1?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Atsushi Matsuo" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://m.igrs.jp/"><img alt="Masato Igarashi" height="32" src="http://www.gravatar.com/avatar/6fd2e23d73c26ccbd7df9e3eefacd3ae?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masato Igarashi" width="32"></a>
+<a href="http://m.igrs.jp/"><img alt="Masato Igarashi" height="32" src="https://www.gravatar.com/avatar/6fd2e23d73c26ccbd7df9e3eefacd3ae?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masato Igarashi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://resume.github.com/?walf443"><img alt="Keiji Yoshimi" height="32" src="http://www.gravatar.com/avatar/dea4fe079aec284744ad02eb3d2594f5?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Keiji Yoshimi" width="32"></a>
+<a href="http://resume.github.com/?walf443"><img alt="Keiji Yoshimi" height="32" src="https://www.gravatar.com/avatar/dea4fe079aec284744ad02eb3d2594f5?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Keiji Yoshimi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://gunjisatoshi.appspot.com/"><img alt="GUNJI Satoshi" height="32" src="http://www.gravatar.com/avatar/e6980e09fdff8f481b70f2e1f241231d?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="GUNJI Satoshi" width="32"></a>
+<a href="http://gunjisatoshi.appspot.com/"><img alt="GUNJI Satoshi" height="32" src="https://www.gravatar.com/avatar/e6980e09fdff8f481b70f2e1f241231d?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="GUNJI Satoshi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<img alt="Hisashi Yamaeda" height="32" src="http://www.gravatar.com/avatar/01ca4ebeee47c9b4d6ba9ad58db694a0?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hisashi Yamaeda" width="32">
+<img alt="Hisashi Yamaeda" height="32" src="https://www.gravatar.com/avatar/01ca4ebeee47c9b4d6ba9ad58db694a0?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hisashi Yamaeda" width="32">
 <a href="#"></a>
 </li>
 <li>
-<img alt="gekidanyonin" height="32" src="http://www.gravatar.com/avatar/2b196f1723fdbcbf7bd297b3e7f8cd3c?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="gekidanyonin" width="32">
+<img alt="gekidanyonin" height="32" src="https://www.gravatar.com/avatar/2b196f1723fdbcbf7bd297b3e7f8cd3c?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="gekidanyonin" width="32">
 <a href="#"></a>
 </li>
 <li>
-<a href="http://jp.linkedin.com/in/nakaomitsuteru"><img alt="Mitsuteru Nakao" height="32" src="http://www.gravatar.com/avatar/9090e122cba40b90124ea8eb4859bf8e?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Mitsuteru Nakao" width="32"></a>
+<a href="http://jp.linkedin.com/in/nakaomitsuteru"><img alt="Mitsuteru Nakao" height="32" src="https://www.gravatar.com/avatar/9090e122cba40b90124ea8eb4859bf8e?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Mitsuteru Nakao" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://zaki.asia"><img alt="Dezso Zoltan" height="32" src="http://www.gravatar.com/avatar/a771de8e1e49a9da61e2a602a2af42bc?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Dezso Zoltan" width="32"></a>
+<a href="http://zaki.asia"><img alt="Dezso Zoltan" height="32" src="https://www.gravatar.com/avatar/a771de8e1e49a9da61e2a602a2af42bc?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Dezso Zoltan" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.twitter.com/ope"><img alt="Takanori Nakanowatari" height="32" src="http://www.gravatar.com/avatar/55bcf6eb5de45a70e76f8a2678822ecb?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takanori Nakanowatari" width="32"></a>
+<a href="http://www.twitter.com/ope"><img alt="Takanori Nakanowatari" height="32" src="https://www.gravatar.com/avatar/55bcf6eb5de45a70e76f8a2678822ecb?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takanori Nakanowatari" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="https://github.com/zev"><img alt="Zev Blut" height="32" src="http://www.gravatar.com/avatar/1c77ad9f35746369dd1f4dd69b9f8b18?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Zev Blut" width="32"></a>
+<a href="https://github.com/zev"><img alt="Zev Blut" height="32" src="https://www.gravatar.com/avatar/1c77ad9f35746369dd1f4dd69b9f8b18?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Zev Blut" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://tako3.com/http://rubykaigi.org/rubyists/kei-s"><img alt="kei-s" height="32" src="http://www.gravatar.com/avatar/bf7ce9b68bbb0058721906b4db15b9b5?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="kei-s" width="32"></a>
+<a href="http://tako3.com/http://rubykaigi.org/rubyists/kei-s"><img alt="kei-s" height="32" src="https://www.gravatar.com/avatar/bf7ce9b68bbb0058721906b4db15b9b5?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="kei-s" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/bobbyjam99"><img alt="Tomokazu IMAI" height="32" src="http://www.gravatar.com/avatar/33814e72445b35ad3b65b1b05e699adc?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomokazu IMAI" width="32"></a>
+<a href="http://twitter.com/bobbyjam99"><img alt="Tomokazu IMAI" height="32" src="https://www.gravatar.com/avatar/33814e72445b35ad3b65b1b05e699adc?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomokazu IMAI" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/hasimo"><img alt="Tohru Hashimoto" height="32" src="http://www.gravatar.com/avatar/6e3d1578114e5d3951a7f90579fff74c?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tohru Hashimoto" width="32"></a>
+<a href="http://twitter.com/hasimo"><img alt="Tohru Hashimoto" height="32" src="https://www.gravatar.com/avatar/6e3d1578114e5d3951a7f90579fff74c?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tohru Hashimoto" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.mobalean.com/founders/michael"><img alt="Michael Reinsch" height="32" src="http://www.gravatar.com/avatar/c7915a424cbb28fdd6c1cce270be6b58?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Michael Reinsch" width="32"></a>
+<a href="http://www.mobalean.com/founders/michael"><img alt="Michael Reinsch" height="32" src="https://www.gravatar.com/avatar/c7915a424cbb28fdd6c1cce270be6b58?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Michael Reinsch" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/sandinist"><img alt="Tsuyoshi MAEHANA" height="32" src="http://www.gravatar.com/avatar/e8ebe7d4ec09c5dd77ee064706836f23?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tsuyoshi MAEHANA" width="32"></a>
+<a href="http://twitter.com/sandinist"><img alt="Tsuyoshi MAEHANA" height="32" src="https://www.gravatar.com/avatar/e8ebe7d4ec09c5dd77ee064706836f23?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tsuyoshi MAEHANA" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://sane.jp"><img alt="Murahashi Sanemat Kenichi" height="32" src="http://www.gravatar.com/avatar/5b1d016f87f05ff645ae572ccbbf0448?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Murahashi Sanemat Kenichi" width="32"></a>
+<a href="http://sane.jp"><img alt="Murahashi Sanemat Kenichi" height="32" src="https://www.gravatar.com/avatar/5b1d016f87f05ff645ae572ccbbf0448?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Murahashi Sanemat Kenichi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://aerial.st"><img alt="Masato Ikeda" height="32" src="http://www.gravatar.com/avatar/03abf5741b7bbd28670af5ec92b6141d?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masato Ikeda" width="32"></a>
+<a href="http://aerial.st"><img alt="Masato Ikeda" height="32" src="https://www.gravatar.com/avatar/03abf5741b7bbd28670af5ec92b6141d?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masato Ikeda" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/tex314"><img alt="OKAZAKI Takurou" height="32" src="http://www.gravatar.com/avatar/45c2cc1a731924edf1045d9146ca4a78?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="OKAZAKI Takurou" width="32"></a>
+<a href="http://twitter.com/tex314"><img alt="OKAZAKI Takurou" height="32" src="https://www.gravatar.com/avatar/45c2cc1a731924edf1045d9146ca4a78?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="OKAZAKI Takurou" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="https://twitter.com/toshi3221"><img alt="Toshiharu Takematsu" height="32" src="http://www.gravatar.com/avatar/3ca4621fbbb03278d4550f89e2f723ba?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Toshiharu Takematsu" width="32"></a>
+<a href="https://twitter.com/toshi3221"><img alt="Toshiharu Takematsu" height="32" src="https://www.gravatar.com/avatar/3ca4621fbbb03278d4550f89e2f723ba?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Toshiharu Takematsu" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://tdtds.jp"><img alt="TADA Tadashi" height="32" src="http://www.gravatar.com/avatar/846a80b9bf7ea7becb6c4ecd67bedd6f?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TADA Tadashi" width="32"></a>
+<a href="http://tdtds.jp"><img alt="TADA Tadashi" height="32" src="https://www.gravatar.com/avatar/846a80b9bf7ea7becb6c4ecd67bedd6f?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TADA Tadashi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://hisano.com"><img alt="HISANO Kozo" height="32" src="http://www.gravatar.com/avatar/b8fa07639c3b720c33ffdcaf89299dda?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="HISANO Kozo" width="32"></a>
+<a href="http://hisano.com"><img alt="HISANO Kozo" height="32" src="https://www.gravatar.com/avatar/b8fa07639c3b720c33ffdcaf89299dda?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="HISANO Kozo" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/kouma31/"><img alt="kmuroi" height="32" src="http://www.gravatar.com/avatar/165599097b8533c91af2aad5d7b31449?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="kmuroi" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<img alt="Anonymous" height="32" src="/2011/images/bow_face.png?1359134037" title="Anonymous" width="32">
-<a href="#"></a>
-</li>
-<li>
-<a href="http://twitter.com/h4n"><img alt="Han Kessels" height="32" src="http://www.gravatar.com/avatar/f0bd4ed83708d0af0e0d1374fc7e605b?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Han Kessels" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://twitter.com/takagi"><img alt="TAKAGI Masahiro" height="32" src="http://www.gravatar.com/avatar/c3f5a6e729b57f99cb9e7b3ca60152aa?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TAKAGI Masahiro" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://d.hatena.ne.jp/tmtms/"><img alt="TOMITA Masahiro" height="32" src="http://www.gravatar.com/avatar/e4763acee4cf0377437f614fc372a061?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TOMITA Masahiro" width="32"></a>
+<a href="http://d.hatena.ne.jp/kouma31/"><img alt="kmuroi" height="32" src="https://www.gravatar.com/avatar/165599097b8533c91af2aad5d7b31449?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="kmuroi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
@@ -2146,79 +2130,95 @@ Gold Sponsor
 <a href="#"></a>
 </li>
 <li>
-<a href="http://kmuto.jp/"><img alt="Kenshi Muto" height="32" src="http://www.gravatar.com/avatar/43d44fbc12adcf80c9fc24e235f48234?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kenshi Muto" width="32"></a>
+<a href="http://twitter.com/h4n"><img alt="Han Kessels" height="32" src="https://www.gravatar.com/avatar/f0bd4ed83708d0af0e0d1374fc7e605b?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Han Kessels" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<img alt="1syo" height="32" src="http://www.gravatar.com/avatar/83899fe2d00874176098a3bb71b043be?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="1syo" width="32">
+<a href="http://twitter.com/takagi"><img alt="TAKAGI Masahiro" height="32" src="https://www.gravatar.com/avatar/c3f5a6e729b57f99cb9e7b3ca60152aa?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TAKAGI Masahiro" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://fkino.net"><img alt="Fumihiko Kinoshita" height="32" src="http://www.gravatar.com/avatar/f301c0275838d562c72ea9177e7ddc68?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Fumihiko Kinoshita" width="32"></a>
+<a href="http://d.hatena.ne.jp/tmtms/"><img alt="TOMITA Masahiro" height="32" src="https://www.gravatar.com/avatar/e4763acee4cf0377437f614fc372a061?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TOMITA Masahiro" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://blog.masuidrive.jp/"><img alt="Yuichiro MASUI" height="32" src="http://www.gravatar.com/avatar/0ec58a040e1e4e959c8566484b4bba19?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yuichiro MASUI" width="32"></a>
+<img alt="Anonymous" height="32" src="/2011/images/bow_face.png?1359134037" title="Anonymous" width="32">
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/t2os/"><img alt="tatsuoSakurai" height="32" src="http://www.gravatar.com/avatar/092404bdf9897eba9ab16e61f56592db?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="tatsuoSakurai" width="32"></a>
+<a href="http://kmuto.jp/"><img alt="Kenshi Muto" height="32" src="https://www.gravatar.com/avatar/43d44fbc12adcf80c9fc24e235f48234?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kenshi Muto" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://ogijun.org"><img alt="Junya Ogino" height="32" src="http://www.gravatar.com/avatar/3a82321f68500d9691a9e190979ac2f0?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Junya Ogino" width="32"></a>
+<img alt="1syo" height="32" src="https://www.gravatar.com/avatar/83899fe2d00874176098a3bb71b043be?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="1syo" width="32">
 <a href="#"></a>
 </li>
 <li>
-<a href="http://about.me/mackato"><img alt="Masakuni Kato" height="32" src="http://www.gravatar.com/avatar/28347314c7fc698b4ac0e01113545e25?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masakuni Kato" width="32"></a>
+<a href="http://fkino.net"><img alt="Fumihiko Kinoshita" height="32" src="https://www.gravatar.com/avatar/f301c0275838d562c72ea9177e7ddc68?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Fumihiko Kinoshita" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/IWAKIRI"><img alt="IWAKIRI,Akiko" height="32" src="http://www.gravatar.com/avatar/2a02258781c7592d0da1cd5cffa627a8?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="IWAKIRI,Akiko" width="32"></a>
+<a href="http://blog.masuidrive.jp/"><img alt="Yuichiro MASUI" height="32" src="https://www.gravatar.com/avatar/0ec58a040e1e4e959c8566484b4bba19?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yuichiro MASUI" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://june29.jp/"><img alt="june29" height="32" src="http://www.gravatar.com/avatar/6fd9be5cd0196df5ad62a5a5f2be3c55?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="june29" width="32"></a>
+<a href="http://d.hatena.ne.jp/t2os/"><img alt="tatsuoSakurai" height="32" src="https://www.gravatar.com/avatar/092404bdf9897eba9ab16e61f56592db?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="tatsuoSakurai" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.socialtoprunners.jp/"><img alt="tomokazuhattanda" height="32" src="http://www.gravatar.com/avatar/19798587cb27b5220a5dcdbaa9a50d57?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="tomokazuhattanda" width="32"></a>
+<a href="http://ogijun.org"><img alt="Junya Ogino" height="32" src="https://www.gravatar.com/avatar/3a82321f68500d9691a9e190979ac2f0?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Junya Ogino" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.jamboree.jp/"><img alt="TOYOSHI, Ryuichiro" height="32" src="http://www.gravatar.com/avatar/203c324392b6c51241da5b42bbf888bd?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TOYOSHI, Ryuichiro" width="32"></a>
+<a href="http://about.me/mackato"><img alt="Masakuni Kato" height="32" src="https://www.gravatar.com/avatar/28347314c7fc698b4ac0e01113545e25?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masakuni Kato" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/takano32"><img alt="たかのみつひろ" height="32" src="http://www.gravatar.com/avatar/eba4a40bdae5edfe1589601c050a2b96?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="たかのみつひろ" width="32"></a>
+<a href="http://d.hatena.ne.jp/IWAKIRI"><img alt="IWAKIRI,Akiko" height="32" src="https://www.gravatar.com/avatar/2a02258781c7592d0da1cd5cffa627a8?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="IWAKIRI,Akiko" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/tyabe"><img alt="tyabe" height="32" src="http://www.gravatar.com/avatar/d21900444f5548d9329861593321b5a6?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="tyabe" width="32"></a>
+<a href="http://june29.jp/"><img alt="june29" height="32" src="https://www.gravatar.com/avatar/6fd9be5cd0196df5ad62a5a5f2be3c55?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="june29" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/#!/maxyz"><img alt="Masafumi Fujiwara" height="32" src="http://www.gravatar.com/avatar/4dd4d13d27559db2fb64ad069f2c49ba?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masafumi Fujiwara" width="32"></a>
+<a href="http://www.socialtoprunners.jp/"><img alt="tomokazuhattanda" height="32" src="https://www.gravatar.com/avatar/19798587cb27b5220a5dcdbaa9a50d57?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="tomokazuhattanda" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/kdmsnr"><img alt="Masanori Kado" height="32" src="http://www.gravatar.com/avatar/70b07e6b7fe7d921d7ac542d0ccb3b2c?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masanori Kado" width="32"></a>
+<a href="http://www.jamboree.jp/"><img alt="TOYOSHI, Ryuichiro" height="32" src="https://www.gravatar.com/avatar/203c324392b6c51241da5b42bbf888bd?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TOYOSHI, Ryuichiro" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.jitu.org/~tko"><img alt="Tomoyuki Kosimizu" height="32" src="http://www.gravatar.com/avatar/3585181753c22a9531e70a8297771b01?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomoyuki Kosimizu" width="32"></a>
+<a href="http://twitter.com/takano32"><img alt="たかのみつひろ" height="32" src="https://www.gravatar.com/avatar/eba4a40bdae5edfe1589601c050a2b96?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="たかのみつひろ" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/chinmo"><img alt="Tomonori Fukuta" height="32" src="http://www.gravatar.com/avatar/7977a0896e60587b2690550891be2ea7?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomonori Fukuta" width="32"></a>
+<a href="http://twitter.com/tyabe"><img alt="tyabe" height="32" src="https://www.gravatar.com/avatar/d21900444f5548d9329861593321b5a6?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="tyabe" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<img alt="YOKOTA Akiko" height="32" src="http://www.gravatar.com/avatar/03e548747e667fc94cc8495868bfd85e?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="YOKOTA Akiko" width="32">
+<a href="http://twitter.com/#!/maxyz"><img alt="Masafumi Fujiwara" height="32" src="https://www.gravatar.com/avatar/4dd4d13d27559db2fb64ad069f2c49ba?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masafumi Fujiwara" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://nov.tdiary.net/"><img alt="Nobuhiro IMAI" height="32" src="http://www.gravatar.com/avatar/e49ab9f0774711c473660019728cde95?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Nobuhiro IMAI" width="32"></a>
+<a href="http://twitter.com/kdmsnr"><img alt="Masanori Kado" height="32" src="https://www.gravatar.com/avatar/70b07e6b7fe7d921d7ac542d0ccb3b2c?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masanori Kado" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://www.jitu.org/~tko"><img alt="Tomoyuki Kosimizu" height="32" src="https://www.gravatar.com/avatar/3585181753c22a9531e70a8297771b01?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomoyuki Kosimizu" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://twitter.com/chinmo"><img alt="Tomonori Fukuta" height="32" src="https://www.gravatar.com/avatar/7977a0896e60587b2690550891be2ea7?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomonori Fukuta" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<img alt="YOKOTA Akiko" height="32" src="https://www.gravatar.com/avatar/03e548747e667fc94cc8495868bfd85e?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="YOKOTA Akiko" width="32">
+<a href="#"></a>
+</li>
+<li>
+<a href="http://nov.tdiary.net/"><img alt="Nobuhiro IMAI" height="32" src="https://www.gravatar.com/avatar/e49ab9f0774711c473660019728cde95?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Nobuhiro IMAI" width="32"></a>
 <a href="#"></a>
 </li>
 </ul>

--- a/2011/en/sponsors/index.html
+++ b/2011/en/sponsors/index.html
@@ -240,55 +240,39 @@ Gold Sponsor
 </h2>
 <ul>
 <li>
-<a href="http://shyouhei.tumblr.com"><img alt="Urabe, Shyouhei" height="32" src="http://www.gravatar.com/avatar/9d2f78236e45a335301ba1195026105d?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Urabe, Shyouhei" width="32"></a>
+<a href="http://shyouhei.tumblr.com"><img alt="Urabe, Shyouhei" height="32" src="https://www.gravatar.com/avatar/9d2f78236e45a335301ba1195026105d?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Urabe, Shyouhei" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/noplans"><img alt="TANIGUCHI Fumitake" height="32" src="http://www.gravatar.com/avatar/e514ae09c9b84e04231af57f1d1946b8?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TANIGUCHI Fumitake" width="32"></a>
+<a href="http://twitter.com/noplans"><img alt="TANIGUCHI Fumitake" height="32" src="https://www.gravatar.com/avatar/e514ae09c9b84e04231af57f1d1946b8?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TANIGUCHI Fumitake" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://jmettraux.wordpress.com"><img alt="John Mettraux" height="32" src="http://www.gravatar.com/avatar/8d96626e52beb1ff90f57a8e189e1e6f?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="John Mettraux" width="32"></a>
+<a href="http://jmettraux.wordpress.com"><img alt="John Mettraux" height="32" src="https://www.gravatar.com/avatar/8d96626e52beb1ff90f57a8e189e1e6f?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="John Mettraux" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/japanrock"><img alt="Shintaro Nozaki" height="32" src="http://www.gravatar.com/avatar/b31a258dd8f615f61b2d355297f82dc9?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shintaro Nozaki" width="32"></a>
+<a href="http://twitter.com/japanrock"><img alt="Shintaro Nozaki" height="32" src="https://www.gravatar.com/avatar/b31a258dd8f615f61b2d355297f82dc9?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shintaro Nozaki" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://blog.dio.jp"><img alt="Akira Matsuda" height="32" src="http://www.gravatar.com/avatar/76a777ff80f30bd3b390e275cce625bc?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Akira Matsuda" width="32"></a>
+<a href="http://blog.dio.jp"><img alt="Akira Matsuda" height="32" src="https://www.gravatar.com/avatar/76a777ff80f30bd3b390e275cce625bc?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Akira Matsuda" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.bovensiepen.net"><img alt="Daniel Bovensiepen" height="32" src="http://www.gravatar.com/avatar/49d6f762505615af259534deed94bc54?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Daniel Bovensiepen" width="32"></a>
+<a href="http://www.bovensiepen.net"><img alt="Daniel Bovensiepen" height="32" src="https://www.gravatar.com/avatar/49d6f762505615af259534deed94bc54?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Daniel Bovensiepen" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://firn.jp/"><img alt="Dai Akatsuka" height="32" src="http://www.gravatar.com/avatar/4efe7b5cdbe97df84e6e607948171eef?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Dai Akatsuka" width="32"></a>
+<a href="http://firn.jp/"><img alt="Dai Akatsuka" height="32" src="https://www.gravatar.com/avatar/4efe7b5cdbe97df84e6e607948171eef?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Dai Akatsuka" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.din.or.jp/~shinodas/"><img alt="Yoshihiko Hara" height="32" src="http://www.gravatar.com/avatar/8055fbffa700065178460bb7e3b8ee24?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yoshihiko Hara" width="32"></a>
+<a href="http://www.din.or.jp/~shinodas/"><img alt="Yoshihiko Hara" height="32" src="https://www.gravatar.com/avatar/8055fbffa700065178460bb7e3b8ee24?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yoshihiko Hara" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://benhoskin.gs"><img alt="Ben Hoskings" height="32" src="http://www.gravatar.com/avatar/7ed99cb90a060539d729e2491442a603?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ben Hoskings" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<img alt="Anonymous" height="32" src="/2011/images/bow_face.png?1359134037" title="Anonymous" width="32">
-<a href="#"></a>
-</li>
-<li>
-<a href="http://www.nextseed.jp/"><img alt="Hitoshi Kurokawa" height="32" src="http://www.gravatar.com/avatar/11e89e3c85d9998b2c73933bde77c71e?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hitoshi Kurokawa" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://d.hatena.ne.jp/kinpoco/"><img alt="Yutaka Kanemoto" height="32" src="http://www.gravatar.com/avatar/0e728bf538d1848bc253d80a8626bbc2?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yutaka Kanemoto" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://d.hatena.ne.jp/yuichi_katahira"><img alt="Yuichi Katahira " height="32" src="http://www.gravatar.com/avatar/3072ae08f580fc8474b47652a3d8dd0f?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yuichi Katahira " width="32"></a>
+<a href="http://benhoskin.gs"><img alt="Ben Hoskings" height="32" src="https://www.gravatar.com/avatar/7ed99cb90a060539d729e2491442a603?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ben Hoskings" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
@@ -296,87 +280,15 @@ Gold Sponsor
 <a href="#"></a>
 </li>
 <li>
-<a href="http://kitaj.no-ip.com/tdiary/"><img alt="Junichiro Kita" height="32" src="http://www.gravatar.com/avatar/70405ca68e6f8779be65e75b1a90525b?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Junichiro Kita" width="32"></a>
+<a href="http://www.nextseed.jp/"><img alt="Hitoshi Kurokawa" height="32" src="https://www.gravatar.com/avatar/11e89e3c85d9998b2c73933bde77c71e?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hitoshi Kurokawa" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/idesaku"><img alt="Daisuke Goto" height="32" src="http://www.gravatar.com/avatar/85c8086344e5f31b2a4d22f163660536?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Daisuke Goto" width="32"></a>
+<a href="http://d.hatena.ne.jp/kinpoco/"><img alt="Yutaka Kanemoto" height="32" src="https://www.gravatar.com/avatar/0e728bf538d1848bc253d80a8626bbc2?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yutaka Kanemoto" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<img alt="Anonymous" height="32" src="/2011/images/bow_face.png?1359134037" title="Anonymous" width="32">
-<a href="#"></a>
-</li>
-<li>
-<a href="http://www.on-sky.net/~hs/"><img alt="Hideki SAKAMOTO" height="32" src="http://www.gravatar.com/avatar/7038a6cfc30b8c3b00b5c08d70cda2f1?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hideki SAKAMOTO" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://twitter.com/agilekawabata"><img alt="Kawabata Mitsuyoshi" height="32" src="http://www.gravatar.com/avatar/5236eb3ad498b3c5336a4575408fb1b1?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kawabata Mitsuyoshi" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://www.kt.rim.or.jp/~kbk/"><img alt="KIMURA Koichi" height="32" src="http://www.gravatar.com/avatar/04c1a31d1e33e7fc25a7ca99930e4c70?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="KIMURA Koichi" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://d.hatena.ne.jp/takkaw/"><img alt="Takayoshi Kawada" height="32" src="http://www.gravatar.com/avatar/38bf2ca557d9cc20dcdcbd773a68664b?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takayoshi Kawada" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://www.suchi.org/"><img alt="Shigeru UCHIYAMA" height="32" src="http://www.gravatar.com/avatar/398e2dd764d43aad735c6e5bca92c3b6?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shigeru UCHIYAMA" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://twitter.com/#!/andrewjgrimm"><img alt="Andrew Grimm" height="32" src="http://www.gravatar.com/avatar/01bbb59a1c3ef9960f25a97afe7e920f?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Andrew Grimm" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://twitter.com/kimuraw"><img alt="kimura wataru" height="32" src="http://www.gravatar.com/avatar/e298234a6e5a2c159287476abd76504a?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="kimura wataru" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://saikyoline.jp/"><img alt="MIKAMI Yoshiyuki" height="32" src="http://www.gravatar.com/avatar/e0920f5f813ae29ba7859f950a7f0df3?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MIKAMI Yoshiyuki" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://jp.rubyist.net/?KansaiWorkshop"><img alt="HIGAKI Masaru" height="32" src="http://www.gravatar.com/avatar/a8192f5a7b25ef32a983740ee8593bd3?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="HIGAKI Masaru" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://twitter.com/ayumin"><img alt="Ayumu AIZAWA" height="32" src="http://www.gravatar.com/avatar/2e9a2dbe335e0111e4879a9d65dcbae0?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ayumu AIZAWA" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://shunichi-arai.blogspot.com/"><img alt="Shunichi Arai" height="32" src="http://www.gravatar.com/avatar/74daf3516e33a75968ec0f933954b5a8?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shunichi Arai" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://www.tokyodev.com"><img alt="Paul McMahon" height="32" src="http://www.gravatar.com/avatar/dd24adb5a3a430fed83a33ed552fe1b5?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Paul McMahon" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://d.hatena.ne.jp/hs9587/"><img alt="Hiroyuki Shimura" height="32" src="http://www.gravatar.com/avatar/287a899c91a7a14535188d7e4784050e?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hiroyuki Shimura" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://kakutani.com"><img alt="Kakutani Shintaro" height="32" src="http://www.gravatar.com/avatar/34fcd5f1deeb25b1138e9845137feb6e?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kakutani Shintaro" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://d.hatena.ne.jp/mrkn"><img alt="Kenta Murata" height="32" src="http://www.gravatar.com/avatar/819b3c0a25f9708fd32261b8ae2d23f6?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kenta Murata" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://rails.to"><img alt="Masatoshi Itagaki" height="32" src="http://www.gravatar.com/avatar/f8865f41777ef3caced0e4e6801ff83a?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masatoshi Itagaki" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://spring-aki.com/"><img alt="Aki" height="32" src="http://www.gravatar.com/avatar/81f2122b45f48829be4507bf972666e9?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Aki" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://twitter.com/shin_asou"><img alt="Shinichi Okada" height="32" src="http://www.gravatar.com/avatar/20805358592bd93f92bf15aa10137251?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shinichi Okada" width="32"></a>
+<a href="http://d.hatena.ne.jp/yuichi_katahira"><img alt="Yuichi Katahira " height="32" src="https://www.gravatar.com/avatar/3072ae08f580fc8474b47652a3d8dd0f?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yuichi Katahira " width="32"></a>
 <a href="#"></a>
 </li>
 <li>
@@ -384,35 +296,11 @@ Gold Sponsor
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.kumaryu.net/"><img alt="Ryuichi Sakamoto" height="32" src="http://www.gravatar.com/avatar/1b2ca00132480422c75c1f2c61e84e26?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ryuichi Sakamoto" width="32"></a>
+<a href="http://kitaj.no-ip.com/tdiary/"><img alt="Junichiro Kita" height="32" src="https://www.gravatar.com/avatar/70405ca68e6f8779be65e75b1a90525b?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Junichiro Kita" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<img alt="Eito Katagiri" height="32" src="http://www.gravatar.com/avatar/b5852cf79505d7ba513f8f16ef95a50f?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Eito Katagiri" width="32">
-<a href="#"></a>
-</li>
-<li>
-<a href="http://ukstudio.jp/"><img alt="AKAMATSU Yuki" height="32" src="http://www.gravatar.com/avatar/0c471249ee93ab17a011f3e8d2b1057a?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="AKAMATSU Yuki" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://hisashim.org"><img alt="Hisashi Morita" height="32" src="http://www.gravatar.com/avatar/b3fba7af93cd27e6ed28e7eae88a9585?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hisashi Morita" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://d.hatena.ne.jp/muryoImpl/"><img alt="Ken muryoi" height="32" src="http://www.gravatar.com/avatar/ac6dba8ce93944d17714de362ca17e54?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ken muryoi" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://d.hatena.ne.jp/nagachika/"><img alt="Tomoyuki Chikanaga" height="32" src="http://www.gravatar.com/avatar/5cf8f058a4c094bb708174fb43e7a387?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomoyuki Chikanaga" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://d.hatena.ne.jp/takeshinoda/"><img alt="Takeshi SHINODA" height="32" src="http://www.gravatar.com/avatar/06febd004d7cc9c9f6a4e0272b686bc7?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takeshi SHINODA" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://twitter.com/knsmr"><img alt="Ken Nishimura" height="32" src="http://www.gravatar.com/avatar/91fb4852880d1727cca911036e2fef5f?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ken Nishimura" width="32"></a>
+<a href="http://d.hatena.ne.jp/idesaku"><img alt="Daisuke Goto" height="32" src="https://www.gravatar.com/avatar/85c8086344e5f31b2a4d22f163660536?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Daisuke Goto" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
@@ -420,35 +308,75 @@ Gold Sponsor
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/koko_u/"><img alt="Kozaki Tsuneaki" height="32" src="http://www.gravatar.com/avatar/5b1b558d563288da615a9ea2889afdd5?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kozaki Tsuneaki" width="32"></a>
+<a href="http://www.on-sky.net/~hs/"><img alt="Hideki SAKAMOTO" height="32" src="https://www.gravatar.com/avatar/7038a6cfc30b8c3b00b5c08d70cda2f1?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hideki SAKAMOTO" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/adzuki34"><img alt="SUZUKI Miho" height="32" src="http://www.gravatar.com/avatar/f37b9a968b2326062190677906a93080?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="SUZUKI Miho" width="32"></a>
+<a href="http://twitter.com/agilekawabata"><img alt="Kawabata Mitsuyoshi" height="32" src="https://www.gravatar.com/avatar/5236eb3ad498b3c5336a4575408fb1b1?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kawabata Mitsuyoshi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/lchin"><img alt="Leonard Chin" height="32" src="http://www.gravatar.com/avatar/70762059db0218c6f0ff48042ca0756a?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Leonard Chin" width="32"></a>
+<a href="http://www.kt.rim.or.jp/~kbk/"><img alt="KIMURA Koichi" height="32" src="https://www.gravatar.com/avatar/04c1a31d1e33e7fc25a7ca99930e4c70?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="KIMURA Koichi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/suzumura_ss/"><img alt="Toshiyuki Terashita" height="32" src="http://www.gravatar.com/avatar/bb8b58cab667163b6ee53aad0e5f0414?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Toshiyuki Terashita" width="32"></a>
+<a href="http://d.hatena.ne.jp/takkaw/"><img alt="Takayoshi Kawada" height="32" src="https://www.gravatar.com/avatar/38bf2ca557d9cc20dcdcbd773a68664b?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takayoshi Kawada" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://sites.google.com/site/akihikohashimoto/"><img alt="Akihiko Hashimoto" height="32" src="http://www.gravatar.com/avatar/c8803a4130c3238e34b605d0a0cffe94?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Akihiko Hashimoto" width="32"></a>
+<a href="http://www.suchi.org/"><img alt="Shigeru UCHIYAMA" height="32" src="https://www.gravatar.com/avatar/398e2dd764d43aad735c6e5bca92c3b6?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shigeru UCHIYAMA" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<img alt="OZAWA Sakuro" height="32" src="http://www.gravatar.com/avatar/a1cbed8bf64473e2acdd0c7066cc5b29?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="OZAWA Sakuro" width="32">
+<a href="http://twitter.com/#!/andrewjgrimm"><img alt="Andrew Grimm" height="32" src="https://www.gravatar.com/avatar/01bbb59a1c3ef9960f25a97afe7e920f?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Andrew Grimm" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://fkmn.exblog.jp/"><img alt="Arinobu FUKUHARA" height="32" src="http://www.gravatar.com/avatar/85319f2b72d7b37ddef5c25a2dd40d30?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Arinobu FUKUHARA" width="32"></a>
+<a href="http://twitter.com/kimuraw"><img alt="kimura wataru" height="32" src="https://www.gravatar.com/avatar/e298234a6e5a2c159287476abd76504a?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="kimura wataru" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/shachi"><img alt="Kazuyuki Koizuka-shachi" height="32" src="http://www.gravatar.com/avatar/f51ee84097a72a8d91bee9bb98736541?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kazuyuki Koizuka-shachi" width="32"></a>
+<a href="http://saikyoline.jp/"><img alt="MIKAMI Yoshiyuki" height="32" src="https://www.gravatar.com/avatar/e0920f5f813ae29ba7859f950a7f0df3?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MIKAMI Yoshiyuki" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://jp.rubyist.net/?KansaiWorkshop"><img alt="HIGAKI Masaru" height="32" src="https://www.gravatar.com/avatar/a8192f5a7b25ef32a983740ee8593bd3?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="HIGAKI Masaru" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://twitter.com/ayumin"><img alt="Ayumu AIZAWA" height="32" src="https://www.gravatar.com/avatar/2e9a2dbe335e0111e4879a9d65dcbae0?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ayumu AIZAWA" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://shunichi-arai.blogspot.com/"><img alt="Shunichi Arai" height="32" src="https://www.gravatar.com/avatar/74daf3516e33a75968ec0f933954b5a8?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shunichi Arai" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://www.tokyodev.com"><img alt="Paul McMahon" height="32" src="https://www.gravatar.com/avatar/dd24adb5a3a430fed83a33ed552fe1b5?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Paul McMahon" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://d.hatena.ne.jp/hs9587/"><img alt="Hiroyuki Shimura" height="32" src="https://www.gravatar.com/avatar/287a899c91a7a14535188d7e4784050e?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hiroyuki Shimura" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://kakutani.com"><img alt="Kakutani Shintaro" height="32" src="https://www.gravatar.com/avatar/34fcd5f1deeb25b1138e9845137feb6e?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kakutani Shintaro" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://d.hatena.ne.jp/mrkn"><img alt="Kenta Murata" height="32" src="https://www.gravatar.com/avatar/819b3c0a25f9708fd32261b8ae2d23f6?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kenta Murata" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://rails.to"><img alt="Masatoshi Itagaki" height="32" src="https://www.gravatar.com/avatar/f8865f41777ef3caced0e4e6801ff83a?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masatoshi Itagaki" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://spring-aki.com/"><img alt="Aki" height="32" src="https://www.gravatar.com/avatar/81f2122b45f48829be4507bf972666e9?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Aki" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://twitter.com/shin_asou"><img alt="Shinichi Okada" height="32" src="https://www.gravatar.com/avatar/20805358592bd93f92bf15aa10137251?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shinichi Okada" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
@@ -456,103 +384,175 @@ Gold Sponsor
 <a href="#"></a>
 </li>
 <li>
-<a href="http://atakigu.tumblr.com/"><img alt="atakig" height="32" src="http://www.gravatar.com/avatar/8a949c60e450d226de776072273a1ffc?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="atakig" width="32"></a>
+<a href="http://www.kumaryu.net/"><img alt="Ryuichi Sakamoto" height="32" src="https://www.gravatar.com/avatar/1b2ca00132480422c75c1f2c61e84e26?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ryuichi Sakamoto" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<img alt="TSUTSUI Toshinori" height="32" src="http://www.gravatar.com/avatar/ad66fd981c429c12e0f76c436da3337e?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TSUTSUI Toshinori" width="32">
+<img alt="Eito Katagiri" height="32" src="https://www.gravatar.com/avatar/b5852cf79505d7ba513f8f16ef95a50f?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Eito Katagiri" width="32">
 <a href="#"></a>
 </li>
 <li>
-<a href="http://yugui.jp"><img alt="Yuki Sonoda (Yugui)" height="32" src="http://www.gravatar.com/avatar/1e7e007723cfe59320d994a7db4ab4cf?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yuki Sonoda (Yugui)" width="32"></a>
+<a href="http://ukstudio.jp/"><img alt="AKAMATSU Yuki" height="32" src="https://www.gravatar.com/avatar/0c471249ee93ab17a011f3e8d2b1057a?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="AKAMATSU Yuki" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/seiunsky"><img alt="sugamasao" height="32" src="http://www.gravatar.com/avatar/961126d9892ae4df45249529a0721571?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="sugamasao" width="32"></a>
+<a href="http://hisashim.org"><img alt="Hisashi Morita" height="32" src="https://www.gravatar.com/avatar/b3fba7af93cd27e6ed28e7eae88a9585?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hisashi Morita" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/mkgin/"><img alt="Makoto Kouno" height="32" src="http://www.gravatar.com/avatar/06e6dcde277cbe5c614baf5d25871025?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Makoto Kouno" width="32"></a>
+<a href="http://d.hatena.ne.jp/muryoImpl/"><img alt="Ken muryoi" height="32" src="https://www.gravatar.com/avatar/ac6dba8ce93944d17714de362ca17e54?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ken muryoi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/suzuki"><img alt="Norio Suzuki" height="32" src="http://www.gravatar.com/avatar/8e528456ff66ec543952daa815353a01?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Norio Suzuki" width="32"></a>
+<a href="http://d.hatena.ne.jp/nagachika/"><img alt="Tomoyuki Chikanaga" height="32" src="https://www.gravatar.com/avatar/5cf8f058a4c094bb708174fb43e7a387?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomoyuki Chikanaga" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.artonx.org"><img alt="Akio Tajima" height="32" src="http://www.gravatar.com/avatar/0441ff038018e53a35bb207e81105a5c?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Akio Tajima" width="32"></a>
+<a href="http://d.hatena.ne.jp/takeshinoda/"><img alt="Takeshi SHINODA" height="32" src="https://www.gravatar.com/avatar/06febd004d7cc9c9f6a4e0272b686bc7?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takeshi SHINODA" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://moonrock.jp/~don/"><img alt="Hiroyuki Iwatsuki" height="32" src="http://www.gravatar.com/avatar/cb1f0f80c3fe2729ba593656772c266d?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hiroyuki Iwatsuki" width="32"></a>
+<a href="http://twitter.com/knsmr"><img alt="Ken Nishimura" height="32" src="https://www.gravatar.com/avatar/91fb4852880d1727cca911036e2fef5f?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ken Nishimura" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/monyakata/"><img alt="MUNAKATA Akiko" height="32" src="http://www.gravatar.com/avatar/55a6db4b079c962f72adb014055e9a28?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MUNAKATA Akiko" width="32"></a>
+<img alt="Anonymous" height="32" src="/2011/images/bow_face.png?1359134037" title="Anonymous" width="32">
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.bawdo.com"><img alt="Keith Bawden" height="32" src="http://www.gravatar.com/avatar/a6cc567a6b77ee09f7363d175455593b?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Keith Bawden" width="32"></a>
+<a href="http://d.hatena.ne.jp/koko_u/"><img alt="Kozaki Tsuneaki" height="32" src="https://www.gravatar.com/avatar/5b1b558d563288da615a9ea2889afdd5?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kozaki Tsuneaki" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<img alt="Norihito Yoshioka" height="32" src="http://www.gravatar.com/avatar/c6033734a5b01f43cca06773ea9ff1fe?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Norihito Yoshioka" width="32">
+<a href="http://twitter.com/adzuki34"><img alt="SUZUKI Miho" height="32" src="https://www.gravatar.com/avatar/f37b9a968b2326062190677906a93080?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="SUZUKI Miho" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/vestige/"><img alt="makoto yonezawa" height="32" src="http://www.gravatar.com/avatar/8da7ceb361c63bd6622fe33153a0293b?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="makoto yonezawa" width="32"></a>
+<a href="http://twitter.com/lchin"><img alt="Leonard Chin" height="32" src="https://www.gravatar.com/avatar/70762059db0218c6f0ff48042ca0756a?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Leonard Chin" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="https://twitter.com/tsuboi"><img alt="Sougo TSUBOI" height="32" src="http://www.gravatar.com/avatar/847bf4e3766b2e17cafef8e83b046db1?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Sougo TSUBOI" width="32"></a>
+<a href="http://d.hatena.ne.jp/suzumura_ss/"><img alt="Toshiyuki Terashita" height="32" src="https://www.gravatar.com/avatar/bb8b58cab667163b6ee53aad0e5f0414?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Toshiyuki Terashita" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/#!/mojamoja_mixi"><img alt="MojaMoja" height="32" src="http://www.gravatar.com/avatar/7b0d6fc806322376d65cbb95d40bc176?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MojaMoja" width="32"></a>
+<a href="http://sites.google.com/site/akihikohashimoto/"><img alt="Akihiko Hashimoto" height="32" src="https://www.gravatar.com/avatar/c8803a4130c3238e34b605d0a0cffe94?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Akihiko Hashimoto" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/takkanm"><img alt="mitsutaka mimura" height="32" src="http://www.gravatar.com/avatar/8f39a252784d5a99589be6e20c4553fb?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="mitsutaka mimura" width="32"></a>
+<img alt="OZAWA Sakuro" height="32" src="https://www.gravatar.com/avatar/a1cbed8bf64473e2acdd0c7066cc5b29?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="OZAWA Sakuro" width="32">
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/dan5ya"><img alt="Dan Yamamoto" height="32" src="http://www.gravatar.com/avatar/ffaa5dad365d5bb5025f4126bb54676c?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Dan Yamamoto" width="32"></a>
+<a href="http://fkmn.exblog.jp/"><img alt="Arinobu FUKUHARA" height="32" src="https://www.gravatar.com/avatar/85319f2b72d7b37ddef5c25a2dd40d30?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Arinobu FUKUHARA" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.hsbt.org/"><img alt="SHIBATA Hiroshi" height="32" src="http://www.gravatar.com/avatar/eabad423977cfc6873b8f5df62b848a6?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="SHIBATA Hiroshi" width="32"></a>
+<a href="http://twitter.com/shachi"><img alt="Kazuyuki Koizuka-shachi" height="32" src="https://www.gravatar.com/avatar/f51ee84097a72a8d91bee9bb98736541?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kazuyuki Koizuka-shachi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/moro/"><img alt="MOROHASHI Kyosuke" height="32" src="http://www.gravatar.com/avatar/70e13d9877054026fda46d5a5b53a236?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MOROHASHI Kyosuke" width="32"></a>
+<img alt="Anonymous" height="32" src="/2011/images/bow_face.png?1359134037" title="Anonymous" width="32">
 <a href="#"></a>
 </li>
 <li>
-<a href="http://rsss.be/hibariya"><img alt="Hibariya Hi" height="32" src="http://www.gravatar.com/avatar/de0df5acda15a9c7eeb6c28a5e5d4e8e?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hibariya Hi" width="32"></a>
+<a href="http://atakigu.tumblr.com/"><img alt="atakig" height="32" src="https://www.gravatar.com/avatar/8a949c60e450d226de776072273a1ffc?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="atakig" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/kyanny"><img alt="Kensuke Nagae" height="32" src="http://www.gravatar.com/avatar/fffd8bf62b842a46803fb07792029fa4?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kensuke Nagae" width="32"></a>
+<img alt="TSUTSUI Toshinori" height="32" src="https://www.gravatar.com/avatar/ad66fd981c429c12e0f76c436da3337e?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TSUTSUI Toshinori" width="32">
 <a href="#"></a>
 </li>
 <li>
-<img alt="oku23" height="32" src="http://www.gravatar.com/avatar/3725ec1dce281fb187d798a9b9ddc9d3?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="oku23" width="32">
+<a href="http://yugui.jp"><img alt="Yuki Sonoda (Yugui)" height="32" src="https://www.gravatar.com/avatar/1e7e007723cfe59320d994a7db4ab4cf?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yuki Sonoda (Yugui)" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://ko.meadowy.net/~koichiro/diary/"><img alt="Koichiro Ohba" height="32" src="http://www.gravatar.com/avatar/1ce18b10bd8f911566c5577042b6a44c?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Koichiro Ohba" width="32"></a>
+<a href="http://d.hatena.ne.jp/seiunsky"><img alt="sugamasao" height="32" src="https://www.gravatar.com/avatar/961126d9892ae4df45249529a0721571?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="sugamasao" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.flickr.com/photos/t-seto"><img alt="せとん" height="32" src="http://www.gravatar.com/avatar/ac007a5b84f817d8cc80a3c208ea0181?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="せとん" width="32"></a>
+<a href="http://d.hatena.ne.jp/mkgin/"><img alt="Makoto Kouno" height="32" src="https://www.gravatar.com/avatar/06e6dcde277cbe5c614baf5d25871025?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Makoto Kouno" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/#!/tsuyoshikawa"><img alt="Tsuyoshi Yoshikawa" height="32" src="http://www.gravatar.com/avatar/6969ade78c1eaff0d08c76020fc80e83?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tsuyoshi Yoshikawa" width="32"></a>
+<a href="http://twitter.com/suzuki"><img alt="Norio Suzuki" height="32" src="https://www.gravatar.com/avatar/8e528456ff66ec543952daa815353a01?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Norio Suzuki" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.water-lily.biz/"><img alt="Water Lily LLC" height="32" src="http://www.gravatar.com/avatar/0734b8ec5eed71892e5db432856f4f40?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Water Lily LLC" width="32"></a>
+<a href="http://www.artonx.org"><img alt="Akio Tajima" height="32" src="https://www.gravatar.com/avatar/0441ff038018e53a35bb207e81105a5c?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Akio Tajima" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://moonrock.jp/~don/"><img alt="Hiroyuki Iwatsuki" height="32" src="https://www.gravatar.com/avatar/cb1f0f80c3fe2729ba593656772c266d?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hiroyuki Iwatsuki" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://d.hatena.ne.jp/monyakata/"><img alt="MUNAKATA Akiko" height="32" src="https://www.gravatar.com/avatar/55a6db4b079c962f72adb014055e9a28?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MUNAKATA Akiko" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://www.bawdo.com"><img alt="Keith Bawden" height="32" src="https://www.gravatar.com/avatar/a6cc567a6b77ee09f7363d175455593b?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Keith Bawden" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<img alt="Norihito Yoshioka" height="32" src="https://www.gravatar.com/avatar/c6033734a5b01f43cca06773ea9ff1fe?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Norihito Yoshioka" width="32">
+<a href="#"></a>
+</li>
+<li>
+<a href="http://d.hatena.ne.jp/vestige/"><img alt="makoto yonezawa" height="32" src="https://www.gravatar.com/avatar/8da7ceb361c63bd6622fe33153a0293b?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="makoto yonezawa" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="https://twitter.com/tsuboi"><img alt="Sougo TSUBOI" height="32" src="https://www.gravatar.com/avatar/847bf4e3766b2e17cafef8e83b046db1?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Sougo TSUBOI" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://twitter.com/#!/mojamoja_mixi"><img alt="MojaMoja" height="32" src="https://www.gravatar.com/avatar/7b0d6fc806322376d65cbb95d40bc176?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MojaMoja" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://twitter.com/takkanm"><img alt="mitsutaka mimura" height="32" src="https://www.gravatar.com/avatar/8f39a252784d5a99589be6e20c4553fb?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="mitsutaka mimura" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://twitter.com/dan5ya"><img alt="Dan Yamamoto" height="32" src="https://www.gravatar.com/avatar/ffaa5dad365d5bb5025f4126bb54676c?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Dan Yamamoto" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://www.hsbt.org/"><img alt="SHIBATA Hiroshi" height="32" src="https://www.gravatar.com/avatar/eabad423977cfc6873b8f5df62b848a6?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="SHIBATA Hiroshi" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://d.hatena.ne.jp/moro/"><img alt="MOROHASHI Kyosuke" height="32" src="https://www.gravatar.com/avatar/70e13d9877054026fda46d5a5b53a236?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MOROHASHI Kyosuke" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://rsss.be/hibariya"><img alt="Hibariya Hi" height="32" src="https://www.gravatar.com/avatar/de0df5acda15a9c7eeb6c28a5e5d4e8e?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hibariya Hi" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://twitter.com/kyanny"><img alt="Kensuke Nagae" height="32" src="https://www.gravatar.com/avatar/fffd8bf62b842a46803fb07792029fa4?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kensuke Nagae" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<img alt="oku23" height="32" src="https://www.gravatar.com/avatar/3725ec1dce281fb187d798a9b9ddc9d3?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="oku23" width="32">
+<a href="#"></a>
+</li>
+<li>
+<a href="http://ko.meadowy.net/~koichiro/diary/"><img alt="Koichiro Ohba" height="32" src="https://www.gravatar.com/avatar/1ce18b10bd8f911566c5577042b6a44c?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Koichiro Ohba" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://www.flickr.com/photos/t-seto"><img alt="せとん" height="32" src="https://www.gravatar.com/avatar/ac007a5b84f817d8cc80a3c208ea0181?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="せとん" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://twitter.com/#!/tsuyoshikawa"><img alt="Tsuyoshi Yoshikawa" height="32" src="https://www.gravatar.com/avatar/6969ade78c1eaff0d08c76020fc80e83?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tsuyoshi Yoshikawa" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://www.water-lily.biz/"><img alt="Water Lily LLC" height="32" src="https://www.gravatar.com/avatar/0734b8ec5eed71892e5db432856f4f40?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Water Lily LLC" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
@@ -560,115 +560,99 @@ Gold Sponsor
 <a href="#"></a>
 </li>
 <li>
-<a href="http://web-engineer.buyuden.net/blog/kawai/"><img alt="Takeshi Kawai" height="32" src="http://www.gravatar.com/avatar/6b53e472c9200f5ed61d7a6db0a28986?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takeshi Kawai" width="32"></a>
+<a href="http://web-engineer.buyuden.net/blog/kawai/"><img alt="Takeshi Kawai" height="32" src="https://www.gravatar.com/avatar/6b53e472c9200f5ed61d7a6db0a28986?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takeshi Kawai" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/k3c/"><img alt="KANEKO Seiji" height="32" src="http://www.gravatar.com/avatar/63d3818b5c107a6483a1d2e2767be4c5?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="KANEKO Seiji" width="32"></a>
+<a href="http://d.hatena.ne.jp/k3c/"><img alt="KANEKO Seiji" height="32" src="https://www.gravatar.com/avatar/63d3818b5c107a6483a1d2e2767be4c5?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="KANEKO Seiji" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.famlog.jp/"><img alt="Atsushi Matsuo" height="32" src="http://www.gravatar.com/avatar/0a4da00dbfd37e7f06ef8dceb58ca0c1?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Atsushi Matsuo" width="32"></a>
+<a href="http://www.famlog.jp/"><img alt="Atsushi Matsuo" height="32" src="https://www.gravatar.com/avatar/0a4da00dbfd37e7f06ef8dceb58ca0c1?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Atsushi Matsuo" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://m.igrs.jp/"><img alt="Masato Igarashi" height="32" src="http://www.gravatar.com/avatar/6fd2e23d73c26ccbd7df9e3eefacd3ae?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masato Igarashi" width="32"></a>
+<a href="http://m.igrs.jp/"><img alt="Masato Igarashi" height="32" src="https://www.gravatar.com/avatar/6fd2e23d73c26ccbd7df9e3eefacd3ae?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masato Igarashi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://resume.github.com/?walf443"><img alt="Keiji Yoshimi" height="32" src="http://www.gravatar.com/avatar/dea4fe079aec284744ad02eb3d2594f5?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Keiji Yoshimi" width="32"></a>
+<a href="http://resume.github.com/?walf443"><img alt="Keiji Yoshimi" height="32" src="https://www.gravatar.com/avatar/dea4fe079aec284744ad02eb3d2594f5?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Keiji Yoshimi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://gunjisatoshi.appspot.com/"><img alt="GUNJI Satoshi" height="32" src="http://www.gravatar.com/avatar/e6980e09fdff8f481b70f2e1f241231d?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="GUNJI Satoshi" width="32"></a>
+<a href="http://gunjisatoshi.appspot.com/"><img alt="GUNJI Satoshi" height="32" src="https://www.gravatar.com/avatar/e6980e09fdff8f481b70f2e1f241231d?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="GUNJI Satoshi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<img alt="Hisashi Yamaeda" height="32" src="http://www.gravatar.com/avatar/01ca4ebeee47c9b4d6ba9ad58db694a0?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hisashi Yamaeda" width="32">
+<img alt="Hisashi Yamaeda" height="32" src="https://www.gravatar.com/avatar/01ca4ebeee47c9b4d6ba9ad58db694a0?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hisashi Yamaeda" width="32">
 <a href="#"></a>
 </li>
 <li>
-<img alt="gekidanyonin" height="32" src="http://www.gravatar.com/avatar/2b196f1723fdbcbf7bd297b3e7f8cd3c?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="gekidanyonin" width="32">
+<img alt="gekidanyonin" height="32" src="https://www.gravatar.com/avatar/2b196f1723fdbcbf7bd297b3e7f8cd3c?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="gekidanyonin" width="32">
 <a href="#"></a>
 </li>
 <li>
-<a href="http://jp.linkedin.com/in/nakaomitsuteru"><img alt="Mitsuteru Nakao" height="32" src="http://www.gravatar.com/avatar/9090e122cba40b90124ea8eb4859bf8e?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Mitsuteru Nakao" width="32"></a>
+<a href="http://jp.linkedin.com/in/nakaomitsuteru"><img alt="Mitsuteru Nakao" height="32" src="https://www.gravatar.com/avatar/9090e122cba40b90124ea8eb4859bf8e?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Mitsuteru Nakao" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://zaki.asia"><img alt="Dezso Zoltan" height="32" src="http://www.gravatar.com/avatar/a771de8e1e49a9da61e2a602a2af42bc?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Dezso Zoltan" width="32"></a>
+<a href="http://zaki.asia"><img alt="Dezso Zoltan" height="32" src="https://www.gravatar.com/avatar/a771de8e1e49a9da61e2a602a2af42bc?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Dezso Zoltan" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.twitter.com/ope"><img alt="Takanori Nakanowatari" height="32" src="http://www.gravatar.com/avatar/55bcf6eb5de45a70e76f8a2678822ecb?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takanori Nakanowatari" width="32"></a>
+<a href="http://www.twitter.com/ope"><img alt="Takanori Nakanowatari" height="32" src="https://www.gravatar.com/avatar/55bcf6eb5de45a70e76f8a2678822ecb?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takanori Nakanowatari" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="https://github.com/zev"><img alt="Zev Blut" height="32" src="http://www.gravatar.com/avatar/1c77ad9f35746369dd1f4dd69b9f8b18?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Zev Blut" width="32"></a>
+<a href="https://github.com/zev"><img alt="Zev Blut" height="32" src="https://www.gravatar.com/avatar/1c77ad9f35746369dd1f4dd69b9f8b18?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Zev Blut" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://tako3.com/http://rubykaigi.org/rubyists/kei-s"><img alt="kei-s" height="32" src="http://www.gravatar.com/avatar/bf7ce9b68bbb0058721906b4db15b9b5?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="kei-s" width="32"></a>
+<a href="http://tako3.com/http://rubykaigi.org/rubyists/kei-s"><img alt="kei-s" height="32" src="https://www.gravatar.com/avatar/bf7ce9b68bbb0058721906b4db15b9b5?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="kei-s" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/bobbyjam99"><img alt="Tomokazu IMAI" height="32" src="http://www.gravatar.com/avatar/33814e72445b35ad3b65b1b05e699adc?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomokazu IMAI" width="32"></a>
+<a href="http://twitter.com/bobbyjam99"><img alt="Tomokazu IMAI" height="32" src="https://www.gravatar.com/avatar/33814e72445b35ad3b65b1b05e699adc?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomokazu IMAI" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/hasimo"><img alt="Tohru Hashimoto" height="32" src="http://www.gravatar.com/avatar/6e3d1578114e5d3951a7f90579fff74c?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tohru Hashimoto" width="32"></a>
+<a href="http://twitter.com/hasimo"><img alt="Tohru Hashimoto" height="32" src="https://www.gravatar.com/avatar/6e3d1578114e5d3951a7f90579fff74c?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tohru Hashimoto" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.mobalean.com/founders/michael"><img alt="Michael Reinsch" height="32" src="http://www.gravatar.com/avatar/c7915a424cbb28fdd6c1cce270be6b58?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Michael Reinsch" width="32"></a>
+<a href="http://www.mobalean.com/founders/michael"><img alt="Michael Reinsch" height="32" src="https://www.gravatar.com/avatar/c7915a424cbb28fdd6c1cce270be6b58?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Michael Reinsch" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/sandinist"><img alt="Tsuyoshi MAEHANA" height="32" src="http://www.gravatar.com/avatar/e8ebe7d4ec09c5dd77ee064706836f23?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tsuyoshi MAEHANA" width="32"></a>
+<a href="http://twitter.com/sandinist"><img alt="Tsuyoshi MAEHANA" height="32" src="https://www.gravatar.com/avatar/e8ebe7d4ec09c5dd77ee064706836f23?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tsuyoshi MAEHANA" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://sane.jp"><img alt="Murahashi Sanemat Kenichi" height="32" src="http://www.gravatar.com/avatar/5b1d016f87f05ff645ae572ccbbf0448?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Murahashi Sanemat Kenichi" width="32"></a>
+<a href="http://sane.jp"><img alt="Murahashi Sanemat Kenichi" height="32" src="https://www.gravatar.com/avatar/5b1d016f87f05ff645ae572ccbbf0448?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Murahashi Sanemat Kenichi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://aerial.st"><img alt="Masato Ikeda" height="32" src="http://www.gravatar.com/avatar/03abf5741b7bbd28670af5ec92b6141d?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masato Ikeda" width="32"></a>
+<a href="http://aerial.st"><img alt="Masato Ikeda" height="32" src="https://www.gravatar.com/avatar/03abf5741b7bbd28670af5ec92b6141d?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masato Ikeda" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/tex314"><img alt="OKAZAKI Takurou" height="32" src="http://www.gravatar.com/avatar/45c2cc1a731924edf1045d9146ca4a78?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="OKAZAKI Takurou" width="32"></a>
+<a href="http://twitter.com/tex314"><img alt="OKAZAKI Takurou" height="32" src="https://www.gravatar.com/avatar/45c2cc1a731924edf1045d9146ca4a78?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="OKAZAKI Takurou" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="https://twitter.com/toshi3221"><img alt="Toshiharu Takematsu" height="32" src="http://www.gravatar.com/avatar/3ca4621fbbb03278d4550f89e2f723ba?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Toshiharu Takematsu" width="32"></a>
+<a href="https://twitter.com/toshi3221"><img alt="Toshiharu Takematsu" height="32" src="https://www.gravatar.com/avatar/3ca4621fbbb03278d4550f89e2f723ba?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Toshiharu Takematsu" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://tdtds.jp"><img alt="TADA Tadashi" height="32" src="http://www.gravatar.com/avatar/846a80b9bf7ea7becb6c4ecd67bedd6f?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TADA Tadashi" width="32"></a>
+<a href="http://tdtds.jp"><img alt="TADA Tadashi" height="32" src="https://www.gravatar.com/avatar/846a80b9bf7ea7becb6c4ecd67bedd6f?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TADA Tadashi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://hisano.com"><img alt="HISANO Kozo" height="32" src="http://www.gravatar.com/avatar/b8fa07639c3b720c33ffdcaf89299dda?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="HISANO Kozo" width="32"></a>
+<a href="http://hisano.com"><img alt="HISANO Kozo" height="32" src="https://www.gravatar.com/avatar/b8fa07639c3b720c33ffdcaf89299dda?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="HISANO Kozo" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/kouma31/"><img alt="kmuroi" height="32" src="http://www.gravatar.com/avatar/165599097b8533c91af2aad5d7b31449?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="kmuroi" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<img alt="Anonymous" height="32" src="/2011/images/bow_face.png?1359134037" title="Anonymous" width="32">
-<a href="#"></a>
-</li>
-<li>
-<a href="http://twitter.com/h4n"><img alt="Han Kessels" height="32" src="http://www.gravatar.com/avatar/f0bd4ed83708d0af0e0d1374fc7e605b?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Han Kessels" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://twitter.com/takagi"><img alt="TAKAGI Masahiro" height="32" src="http://www.gravatar.com/avatar/c3f5a6e729b57f99cb9e7b3ca60152aa?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TAKAGI Masahiro" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://d.hatena.ne.jp/tmtms/"><img alt="TOMITA Masahiro" height="32" src="http://www.gravatar.com/avatar/e4763acee4cf0377437f614fc372a061?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TOMITA Masahiro" width="32"></a>
+<a href="http://d.hatena.ne.jp/kouma31/"><img alt="kmuroi" height="32" src="https://www.gravatar.com/avatar/165599097b8533c91af2aad5d7b31449?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="kmuroi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
@@ -676,79 +660,95 @@ Gold Sponsor
 <a href="#"></a>
 </li>
 <li>
-<a href="http://kmuto.jp/"><img alt="Kenshi Muto" height="32" src="http://www.gravatar.com/avatar/43d44fbc12adcf80c9fc24e235f48234?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kenshi Muto" width="32"></a>
+<a href="http://twitter.com/h4n"><img alt="Han Kessels" height="32" src="https://www.gravatar.com/avatar/f0bd4ed83708d0af0e0d1374fc7e605b?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Han Kessels" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<img alt="1syo" height="32" src="http://www.gravatar.com/avatar/83899fe2d00874176098a3bb71b043be?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="1syo" width="32">
+<a href="http://twitter.com/takagi"><img alt="TAKAGI Masahiro" height="32" src="https://www.gravatar.com/avatar/c3f5a6e729b57f99cb9e7b3ca60152aa?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TAKAGI Masahiro" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://fkino.net"><img alt="Fumihiko Kinoshita" height="32" src="http://www.gravatar.com/avatar/f301c0275838d562c72ea9177e7ddc68?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Fumihiko Kinoshita" width="32"></a>
+<a href="http://d.hatena.ne.jp/tmtms/"><img alt="TOMITA Masahiro" height="32" src="https://www.gravatar.com/avatar/e4763acee4cf0377437f614fc372a061?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TOMITA Masahiro" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://blog.masuidrive.jp/"><img alt="Yuichiro MASUI" height="32" src="http://www.gravatar.com/avatar/0ec58a040e1e4e959c8566484b4bba19?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yuichiro MASUI" width="32"></a>
+<img alt="Anonymous" height="32" src="/2011/images/bow_face.png?1359134037" title="Anonymous" width="32">
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/t2os/"><img alt="tatsuoSakurai" height="32" src="http://www.gravatar.com/avatar/092404bdf9897eba9ab16e61f56592db?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="tatsuoSakurai" width="32"></a>
+<a href="http://kmuto.jp/"><img alt="Kenshi Muto" height="32" src="https://www.gravatar.com/avatar/43d44fbc12adcf80c9fc24e235f48234?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kenshi Muto" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://ogijun.org"><img alt="Junya Ogino" height="32" src="http://www.gravatar.com/avatar/3a82321f68500d9691a9e190979ac2f0?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Junya Ogino" width="32"></a>
+<img alt="1syo" height="32" src="https://www.gravatar.com/avatar/83899fe2d00874176098a3bb71b043be?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="1syo" width="32">
 <a href="#"></a>
 </li>
 <li>
-<a href="http://about.me/mackato"><img alt="Masakuni Kato" height="32" src="http://www.gravatar.com/avatar/28347314c7fc698b4ac0e01113545e25?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masakuni Kato" width="32"></a>
+<a href="http://fkino.net"><img alt="Fumihiko Kinoshita" height="32" src="https://www.gravatar.com/avatar/f301c0275838d562c72ea9177e7ddc68?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Fumihiko Kinoshita" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/IWAKIRI"><img alt="IWAKIRI,Akiko" height="32" src="http://www.gravatar.com/avatar/2a02258781c7592d0da1cd5cffa627a8?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="IWAKIRI,Akiko" width="32"></a>
+<a href="http://blog.masuidrive.jp/"><img alt="Yuichiro MASUI" height="32" src="https://www.gravatar.com/avatar/0ec58a040e1e4e959c8566484b4bba19?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yuichiro MASUI" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://june29.jp/"><img alt="june29" height="32" src="http://www.gravatar.com/avatar/6fd9be5cd0196df5ad62a5a5f2be3c55?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="june29" width="32"></a>
+<a href="http://d.hatena.ne.jp/t2os/"><img alt="tatsuoSakurai" height="32" src="https://www.gravatar.com/avatar/092404bdf9897eba9ab16e61f56592db?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="tatsuoSakurai" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.socialtoprunners.jp/"><img alt="tomokazuhattanda" height="32" src="http://www.gravatar.com/avatar/19798587cb27b5220a5dcdbaa9a50d57?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="tomokazuhattanda" width="32"></a>
+<a href="http://ogijun.org"><img alt="Junya Ogino" height="32" src="https://www.gravatar.com/avatar/3a82321f68500d9691a9e190979ac2f0?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Junya Ogino" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.jamboree.jp/"><img alt="TOYOSHI, Ryuichiro" height="32" src="http://www.gravatar.com/avatar/203c324392b6c51241da5b42bbf888bd?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TOYOSHI, Ryuichiro" width="32"></a>
+<a href="http://about.me/mackato"><img alt="Masakuni Kato" height="32" src="https://www.gravatar.com/avatar/28347314c7fc698b4ac0e01113545e25?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masakuni Kato" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/takano32"><img alt="たかのみつひろ" height="32" src="http://www.gravatar.com/avatar/eba4a40bdae5edfe1589601c050a2b96?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="たかのみつひろ" width="32"></a>
+<a href="http://d.hatena.ne.jp/IWAKIRI"><img alt="IWAKIRI,Akiko" height="32" src="https://www.gravatar.com/avatar/2a02258781c7592d0da1cd5cffa627a8?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="IWAKIRI,Akiko" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/tyabe"><img alt="tyabe" height="32" src="http://www.gravatar.com/avatar/d21900444f5548d9329861593321b5a6?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="tyabe" width="32"></a>
+<a href="http://june29.jp/"><img alt="june29" height="32" src="https://www.gravatar.com/avatar/6fd9be5cd0196df5ad62a5a5f2be3c55?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="june29" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/#!/maxyz"><img alt="Masafumi Fujiwara" height="32" src="http://www.gravatar.com/avatar/4dd4d13d27559db2fb64ad069f2c49ba?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masafumi Fujiwara" width="32"></a>
+<a href="http://www.socialtoprunners.jp/"><img alt="tomokazuhattanda" height="32" src="https://www.gravatar.com/avatar/19798587cb27b5220a5dcdbaa9a50d57?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="tomokazuhattanda" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/kdmsnr"><img alt="Masanori Kado" height="32" src="http://www.gravatar.com/avatar/70b07e6b7fe7d921d7ac542d0ccb3b2c?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masanori Kado" width="32"></a>
+<a href="http://www.jamboree.jp/"><img alt="TOYOSHI, Ryuichiro" height="32" src="https://www.gravatar.com/avatar/203c324392b6c51241da5b42bbf888bd?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TOYOSHI, Ryuichiro" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.jitu.org/~tko"><img alt="Tomoyuki Kosimizu" height="32" src="http://www.gravatar.com/avatar/3585181753c22a9531e70a8297771b01?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomoyuki Kosimizu" width="32"></a>
+<a href="http://twitter.com/takano32"><img alt="たかのみつひろ" height="32" src="https://www.gravatar.com/avatar/eba4a40bdae5edfe1589601c050a2b96?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="たかのみつひろ" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/chinmo"><img alt="Tomonori Fukuta" height="32" src="http://www.gravatar.com/avatar/7977a0896e60587b2690550891be2ea7?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomonori Fukuta" width="32"></a>
+<a href="http://twitter.com/tyabe"><img alt="tyabe" height="32" src="https://www.gravatar.com/avatar/d21900444f5548d9329861593321b5a6?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="tyabe" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<img alt="YOKOTA Akiko" height="32" src="http://www.gravatar.com/avatar/03e548747e667fc94cc8495868bfd85e?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="YOKOTA Akiko" width="32">
+<a href="http://twitter.com/#!/maxyz"><img alt="Masafumi Fujiwara" height="32" src="https://www.gravatar.com/avatar/4dd4d13d27559db2fb64ad069f2c49ba?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masafumi Fujiwara" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://nov.tdiary.net/"><img alt="Nobuhiro IMAI" height="32" src="http://www.gravatar.com/avatar/e49ab9f0774711c473660019728cde95?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Nobuhiro IMAI" width="32"></a>
+<a href="http://twitter.com/kdmsnr"><img alt="Masanori Kado" height="32" src="https://www.gravatar.com/avatar/70b07e6b7fe7d921d7ac542d0ccb3b2c?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masanori Kado" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://www.jitu.org/~tko"><img alt="Tomoyuki Kosimizu" height="32" src="https://www.gravatar.com/avatar/3585181753c22a9531e70a8297771b01?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomoyuki Kosimizu" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://twitter.com/chinmo"><img alt="Tomonori Fukuta" height="32" src="https://www.gravatar.com/avatar/7977a0896e60587b2690550891be2ea7?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomonori Fukuta" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<img alt="YOKOTA Akiko" height="32" src="https://www.gravatar.com/avatar/03e548747e667fc94cc8495868bfd85e?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="YOKOTA Akiko" width="32">
+<a href="#"></a>
+</li>
+<li>
+<a href="http://nov.tdiary.net/"><img alt="Nobuhiro IMAI" height="32" src="https://www.gravatar.com/avatar/e49ab9f0774711c473660019728cde95?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Nobuhiro IMAI" width="32"></a>
 <a href="#"></a>
 </li>
 </ul>

--- a/2011/en/sponsors_individual/index.html
+++ b/2011/en/sponsors_individual/index.html
@@ -89,63 +89,63 @@ Individual Sponsors
 </h1>
 <article>
 <div class="avatar">
-<a href="http://shyouhei.tumblr.com"><img alt="Urabe, Shyouhei" height="42" src="http://www.gravatar.com/avatar/9d2f78236e45a335301ba1195026105d?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Urabe, Shyouhei" width="42"></a>
+<a href="http://shyouhei.tumblr.com"><img alt="Urabe, Shyouhei" height="42" src="https://www.gravatar.com/avatar/9d2f78236e45a335301ba1195026105d?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Urabe, Shyouhei" width="42"></a>
 <p class="linkMark">
 <a href="http://shyouhei.tumblr.com">Urabe, Shyouhei</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://twitter.com/noplans"><img alt="TANIGUCHI Fumitake" height="42" src="http://www.gravatar.com/avatar/e514ae09c9b84e04231af57f1d1946b8?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TANIGUCHI Fumitake" width="42"></a>
+<a href="http://twitter.com/noplans"><img alt="TANIGUCHI Fumitake" height="42" src="https://www.gravatar.com/avatar/e514ae09c9b84e04231af57f1d1946b8?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TANIGUCHI Fumitake" width="42"></a>
 <p class="linkMark">
 <a href="http://twitter.com/noplans">TANIGUCHI Fumitake</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://jmettraux.wordpress.com"><img alt="John Mettraux" height="42" src="http://www.gravatar.com/avatar/8d96626e52beb1ff90f57a8e189e1e6f?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="John Mettraux" width="42"></a>
+<a href="http://jmettraux.wordpress.com"><img alt="John Mettraux" height="42" src="https://www.gravatar.com/avatar/8d96626e52beb1ff90f57a8e189e1e6f?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="John Mettraux" width="42"></a>
 <p class="linkMark">
 <a href="http://jmettraux.wordpress.com">John Mettraux</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://twitter.com/japanrock"><img alt="Shintaro Nozaki" height="42" src="http://www.gravatar.com/avatar/b31a258dd8f615f61b2d355297f82dc9?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shintaro Nozaki" width="42"></a>
+<a href="http://twitter.com/japanrock"><img alt="Shintaro Nozaki" height="42" src="https://www.gravatar.com/avatar/b31a258dd8f615f61b2d355297f82dc9?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shintaro Nozaki" width="42"></a>
 <p class="linkMark">
 <a href="http://twitter.com/japanrock">Shintaro Nozaki</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://blog.dio.jp"><img alt="Akira Matsuda" height="42" src="http://www.gravatar.com/avatar/76a777ff80f30bd3b390e275cce625bc?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Akira Matsuda" width="42"></a>
+<a href="http://blog.dio.jp"><img alt="Akira Matsuda" height="42" src="https://www.gravatar.com/avatar/76a777ff80f30bd3b390e275cce625bc?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Akira Matsuda" width="42"></a>
 <p class="linkMark">
 <a href="http://blog.dio.jp">Akira Matsuda</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://www.bovensiepen.net"><img alt="Daniel Bovensiepen" height="42" src="http://www.gravatar.com/avatar/49d6f762505615af259534deed94bc54?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Daniel Bovensiepen" width="42"></a>
+<a href="http://www.bovensiepen.net"><img alt="Daniel Bovensiepen" height="42" src="https://www.gravatar.com/avatar/49d6f762505615af259534deed94bc54?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Daniel Bovensiepen" width="42"></a>
 <p class="linkMark">
 <a href="http://www.bovensiepen.net">Daniel Bovensiepen</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://firn.jp/"><img alt="Dai Akatsuka" height="42" src="http://www.gravatar.com/avatar/4efe7b5cdbe97df84e6e607948171eef?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Dai Akatsuka" width="42"></a>
+<a href="http://firn.jp/"><img alt="Dai Akatsuka" height="42" src="https://www.gravatar.com/avatar/4efe7b5cdbe97df84e6e607948171eef?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Dai Akatsuka" width="42"></a>
 <p class="linkMark">
 <a href="http://firn.jp/">Dai Akatsuka</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://www.din.or.jp/~shinodas/"><img alt="Yoshihiko Hara" height="42" src="http://www.gravatar.com/avatar/8055fbffa700065178460bb7e3b8ee24?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yoshihiko Hara" width="42"></a>
+<a href="http://www.din.or.jp/~shinodas/"><img alt="Yoshihiko Hara" height="42" src="https://www.gravatar.com/avatar/8055fbffa700065178460bb7e3b8ee24?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yoshihiko Hara" width="42"></a>
 <p class="linkMark">
 <a href="http://www.din.or.jp/~shinodas/">Yoshihiko Hara</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://benhoskin.gs"><img alt="Ben Hoskings" height="42" src="http://www.gravatar.com/avatar/7ed99cb90a060539d729e2491442a603?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ben Hoskings" width="42"></a>
+<a href="http://benhoskin.gs"><img alt="Ben Hoskings" height="42" src="https://www.gravatar.com/avatar/7ed99cb90a060539d729e2491442a603?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ben Hoskings" width="42"></a>
 <p class="linkMark">
 <a href="http://benhoskin.gs">Ben Hoskings</a>
 </p>
@@ -159,21 +159,21 @@ Anonymous
 </div>
 <hr>
 <div class="avatar">
-<a href="http://www.nextseed.jp/"><img alt="Hitoshi Kurokawa" height="42" src="http://www.gravatar.com/avatar/11e89e3c85d9998b2c73933bde77c71e?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hitoshi Kurokawa" width="42"></a>
+<a href="http://www.nextseed.jp/"><img alt="Hitoshi Kurokawa" height="42" src="https://www.gravatar.com/avatar/11e89e3c85d9998b2c73933bde77c71e?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hitoshi Kurokawa" width="42"></a>
 <p class="linkMark">
 <a href="http://www.nextseed.jp/">Hitoshi Kurokawa</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://d.hatena.ne.jp/kinpoco/"><img alt="Yutaka Kanemoto" height="42" src="http://www.gravatar.com/avatar/0e728bf538d1848bc253d80a8626bbc2?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yutaka Kanemoto" width="42"></a>
+<a href="http://d.hatena.ne.jp/kinpoco/"><img alt="Yutaka Kanemoto" height="42" src="https://www.gravatar.com/avatar/0e728bf538d1848bc253d80a8626bbc2?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yutaka Kanemoto" width="42"></a>
 <p class="linkMark">
 <a href="http://d.hatena.ne.jp/kinpoco/">Yutaka Kanemoto</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://d.hatena.ne.jp/yuichi_katahira"><img alt="Yuichi Katahira " height="42" src="http://www.gravatar.com/avatar/3072ae08f580fc8474b47652a3d8dd0f?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yuichi Katahira " width="42"></a>
+<a href="http://d.hatena.ne.jp/yuichi_katahira"><img alt="Yuichi Katahira " height="42" src="https://www.gravatar.com/avatar/3072ae08f580fc8474b47652a3d8dd0f?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yuichi Katahira " width="42"></a>
 <p class="linkMark">
 <a href="http://d.hatena.ne.jp/yuichi_katahira">Yuichi Katahira </a>
 </p>
@@ -187,14 +187,14 @@ Anonymous
 </div>
 <hr>
 <div class="avatar">
-<a href="http://kitaj.no-ip.com/tdiary/"><img alt="Junichiro Kita" height="42" src="http://www.gravatar.com/avatar/70405ca68e6f8779be65e75b1a90525b?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Junichiro Kita" width="42"></a>
+<a href="http://kitaj.no-ip.com/tdiary/"><img alt="Junichiro Kita" height="42" src="https://www.gravatar.com/avatar/70405ca68e6f8779be65e75b1a90525b?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Junichiro Kita" width="42"></a>
 <p class="linkMark">
 <a href="http://kitaj.no-ip.com/tdiary/">Junichiro Kita</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://d.hatena.ne.jp/idesaku"><img alt="Daisuke Goto" height="42" src="http://www.gravatar.com/avatar/85c8086344e5f31b2a4d22f163660536?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Daisuke Goto" width="42"></a>
+<a href="http://d.hatena.ne.jp/idesaku"><img alt="Daisuke Goto" height="42" src="https://www.gravatar.com/avatar/85c8086344e5f31b2a4d22f163660536?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Daisuke Goto" width="42"></a>
 <p class="linkMark">
 <a href="http://d.hatena.ne.jp/idesaku">Daisuke Goto</a>
 </p>
@@ -208,126 +208,126 @@ Anonymous
 </div>
 <hr>
 <div class="avatar">
-<a href="http://www.on-sky.net/~hs/"><img alt="Hideki SAKAMOTO" height="42" src="http://www.gravatar.com/avatar/7038a6cfc30b8c3b00b5c08d70cda2f1?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hideki SAKAMOTO" width="42"></a>
+<a href="http://www.on-sky.net/~hs/"><img alt="Hideki SAKAMOTO" height="42" src="https://www.gravatar.com/avatar/7038a6cfc30b8c3b00b5c08d70cda2f1?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hideki SAKAMOTO" width="42"></a>
 <p class="linkMark">
 <a href="http://www.on-sky.net/~hs/">Hideki SAKAMOTO</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://twitter.com/agilekawabata"><img alt="Kawabata Mitsuyoshi" height="42" src="http://www.gravatar.com/avatar/5236eb3ad498b3c5336a4575408fb1b1?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kawabata Mitsuyoshi" width="42"></a>
+<a href="http://twitter.com/agilekawabata"><img alt="Kawabata Mitsuyoshi" height="42" src="https://www.gravatar.com/avatar/5236eb3ad498b3c5336a4575408fb1b1?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kawabata Mitsuyoshi" width="42"></a>
 <p class="linkMark">
 <a href="http://twitter.com/agilekawabata">Kawabata Mitsuyoshi</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://www.kt.rim.or.jp/~kbk/"><img alt="KIMURA Koichi" height="42" src="http://www.gravatar.com/avatar/04c1a31d1e33e7fc25a7ca99930e4c70?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="KIMURA Koichi" width="42"></a>
+<a href="http://www.kt.rim.or.jp/~kbk/"><img alt="KIMURA Koichi" height="42" src="https://www.gravatar.com/avatar/04c1a31d1e33e7fc25a7ca99930e4c70?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="KIMURA Koichi" width="42"></a>
 <p class="linkMark">
 <a href="http://www.kt.rim.or.jp/~kbk/">KIMURA Koichi</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://d.hatena.ne.jp/takkaw/"><img alt="Takayoshi Kawada" height="42" src="http://www.gravatar.com/avatar/38bf2ca557d9cc20dcdcbd773a68664b?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takayoshi Kawada" width="42"></a>
+<a href="http://d.hatena.ne.jp/takkaw/"><img alt="Takayoshi Kawada" height="42" src="https://www.gravatar.com/avatar/38bf2ca557d9cc20dcdcbd773a68664b?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takayoshi Kawada" width="42"></a>
 <p class="linkMark">
 <a href="http://d.hatena.ne.jp/takkaw/">Takayoshi Kawada</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://www.suchi.org/"><img alt="Shigeru UCHIYAMA" height="42" src="http://www.gravatar.com/avatar/398e2dd764d43aad735c6e5bca92c3b6?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shigeru UCHIYAMA" width="42"></a>
+<a href="http://www.suchi.org/"><img alt="Shigeru UCHIYAMA" height="42" src="https://www.gravatar.com/avatar/398e2dd764d43aad735c6e5bca92c3b6?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shigeru UCHIYAMA" width="42"></a>
 <p class="linkMark">
 <a href="http://www.suchi.org/">Shigeru UCHIYAMA</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://twitter.com/#!/andrewjgrimm"><img alt="Andrew Grimm" height="42" src="http://www.gravatar.com/avatar/01bbb59a1c3ef9960f25a97afe7e920f?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Andrew Grimm" width="42"></a>
+<a href="http://twitter.com/#!/andrewjgrimm"><img alt="Andrew Grimm" height="42" src="https://www.gravatar.com/avatar/01bbb59a1c3ef9960f25a97afe7e920f?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Andrew Grimm" width="42"></a>
 <p class="linkMark">
 <a href="http://twitter.com/#!/andrewjgrimm">Andrew Grimm</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://twitter.com/kimuraw"><img alt="kimura wataru" height="42" src="http://www.gravatar.com/avatar/e298234a6e5a2c159287476abd76504a?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="kimura wataru" width="42"></a>
+<a href="http://twitter.com/kimuraw"><img alt="kimura wataru" height="42" src="https://www.gravatar.com/avatar/e298234a6e5a2c159287476abd76504a?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="kimura wataru" width="42"></a>
 <p class="linkMark">
 <a href="http://twitter.com/kimuraw">kimura wataru</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://saikyoline.jp/"><img alt="MIKAMI Yoshiyuki" height="42" src="http://www.gravatar.com/avatar/e0920f5f813ae29ba7859f950a7f0df3?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MIKAMI Yoshiyuki" width="42"></a>
+<a href="http://saikyoline.jp/"><img alt="MIKAMI Yoshiyuki" height="42" src="https://www.gravatar.com/avatar/e0920f5f813ae29ba7859f950a7f0df3?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MIKAMI Yoshiyuki" width="42"></a>
 <p class="linkMark">
 <a href="http://saikyoline.jp/">MIKAMI Yoshiyuki</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://jp.rubyist.net/?KansaiWorkshop"><img alt="HIGAKI Masaru" height="42" src="http://www.gravatar.com/avatar/a8192f5a7b25ef32a983740ee8593bd3?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="HIGAKI Masaru" width="42"></a>
+<a href="http://jp.rubyist.net/?KansaiWorkshop"><img alt="HIGAKI Masaru" height="42" src="https://www.gravatar.com/avatar/a8192f5a7b25ef32a983740ee8593bd3?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="HIGAKI Masaru" width="42"></a>
 <p class="linkMark">
 <a href="http://jp.rubyist.net/?KansaiWorkshop">HIGAKI Masaru</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://twitter.com/ayumin"><img alt="Ayumu AIZAWA" height="42" src="http://www.gravatar.com/avatar/2e9a2dbe335e0111e4879a9d65dcbae0?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ayumu AIZAWA" width="42"></a>
+<a href="http://twitter.com/ayumin"><img alt="Ayumu AIZAWA" height="42" src="https://www.gravatar.com/avatar/2e9a2dbe335e0111e4879a9d65dcbae0?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ayumu AIZAWA" width="42"></a>
 <p class="linkMark">
 <a href="http://twitter.com/ayumin">Ayumu AIZAWA</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://shunichi-arai.blogspot.com/"><img alt="Shunichi Arai" height="42" src="http://www.gravatar.com/avatar/74daf3516e33a75968ec0f933954b5a8?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shunichi Arai" width="42"></a>
+<a href="http://shunichi-arai.blogspot.com/"><img alt="Shunichi Arai" height="42" src="https://www.gravatar.com/avatar/74daf3516e33a75968ec0f933954b5a8?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shunichi Arai" width="42"></a>
 <p class="linkMark">
 <a href="http://shunichi-arai.blogspot.com/">Shunichi Arai</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://www.tokyodev.com"><img alt="Paul McMahon" height="42" src="http://www.gravatar.com/avatar/dd24adb5a3a430fed83a33ed552fe1b5?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Paul McMahon" width="42"></a>
+<a href="http://www.tokyodev.com"><img alt="Paul McMahon" height="42" src="https://www.gravatar.com/avatar/dd24adb5a3a430fed83a33ed552fe1b5?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Paul McMahon" width="42"></a>
 <p class="linkMark">
 <a href="http://www.tokyodev.com">Paul McMahon</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://d.hatena.ne.jp/hs9587/"><img alt="Hiroyuki Shimura" height="42" src="http://www.gravatar.com/avatar/287a899c91a7a14535188d7e4784050e?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hiroyuki Shimura" width="42"></a>
+<a href="http://d.hatena.ne.jp/hs9587/"><img alt="Hiroyuki Shimura" height="42" src="https://www.gravatar.com/avatar/287a899c91a7a14535188d7e4784050e?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hiroyuki Shimura" width="42"></a>
 <p class="linkMark">
 <a href="http://d.hatena.ne.jp/hs9587/">Hiroyuki Shimura</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://kakutani.com"><img alt="Kakutani Shintaro" height="42" src="http://www.gravatar.com/avatar/34fcd5f1deeb25b1138e9845137feb6e?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kakutani Shintaro" width="42"></a>
+<a href="http://kakutani.com"><img alt="Kakutani Shintaro" height="42" src="https://www.gravatar.com/avatar/34fcd5f1deeb25b1138e9845137feb6e?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kakutani Shintaro" width="42"></a>
 <p class="linkMark">
 <a href="http://kakutani.com">Kakutani Shintaro</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://d.hatena.ne.jp/mrkn"><img alt="Kenta Murata" height="42" src="http://www.gravatar.com/avatar/819b3c0a25f9708fd32261b8ae2d23f6?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kenta Murata" width="42"></a>
+<a href="http://d.hatena.ne.jp/mrkn"><img alt="Kenta Murata" height="42" src="https://www.gravatar.com/avatar/819b3c0a25f9708fd32261b8ae2d23f6?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kenta Murata" width="42"></a>
 <p class="linkMark">
 <a href="http://d.hatena.ne.jp/mrkn">Kenta Murata</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://rails.to"><img alt="Masatoshi Itagaki" height="42" src="http://www.gravatar.com/avatar/f8865f41777ef3caced0e4e6801ff83a?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masatoshi Itagaki" width="42"></a>
+<a href="http://rails.to"><img alt="Masatoshi Itagaki" height="42" src="https://www.gravatar.com/avatar/f8865f41777ef3caced0e4e6801ff83a?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masatoshi Itagaki" width="42"></a>
 <p class="linkMark">
 <a href="http://rails.to">Masatoshi Itagaki</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://spring-aki.com/"><img alt="Aki" height="42" src="http://www.gravatar.com/avatar/81f2122b45f48829be4507bf972666e9?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Aki" width="42"></a>
+<a href="http://spring-aki.com/"><img alt="Aki" height="42" src="https://www.gravatar.com/avatar/81f2122b45f48829be4507bf972666e9?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Aki" width="42"></a>
 <p class="linkMark">
 <a href="http://spring-aki.com/">Aki</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://twitter.com/shin_asou"><img alt="Shinichi Okada" height="42" src="http://www.gravatar.com/avatar/20805358592bd93f92bf15aa10137251?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shinichi Okada" width="42"></a>
+<a href="http://twitter.com/shin_asou"><img alt="Shinichi Okada" height="42" src="https://www.gravatar.com/avatar/20805358592bd93f92bf15aa10137251?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shinichi Okada" width="42"></a>
 <p class="linkMark">
 <a href="http://twitter.com/shin_asou">Shinichi Okada</a>
 </p>
@@ -341,56 +341,56 @@ Anonymous
 </div>
 <hr>
 <div class="avatar">
-<a href="http://www.kumaryu.net/"><img alt="Ryuichi Sakamoto" height="42" src="http://www.gravatar.com/avatar/1b2ca00132480422c75c1f2c61e84e26?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ryuichi Sakamoto" width="42"></a>
+<a href="http://www.kumaryu.net/"><img alt="Ryuichi Sakamoto" height="42" src="https://www.gravatar.com/avatar/1b2ca00132480422c75c1f2c61e84e26?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ryuichi Sakamoto" width="42"></a>
 <p class="linkMark">
 <a href="http://www.kumaryu.net/">Ryuichi Sakamoto</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<img alt="Eito Katagiri" height="42" src="http://www.gravatar.com/avatar/b5852cf79505d7ba513f8f16ef95a50f?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Eito Katagiri" width="42">
+<img alt="Eito Katagiri" height="42" src="https://www.gravatar.com/avatar/b5852cf79505d7ba513f8f16ef95a50f?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Eito Katagiri" width="42">
 <p>
 Eito Katagiri
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://ukstudio.jp/"><img alt="AKAMATSU Yuki" height="42" src="http://www.gravatar.com/avatar/0c471249ee93ab17a011f3e8d2b1057a?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="AKAMATSU Yuki" width="42"></a>
+<a href="http://ukstudio.jp/"><img alt="AKAMATSU Yuki" height="42" src="https://www.gravatar.com/avatar/0c471249ee93ab17a011f3e8d2b1057a?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="AKAMATSU Yuki" width="42"></a>
 <p class="linkMark">
 <a href="http://ukstudio.jp/">AKAMATSU Yuki</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://hisashim.org"><img alt="Hisashi Morita" height="42" src="http://www.gravatar.com/avatar/b3fba7af93cd27e6ed28e7eae88a9585?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hisashi Morita" width="42"></a>
+<a href="http://hisashim.org"><img alt="Hisashi Morita" height="42" src="https://www.gravatar.com/avatar/b3fba7af93cd27e6ed28e7eae88a9585?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hisashi Morita" width="42"></a>
 <p class="linkMark">
 <a href="http://hisashim.org">Hisashi Morita</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://d.hatena.ne.jp/muryoImpl/"><img alt="Ken muryoi" height="42" src="http://www.gravatar.com/avatar/ac6dba8ce93944d17714de362ca17e54?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ken muryoi" width="42"></a>
+<a href="http://d.hatena.ne.jp/muryoImpl/"><img alt="Ken muryoi" height="42" src="https://www.gravatar.com/avatar/ac6dba8ce93944d17714de362ca17e54?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ken muryoi" width="42"></a>
 <p class="linkMark">
 <a href="http://d.hatena.ne.jp/muryoImpl/">Ken muryoi</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://d.hatena.ne.jp/nagachika/"><img alt="Tomoyuki Chikanaga" height="42" src="http://www.gravatar.com/avatar/5cf8f058a4c094bb708174fb43e7a387?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomoyuki Chikanaga" width="42"></a>
+<a href="http://d.hatena.ne.jp/nagachika/"><img alt="Tomoyuki Chikanaga" height="42" src="https://www.gravatar.com/avatar/5cf8f058a4c094bb708174fb43e7a387?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomoyuki Chikanaga" width="42"></a>
 <p class="linkMark">
 <a href="http://d.hatena.ne.jp/nagachika/">Tomoyuki Chikanaga</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://d.hatena.ne.jp/takeshinoda/"><img alt="Takeshi SHINODA" height="42" src="http://www.gravatar.com/avatar/06febd004d7cc9c9f6a4e0272b686bc7?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takeshi SHINODA" width="42"></a>
+<a href="http://d.hatena.ne.jp/takeshinoda/"><img alt="Takeshi SHINODA" height="42" src="https://www.gravatar.com/avatar/06febd004d7cc9c9f6a4e0272b686bc7?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takeshi SHINODA" width="42"></a>
 <p class="linkMark">
 <a href="http://d.hatena.ne.jp/takeshinoda/">Takeshi SHINODA</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://twitter.com/knsmr"><img alt="Ken Nishimura" height="42" src="http://www.gravatar.com/avatar/91fb4852880d1727cca911036e2fef5f?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ken Nishimura" width="42"></a>
+<a href="http://twitter.com/knsmr"><img alt="Ken Nishimura" height="42" src="https://www.gravatar.com/avatar/91fb4852880d1727cca911036e2fef5f?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ken Nishimura" width="42"></a>
 <p class="linkMark">
 <a href="http://twitter.com/knsmr">Ken Nishimura</a>
 </p>
@@ -404,56 +404,56 @@ Anonymous
 </div>
 <hr>
 <div class="avatar">
-<a href="http://d.hatena.ne.jp/koko_u/"><img alt="Kozaki Tsuneaki" height="42" src="http://www.gravatar.com/avatar/5b1b558d563288da615a9ea2889afdd5?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kozaki Tsuneaki" width="42"></a>
+<a href="http://d.hatena.ne.jp/koko_u/"><img alt="Kozaki Tsuneaki" height="42" src="https://www.gravatar.com/avatar/5b1b558d563288da615a9ea2889afdd5?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kozaki Tsuneaki" width="42"></a>
 <p class="linkMark">
 <a href="http://d.hatena.ne.jp/koko_u/">Kozaki Tsuneaki</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://twitter.com/adzuki34"><img alt="SUZUKI Miho" height="42" src="http://www.gravatar.com/avatar/f37b9a968b2326062190677906a93080?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="SUZUKI Miho" width="42"></a>
+<a href="http://twitter.com/adzuki34"><img alt="SUZUKI Miho" height="42" src="https://www.gravatar.com/avatar/f37b9a968b2326062190677906a93080?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="SUZUKI Miho" width="42"></a>
 <p class="linkMark">
 <a href="http://twitter.com/adzuki34">SUZUKI Miho</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://twitter.com/lchin"><img alt="Leonard Chin" height="42" src="http://www.gravatar.com/avatar/70762059db0218c6f0ff48042ca0756a?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Leonard Chin" width="42"></a>
+<a href="http://twitter.com/lchin"><img alt="Leonard Chin" height="42" src="https://www.gravatar.com/avatar/70762059db0218c6f0ff48042ca0756a?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Leonard Chin" width="42"></a>
 <p class="linkMark">
 <a href="http://twitter.com/lchin">Leonard Chin</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://d.hatena.ne.jp/suzumura_ss/"><img alt="Toshiyuki Terashita" height="42" src="http://www.gravatar.com/avatar/bb8b58cab667163b6ee53aad0e5f0414?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Toshiyuki Terashita" width="42"></a>
+<a href="http://d.hatena.ne.jp/suzumura_ss/"><img alt="Toshiyuki Terashita" height="42" src="https://www.gravatar.com/avatar/bb8b58cab667163b6ee53aad0e5f0414?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Toshiyuki Terashita" width="42"></a>
 <p class="linkMark">
 <a href="http://d.hatena.ne.jp/suzumura_ss/">Toshiyuki Terashita</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://sites.google.com/site/akihikohashimoto/"><img alt="Akihiko Hashimoto" height="42" src="http://www.gravatar.com/avatar/c8803a4130c3238e34b605d0a0cffe94?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Akihiko Hashimoto" width="42"></a>
+<a href="http://sites.google.com/site/akihikohashimoto/"><img alt="Akihiko Hashimoto" height="42" src="https://www.gravatar.com/avatar/c8803a4130c3238e34b605d0a0cffe94?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Akihiko Hashimoto" width="42"></a>
 <p class="linkMark">
 <a href="http://sites.google.com/site/akihikohashimoto/">Akihiko Hashimoto</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<img alt="OZAWA Sakuro" height="42" src="http://www.gravatar.com/avatar/a1cbed8bf64473e2acdd0c7066cc5b29?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="OZAWA Sakuro" width="42">
+<img alt="OZAWA Sakuro" height="42" src="https://www.gravatar.com/avatar/a1cbed8bf64473e2acdd0c7066cc5b29?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="OZAWA Sakuro" width="42">
 <p>
 OZAWA Sakuro
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://fkmn.exblog.jp/"><img alt="Arinobu FUKUHARA" height="42" src="http://www.gravatar.com/avatar/85319f2b72d7b37ddef5c25a2dd40d30?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Arinobu FUKUHARA" width="42"></a>
+<a href="http://fkmn.exblog.jp/"><img alt="Arinobu FUKUHARA" height="42" src="https://www.gravatar.com/avatar/85319f2b72d7b37ddef5c25a2dd40d30?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Arinobu FUKUHARA" width="42"></a>
 <p class="linkMark">
 <a href="http://fkmn.exblog.jp/">Arinobu FUKUHARA</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://twitter.com/shachi"><img alt="Kazuyuki Koizuka-shachi" height="42" src="http://www.gravatar.com/avatar/f51ee84097a72a8d91bee9bb98736541?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kazuyuki Koizuka-shachi" width="42"></a>
+<a href="http://twitter.com/shachi"><img alt="Kazuyuki Koizuka-shachi" height="42" src="https://www.gravatar.com/avatar/f51ee84097a72a8d91bee9bb98736541?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kazuyuki Koizuka-shachi" width="42"></a>
 <p class="linkMark">
 <a href="http://twitter.com/shachi">Kazuyuki Koizuka-shachi</a>
 </p>
@@ -467,175 +467,175 @@ Anonymous
 </div>
 <hr>
 <div class="avatar">
-<a href="http://atakigu.tumblr.com/"><img alt="atakig" height="42" src="http://www.gravatar.com/avatar/8a949c60e450d226de776072273a1ffc?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="atakig" width="42"></a>
+<a href="http://atakigu.tumblr.com/"><img alt="atakig" height="42" src="https://www.gravatar.com/avatar/8a949c60e450d226de776072273a1ffc?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="atakig" width="42"></a>
 <p class="linkMark">
 <a href="http://atakigu.tumblr.com/">atakig</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<img alt="TSUTSUI Toshinori" height="42" src="http://www.gravatar.com/avatar/ad66fd981c429c12e0f76c436da3337e?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TSUTSUI Toshinori" width="42">
+<img alt="TSUTSUI Toshinori" height="42" src="https://www.gravatar.com/avatar/ad66fd981c429c12e0f76c436da3337e?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TSUTSUI Toshinori" width="42">
 <p>
 TSUTSUI Toshinori
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://yugui.jp"><img alt="Yuki Sonoda (Yugui)" height="42" src="http://www.gravatar.com/avatar/1e7e007723cfe59320d994a7db4ab4cf?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yuki Sonoda (Yugui)" width="42"></a>
+<a href="http://yugui.jp"><img alt="Yuki Sonoda (Yugui)" height="42" src="https://www.gravatar.com/avatar/1e7e007723cfe59320d994a7db4ab4cf?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yuki Sonoda (Yugui)" width="42"></a>
 <p class="linkMark">
 <a href="http://yugui.jp">Yuki Sonoda (Yugui)</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://d.hatena.ne.jp/seiunsky"><img alt="sugamasao" height="42" src="http://www.gravatar.com/avatar/961126d9892ae4df45249529a0721571?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="sugamasao" width="42"></a>
+<a href="http://d.hatena.ne.jp/seiunsky"><img alt="sugamasao" height="42" src="https://www.gravatar.com/avatar/961126d9892ae4df45249529a0721571?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="sugamasao" width="42"></a>
 <p class="linkMark">
 <a href="http://d.hatena.ne.jp/seiunsky">sugamasao</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://d.hatena.ne.jp/mkgin/"><img alt="Makoto Kouno" height="42" src="http://www.gravatar.com/avatar/06e6dcde277cbe5c614baf5d25871025?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Makoto Kouno" width="42"></a>
+<a href="http://d.hatena.ne.jp/mkgin/"><img alt="Makoto Kouno" height="42" src="https://www.gravatar.com/avatar/06e6dcde277cbe5c614baf5d25871025?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Makoto Kouno" width="42"></a>
 <p class="linkMark">
 <a href="http://d.hatena.ne.jp/mkgin/">Makoto Kouno</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://twitter.com/suzuki"><img alt="Norio Suzuki" height="42" src="http://www.gravatar.com/avatar/8e528456ff66ec543952daa815353a01?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Norio Suzuki" width="42"></a>
+<a href="http://twitter.com/suzuki"><img alt="Norio Suzuki" height="42" src="https://www.gravatar.com/avatar/8e528456ff66ec543952daa815353a01?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Norio Suzuki" width="42"></a>
 <p class="linkMark">
 <a href="http://twitter.com/suzuki">Norio Suzuki</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://www.artonx.org"><img alt="Akio Tajima" height="42" src="http://www.gravatar.com/avatar/0441ff038018e53a35bb207e81105a5c?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Akio Tajima" width="42"></a>
+<a href="http://www.artonx.org"><img alt="Akio Tajima" height="42" src="https://www.gravatar.com/avatar/0441ff038018e53a35bb207e81105a5c?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Akio Tajima" width="42"></a>
 <p class="linkMark">
 <a href="http://www.artonx.org">Akio Tajima</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://moonrock.jp/~don/"><img alt="Hiroyuki Iwatsuki" height="42" src="http://www.gravatar.com/avatar/cb1f0f80c3fe2729ba593656772c266d?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hiroyuki Iwatsuki" width="42"></a>
+<a href="http://moonrock.jp/~don/"><img alt="Hiroyuki Iwatsuki" height="42" src="https://www.gravatar.com/avatar/cb1f0f80c3fe2729ba593656772c266d?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hiroyuki Iwatsuki" width="42"></a>
 <p class="linkMark">
 <a href="http://moonrock.jp/~don/">Hiroyuki Iwatsuki</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://d.hatena.ne.jp/monyakata/"><img alt="MUNAKATA Akiko" height="42" src="http://www.gravatar.com/avatar/55a6db4b079c962f72adb014055e9a28?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MUNAKATA Akiko" width="42"></a>
+<a href="http://d.hatena.ne.jp/monyakata/"><img alt="MUNAKATA Akiko" height="42" src="https://www.gravatar.com/avatar/55a6db4b079c962f72adb014055e9a28?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MUNAKATA Akiko" width="42"></a>
 <p class="linkMark">
 <a href="http://d.hatena.ne.jp/monyakata/">MUNAKATA Akiko</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://www.bawdo.com"><img alt="Keith Bawden" height="42" src="http://www.gravatar.com/avatar/a6cc567a6b77ee09f7363d175455593b?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Keith Bawden" width="42"></a>
+<a href="http://www.bawdo.com"><img alt="Keith Bawden" height="42" src="https://www.gravatar.com/avatar/a6cc567a6b77ee09f7363d175455593b?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Keith Bawden" width="42"></a>
 <p class="linkMark">
 <a href="http://www.bawdo.com">Keith Bawden</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<img alt="Norihito Yoshioka" height="42" src="http://www.gravatar.com/avatar/c6033734a5b01f43cca06773ea9ff1fe?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Norihito Yoshioka" width="42">
+<img alt="Norihito Yoshioka" height="42" src="https://www.gravatar.com/avatar/c6033734a5b01f43cca06773ea9ff1fe?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Norihito Yoshioka" width="42">
 <p>
 Norihito Yoshioka
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://d.hatena.ne.jp/vestige/"><img alt="makoto yonezawa" height="42" src="http://www.gravatar.com/avatar/8da7ceb361c63bd6622fe33153a0293b?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="makoto yonezawa" width="42"></a>
+<a href="http://d.hatena.ne.jp/vestige/"><img alt="makoto yonezawa" height="42" src="https://www.gravatar.com/avatar/8da7ceb361c63bd6622fe33153a0293b?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="makoto yonezawa" width="42"></a>
 <p class="linkMark">
 <a href="http://d.hatena.ne.jp/vestige/">makoto yonezawa</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="https://twitter.com/tsuboi"><img alt="Sougo TSUBOI" height="42" src="http://www.gravatar.com/avatar/847bf4e3766b2e17cafef8e83b046db1?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Sougo TSUBOI" width="42"></a>
+<a href="https://twitter.com/tsuboi"><img alt="Sougo TSUBOI" height="42" src="https://www.gravatar.com/avatar/847bf4e3766b2e17cafef8e83b046db1?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Sougo TSUBOI" width="42"></a>
 <p class="linkMark">
 <a href="https://twitter.com/tsuboi">Sougo TSUBOI</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://twitter.com/#!/mojamoja_mixi"><img alt="MojaMoja" height="42" src="http://www.gravatar.com/avatar/7b0d6fc806322376d65cbb95d40bc176?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MojaMoja" width="42"></a>
+<a href="http://twitter.com/#!/mojamoja_mixi"><img alt="MojaMoja" height="42" src="https://www.gravatar.com/avatar/7b0d6fc806322376d65cbb95d40bc176?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MojaMoja" width="42"></a>
 <p class="linkMark">
 <a href="http://twitter.com/#!/mojamoja_mixi">MojaMoja</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://twitter.com/takkanm"><img alt="mitsutaka mimura" height="42" src="http://www.gravatar.com/avatar/8f39a252784d5a99589be6e20c4553fb?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="mitsutaka mimura" width="42"></a>
+<a href="http://twitter.com/takkanm"><img alt="mitsutaka mimura" height="42" src="https://www.gravatar.com/avatar/8f39a252784d5a99589be6e20c4553fb?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="mitsutaka mimura" width="42"></a>
 <p class="linkMark">
 <a href="http://twitter.com/takkanm">mitsutaka mimura</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://twitter.com/dan5ya"><img alt="Dan Yamamoto" height="42" src="http://www.gravatar.com/avatar/ffaa5dad365d5bb5025f4126bb54676c?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Dan Yamamoto" width="42"></a>
+<a href="http://twitter.com/dan5ya"><img alt="Dan Yamamoto" height="42" src="https://www.gravatar.com/avatar/ffaa5dad365d5bb5025f4126bb54676c?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Dan Yamamoto" width="42"></a>
 <p class="linkMark">
 <a href="http://twitter.com/dan5ya">Dan Yamamoto</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://www.hsbt.org/"><img alt="SHIBATA Hiroshi" height="42" src="http://www.gravatar.com/avatar/eabad423977cfc6873b8f5df62b848a6?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="SHIBATA Hiroshi" width="42"></a>
+<a href="http://www.hsbt.org/"><img alt="SHIBATA Hiroshi" height="42" src="https://www.gravatar.com/avatar/eabad423977cfc6873b8f5df62b848a6?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="SHIBATA Hiroshi" width="42"></a>
 <p class="linkMark">
 <a href="http://www.hsbt.org/">SHIBATA Hiroshi</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://d.hatena.ne.jp/moro/"><img alt="MOROHASHI Kyosuke" height="42" src="http://www.gravatar.com/avatar/70e13d9877054026fda46d5a5b53a236?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MOROHASHI Kyosuke" width="42"></a>
+<a href="http://d.hatena.ne.jp/moro/"><img alt="MOROHASHI Kyosuke" height="42" src="https://www.gravatar.com/avatar/70e13d9877054026fda46d5a5b53a236?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MOROHASHI Kyosuke" width="42"></a>
 <p class="linkMark">
 <a href="http://d.hatena.ne.jp/moro/">MOROHASHI Kyosuke</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://rsss.be/hibariya"><img alt="Hibariya Hi" height="42" src="http://www.gravatar.com/avatar/de0df5acda15a9c7eeb6c28a5e5d4e8e?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hibariya Hi" width="42"></a>
+<a href="http://rsss.be/hibariya"><img alt="Hibariya Hi" height="42" src="https://www.gravatar.com/avatar/de0df5acda15a9c7eeb6c28a5e5d4e8e?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hibariya Hi" width="42"></a>
 <p class="linkMark">
 <a href="http://rsss.be/hibariya">Hibariya Hi</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://twitter.com/kyanny"><img alt="Kensuke Nagae" height="42" src="http://www.gravatar.com/avatar/fffd8bf62b842a46803fb07792029fa4?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kensuke Nagae" width="42"></a>
+<a href="http://twitter.com/kyanny"><img alt="Kensuke Nagae" height="42" src="https://www.gravatar.com/avatar/fffd8bf62b842a46803fb07792029fa4?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kensuke Nagae" width="42"></a>
 <p class="linkMark">
 <a href="http://twitter.com/kyanny">Kensuke Nagae</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<img alt="oku23" height="42" src="http://www.gravatar.com/avatar/3725ec1dce281fb187d798a9b9ddc9d3?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="oku23" width="42">
+<img alt="oku23" height="42" src="https://www.gravatar.com/avatar/3725ec1dce281fb187d798a9b9ddc9d3?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="oku23" width="42">
 <p>
 oku23
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://ko.meadowy.net/~koichiro/diary/"><img alt="Koichiro Ohba" height="42" src="http://www.gravatar.com/avatar/1ce18b10bd8f911566c5577042b6a44c?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Koichiro Ohba" width="42"></a>
+<a href="http://ko.meadowy.net/~koichiro/diary/"><img alt="Koichiro Ohba" height="42" src="https://www.gravatar.com/avatar/1ce18b10bd8f911566c5577042b6a44c?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Koichiro Ohba" width="42"></a>
 <p class="linkMark">
 <a href="http://ko.meadowy.net/~koichiro/diary/">Koichiro Ohba</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://www.flickr.com/photos/t-seto"><img alt="せとん" height="42" src="http://www.gravatar.com/avatar/ac007a5b84f817d8cc80a3c208ea0181?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="せとん" width="42"></a>
+<a href="http://www.flickr.com/photos/t-seto"><img alt="せとん" height="42" src="https://www.gravatar.com/avatar/ac007a5b84f817d8cc80a3c208ea0181?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="せとん" width="42"></a>
 <p class="linkMark">
 <a href="http://www.flickr.com/photos/t-seto">せとん</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://twitter.com/#!/tsuyoshikawa"><img alt="Tsuyoshi Yoshikawa" height="42" src="http://www.gravatar.com/avatar/6969ade78c1eaff0d08c76020fc80e83?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tsuyoshi Yoshikawa" width="42"></a>
+<a href="http://twitter.com/#!/tsuyoshikawa"><img alt="Tsuyoshi Yoshikawa" height="42" src="https://www.gravatar.com/avatar/6969ade78c1eaff0d08c76020fc80e83?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tsuyoshi Yoshikawa" width="42"></a>
 <p class="linkMark">
 <a href="http://twitter.com/#!/tsuyoshikawa">Tsuyoshi Yoshikawa</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://www.water-lily.biz/"><img alt="Water Lily LLC" height="42" src="http://www.gravatar.com/avatar/0734b8ec5eed71892e5db432856f4f40?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Water Lily LLC" width="42"></a>
+<a href="http://www.water-lily.biz/"><img alt="Water Lily LLC" height="42" src="https://www.gravatar.com/avatar/0734b8ec5eed71892e5db432856f4f40?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Water Lily LLC" width="42"></a>
 <p class="linkMark">
 <a href="http://www.water-lily.biz/">Water Lily LLC</a>
 </p>
@@ -649,168 +649,168 @@ oku23
 </div>
 <hr>
 <div class="avatar">
-<a href="http://web-engineer.buyuden.net/blog/kawai/"><img alt="Takeshi Kawai" height="42" src="http://www.gravatar.com/avatar/6b53e472c9200f5ed61d7a6db0a28986?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takeshi Kawai" width="42"></a>
+<a href="http://web-engineer.buyuden.net/blog/kawai/"><img alt="Takeshi Kawai" height="42" src="https://www.gravatar.com/avatar/6b53e472c9200f5ed61d7a6db0a28986?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takeshi Kawai" width="42"></a>
 <p class="linkMark">
 <a href="http://web-engineer.buyuden.net/blog/kawai/">Takeshi Kawai</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://d.hatena.ne.jp/k3c/"><img alt="KANEKO Seiji" height="42" src="http://www.gravatar.com/avatar/63d3818b5c107a6483a1d2e2767be4c5?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="KANEKO Seiji" width="42"></a>
+<a href="http://d.hatena.ne.jp/k3c/"><img alt="KANEKO Seiji" height="42" src="https://www.gravatar.com/avatar/63d3818b5c107a6483a1d2e2767be4c5?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="KANEKO Seiji" width="42"></a>
 <p class="linkMark">
 <a href="http://d.hatena.ne.jp/k3c/">KANEKO Seiji</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://www.famlog.jp/"><img alt="Atsushi Matsuo" height="42" src="http://www.gravatar.com/avatar/0a4da00dbfd37e7f06ef8dceb58ca0c1?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Atsushi Matsuo" width="42"></a>
+<a href="http://www.famlog.jp/"><img alt="Atsushi Matsuo" height="42" src="https://www.gravatar.com/avatar/0a4da00dbfd37e7f06ef8dceb58ca0c1?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Atsushi Matsuo" width="42"></a>
 <p class="linkMark">
 <a href="http://www.famlog.jp/">Atsushi Matsuo</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://m.igrs.jp/"><img alt="Masato Igarashi" height="42" src="http://www.gravatar.com/avatar/6fd2e23d73c26ccbd7df9e3eefacd3ae?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masato Igarashi" width="42"></a>
+<a href="http://m.igrs.jp/"><img alt="Masato Igarashi" height="42" src="https://www.gravatar.com/avatar/6fd2e23d73c26ccbd7df9e3eefacd3ae?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masato Igarashi" width="42"></a>
 <p class="linkMark">
 <a href="http://m.igrs.jp/">Masato Igarashi</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://resume.github.com/?walf443"><img alt="Keiji Yoshimi" height="42" src="http://www.gravatar.com/avatar/dea4fe079aec284744ad02eb3d2594f5?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Keiji Yoshimi" width="42"></a>
+<a href="http://resume.github.com/?walf443"><img alt="Keiji Yoshimi" height="42" src="https://www.gravatar.com/avatar/dea4fe079aec284744ad02eb3d2594f5?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Keiji Yoshimi" width="42"></a>
 <p class="linkMark">
 <a href="http://resume.github.com/?walf443">Keiji Yoshimi</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://gunjisatoshi.appspot.com/"><img alt="GUNJI Satoshi" height="42" src="http://www.gravatar.com/avatar/e6980e09fdff8f481b70f2e1f241231d?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="GUNJI Satoshi" width="42"></a>
+<a href="http://gunjisatoshi.appspot.com/"><img alt="GUNJI Satoshi" height="42" src="https://www.gravatar.com/avatar/e6980e09fdff8f481b70f2e1f241231d?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="GUNJI Satoshi" width="42"></a>
 <p class="linkMark">
 <a href="http://gunjisatoshi.appspot.com/">GUNJI Satoshi</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<img alt="Hisashi Yamaeda" height="42" src="http://www.gravatar.com/avatar/01ca4ebeee47c9b4d6ba9ad58db694a0?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hisashi Yamaeda" width="42">
+<img alt="Hisashi Yamaeda" height="42" src="https://www.gravatar.com/avatar/01ca4ebeee47c9b4d6ba9ad58db694a0?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hisashi Yamaeda" width="42">
 <p>
 Hisashi Yamaeda
 </p>
 </div>
 <hr>
 <div class="avatar">
-<img alt="gekidanyonin" height="42" src="http://www.gravatar.com/avatar/2b196f1723fdbcbf7bd297b3e7f8cd3c?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="gekidanyonin" width="42">
+<img alt="gekidanyonin" height="42" src="https://www.gravatar.com/avatar/2b196f1723fdbcbf7bd297b3e7f8cd3c?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="gekidanyonin" width="42">
 <p>
 gekidanyonin
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://jp.linkedin.com/in/nakaomitsuteru"><img alt="Mitsuteru Nakao" height="42" src="http://www.gravatar.com/avatar/9090e122cba40b90124ea8eb4859bf8e?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Mitsuteru Nakao" width="42"></a>
+<a href="http://jp.linkedin.com/in/nakaomitsuteru"><img alt="Mitsuteru Nakao" height="42" src="https://www.gravatar.com/avatar/9090e122cba40b90124ea8eb4859bf8e?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Mitsuteru Nakao" width="42"></a>
 <p class="linkMark">
 <a href="http://jp.linkedin.com/in/nakaomitsuteru">Mitsuteru Nakao</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://zaki.asia"><img alt="Dezso Zoltan" height="42" src="http://www.gravatar.com/avatar/a771de8e1e49a9da61e2a602a2af42bc?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Dezso Zoltan" width="42"></a>
+<a href="http://zaki.asia"><img alt="Dezso Zoltan" height="42" src="https://www.gravatar.com/avatar/a771de8e1e49a9da61e2a602a2af42bc?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Dezso Zoltan" width="42"></a>
 <p class="linkMark">
 <a href="http://zaki.asia">Dezso Zoltan</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://www.twitter.com/ope"><img alt="Takanori Nakanowatari" height="42" src="http://www.gravatar.com/avatar/55bcf6eb5de45a70e76f8a2678822ecb?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takanori Nakanowatari" width="42"></a>
+<a href="http://www.twitter.com/ope"><img alt="Takanori Nakanowatari" height="42" src="https://www.gravatar.com/avatar/55bcf6eb5de45a70e76f8a2678822ecb?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takanori Nakanowatari" width="42"></a>
 <p class="linkMark">
 <a href="http://www.twitter.com/ope">Takanori Nakanowatari</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="https://github.com/zev"><img alt="Zev Blut" height="42" src="http://www.gravatar.com/avatar/1c77ad9f35746369dd1f4dd69b9f8b18?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Zev Blut" width="42"></a>
+<a href="https://github.com/zev"><img alt="Zev Blut" height="42" src="https://www.gravatar.com/avatar/1c77ad9f35746369dd1f4dd69b9f8b18?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Zev Blut" width="42"></a>
 <p class="linkMark">
 <a href="https://github.com/zev">Zev Blut</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://tako3.com/http://rubykaigi.org/rubyists/kei-s"><img alt="kei-s" height="42" src="http://www.gravatar.com/avatar/bf7ce9b68bbb0058721906b4db15b9b5?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="kei-s" width="42"></a>
+<a href="http://tako3.com/http://rubykaigi.org/rubyists/kei-s"><img alt="kei-s" height="42" src="https://www.gravatar.com/avatar/bf7ce9b68bbb0058721906b4db15b9b5?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="kei-s" width="42"></a>
 <p class="linkMark">
 <a href="http://tako3.com/http://rubykaigi.org/rubyists/kei-s">kei-s</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://twitter.com/bobbyjam99"><img alt="Tomokazu IMAI" height="42" src="http://www.gravatar.com/avatar/33814e72445b35ad3b65b1b05e699adc?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomokazu IMAI" width="42"></a>
+<a href="http://twitter.com/bobbyjam99"><img alt="Tomokazu IMAI" height="42" src="https://www.gravatar.com/avatar/33814e72445b35ad3b65b1b05e699adc?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomokazu IMAI" width="42"></a>
 <p class="linkMark">
 <a href="http://twitter.com/bobbyjam99">Tomokazu IMAI</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://twitter.com/hasimo"><img alt="Tohru Hashimoto" height="42" src="http://www.gravatar.com/avatar/6e3d1578114e5d3951a7f90579fff74c?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tohru Hashimoto" width="42"></a>
+<a href="http://twitter.com/hasimo"><img alt="Tohru Hashimoto" height="42" src="https://www.gravatar.com/avatar/6e3d1578114e5d3951a7f90579fff74c?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tohru Hashimoto" width="42"></a>
 <p class="linkMark">
 <a href="http://twitter.com/hasimo">Tohru Hashimoto</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://www.mobalean.com/founders/michael"><img alt="Michael Reinsch" height="42" src="http://www.gravatar.com/avatar/c7915a424cbb28fdd6c1cce270be6b58?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Michael Reinsch" width="42"></a>
+<a href="http://www.mobalean.com/founders/michael"><img alt="Michael Reinsch" height="42" src="https://www.gravatar.com/avatar/c7915a424cbb28fdd6c1cce270be6b58?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Michael Reinsch" width="42"></a>
 <p class="linkMark">
 <a href="http://www.mobalean.com/founders/michael">Michael Reinsch</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://twitter.com/sandinist"><img alt="Tsuyoshi MAEHANA" height="42" src="http://www.gravatar.com/avatar/e8ebe7d4ec09c5dd77ee064706836f23?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tsuyoshi MAEHANA" width="42"></a>
+<a href="http://twitter.com/sandinist"><img alt="Tsuyoshi MAEHANA" height="42" src="https://www.gravatar.com/avatar/e8ebe7d4ec09c5dd77ee064706836f23?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tsuyoshi MAEHANA" width="42"></a>
 <p class="linkMark">
 <a href="http://twitter.com/sandinist">Tsuyoshi MAEHANA</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://sane.jp"><img alt="Murahashi Sanemat Kenichi" height="42" src="http://www.gravatar.com/avatar/5b1d016f87f05ff645ae572ccbbf0448?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Murahashi Sanemat Kenichi" width="42"></a>
+<a href="http://sane.jp"><img alt="Murahashi Sanemat Kenichi" height="42" src="https://www.gravatar.com/avatar/5b1d016f87f05ff645ae572ccbbf0448?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Murahashi Sanemat Kenichi" width="42"></a>
 <p class="linkMark">
 <a href="http://sane.jp">Murahashi Sanemat Kenichi</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://aerial.st"><img alt="Masato Ikeda" height="42" src="http://www.gravatar.com/avatar/03abf5741b7bbd28670af5ec92b6141d?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masato Ikeda" width="42"></a>
+<a href="http://aerial.st"><img alt="Masato Ikeda" height="42" src="https://www.gravatar.com/avatar/03abf5741b7bbd28670af5ec92b6141d?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masato Ikeda" width="42"></a>
 <p class="linkMark">
 <a href="http://aerial.st">Masato Ikeda</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://twitter.com/tex314"><img alt="OKAZAKI Takurou" height="42" src="http://www.gravatar.com/avatar/45c2cc1a731924edf1045d9146ca4a78?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="OKAZAKI Takurou" width="42"></a>
+<a href="http://twitter.com/tex314"><img alt="OKAZAKI Takurou" height="42" src="https://www.gravatar.com/avatar/45c2cc1a731924edf1045d9146ca4a78?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="OKAZAKI Takurou" width="42"></a>
 <p class="linkMark">
 <a href="http://twitter.com/tex314">OKAZAKI Takurou</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="https://twitter.com/toshi3221"><img alt="Toshiharu Takematsu" height="42" src="http://www.gravatar.com/avatar/3ca4621fbbb03278d4550f89e2f723ba?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Toshiharu Takematsu" width="42"></a>
+<a href="https://twitter.com/toshi3221"><img alt="Toshiharu Takematsu" height="42" src="https://www.gravatar.com/avatar/3ca4621fbbb03278d4550f89e2f723ba?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Toshiharu Takematsu" width="42"></a>
 <p class="linkMark">
 <a href="https://twitter.com/toshi3221">Toshiharu Takematsu</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://tdtds.jp"><img alt="TADA Tadashi" height="42" src="http://www.gravatar.com/avatar/846a80b9bf7ea7becb6c4ecd67bedd6f?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TADA Tadashi" width="42"></a>
+<a href="http://tdtds.jp"><img alt="TADA Tadashi" height="42" src="https://www.gravatar.com/avatar/846a80b9bf7ea7becb6c4ecd67bedd6f?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TADA Tadashi" width="42"></a>
 <p class="linkMark">
 <a href="http://tdtds.jp">TADA Tadashi</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://hisano.com"><img alt="HISANO Kozo" height="42" src="http://www.gravatar.com/avatar/b8fa07639c3b720c33ffdcaf89299dda?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="HISANO Kozo" width="42"></a>
+<a href="http://hisano.com"><img alt="HISANO Kozo" height="42" src="https://www.gravatar.com/avatar/b8fa07639c3b720c33ffdcaf89299dda?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="HISANO Kozo" width="42"></a>
 <p class="linkMark">
 <a href="http://hisano.com">HISANO Kozo</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://d.hatena.ne.jp/kouma31/"><img alt="kmuroi" height="42" src="http://www.gravatar.com/avatar/165599097b8533c91af2aad5d7b31449?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="kmuroi" width="42"></a>
+<a href="http://d.hatena.ne.jp/kouma31/"><img alt="kmuroi" height="42" src="https://www.gravatar.com/avatar/165599097b8533c91af2aad5d7b31449?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="kmuroi" width="42"></a>
 <p class="linkMark">
 <a href="http://d.hatena.ne.jp/kouma31/">kmuroi</a>
 </p>
@@ -824,21 +824,21 @@ Anonymous
 </div>
 <hr>
 <div class="avatar">
-<a href="http://twitter.com/h4n"><img alt="Han Kessels" height="42" src="http://www.gravatar.com/avatar/f0bd4ed83708d0af0e0d1374fc7e605b?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Han Kessels" width="42"></a>
+<a href="http://twitter.com/h4n"><img alt="Han Kessels" height="42" src="https://www.gravatar.com/avatar/f0bd4ed83708d0af0e0d1374fc7e605b?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Han Kessels" width="42"></a>
 <p class="linkMark">
 <a href="http://twitter.com/h4n">Han Kessels</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://twitter.com/takagi"><img alt="TAKAGI Masahiro" height="42" src="http://www.gravatar.com/avatar/c3f5a6e729b57f99cb9e7b3ca60152aa?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TAKAGI Masahiro" width="42"></a>
+<a href="http://twitter.com/takagi"><img alt="TAKAGI Masahiro" height="42" src="https://www.gravatar.com/avatar/c3f5a6e729b57f99cb9e7b3ca60152aa?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TAKAGI Masahiro" width="42"></a>
 <p class="linkMark">
 <a href="http://twitter.com/takagi">TAKAGI Masahiro</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://d.hatena.ne.jp/tmtms/"><img alt="TOMITA Masahiro" height="42" src="http://www.gravatar.com/avatar/e4763acee4cf0377437f614fc372a061?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TOMITA Masahiro" width="42"></a>
+<a href="http://d.hatena.ne.jp/tmtms/"><img alt="TOMITA Masahiro" height="42" src="https://www.gravatar.com/avatar/e4763acee4cf0377437f614fc372a061?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TOMITA Masahiro" width="42"></a>
 <p class="linkMark">
 <a href="http://d.hatena.ne.jp/tmtms/">TOMITA Masahiro</a>
 </p>
@@ -852,133 +852,133 @@ Anonymous
 </div>
 <hr>
 <div class="avatar">
-<a href="http://kmuto.jp/"><img alt="Kenshi Muto" height="42" src="http://www.gravatar.com/avatar/43d44fbc12adcf80c9fc24e235f48234?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kenshi Muto" width="42"></a>
+<a href="http://kmuto.jp/"><img alt="Kenshi Muto" height="42" src="https://www.gravatar.com/avatar/43d44fbc12adcf80c9fc24e235f48234?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kenshi Muto" width="42"></a>
 <p class="linkMark">
 <a href="http://kmuto.jp/">Kenshi Muto</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<img alt="1syo" height="42" src="http://www.gravatar.com/avatar/83899fe2d00874176098a3bb71b043be?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="1syo" width="42">
+<img alt="1syo" height="42" src="https://www.gravatar.com/avatar/83899fe2d00874176098a3bb71b043be?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="1syo" width="42">
 <p>
 1syo
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://fkino.net"><img alt="Fumihiko Kinoshita" height="42" src="http://www.gravatar.com/avatar/f301c0275838d562c72ea9177e7ddc68?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Fumihiko Kinoshita" width="42"></a>
+<a href="http://fkino.net"><img alt="Fumihiko Kinoshita" height="42" src="https://www.gravatar.com/avatar/f301c0275838d562c72ea9177e7ddc68?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Fumihiko Kinoshita" width="42"></a>
 <p class="linkMark">
 <a href="http://fkino.net">Fumihiko Kinoshita</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://blog.masuidrive.jp/"><img alt="Yuichiro MASUI" height="42" src="http://www.gravatar.com/avatar/0ec58a040e1e4e959c8566484b4bba19?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yuichiro MASUI" width="42"></a>
+<a href="http://blog.masuidrive.jp/"><img alt="Yuichiro MASUI" height="42" src="https://www.gravatar.com/avatar/0ec58a040e1e4e959c8566484b4bba19?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yuichiro MASUI" width="42"></a>
 <p class="linkMark">
 <a href="http://blog.masuidrive.jp/">Yuichiro MASUI</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://d.hatena.ne.jp/t2os/"><img alt="tatsuoSakurai" height="42" src="http://www.gravatar.com/avatar/092404bdf9897eba9ab16e61f56592db?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="tatsuoSakurai" width="42"></a>
+<a href="http://d.hatena.ne.jp/t2os/"><img alt="tatsuoSakurai" height="42" src="https://www.gravatar.com/avatar/092404bdf9897eba9ab16e61f56592db?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="tatsuoSakurai" width="42"></a>
 <p class="linkMark">
 <a href="http://d.hatena.ne.jp/t2os/">tatsuoSakurai</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://ogijun.org"><img alt="Junya Ogino" height="42" src="http://www.gravatar.com/avatar/3a82321f68500d9691a9e190979ac2f0?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Junya Ogino" width="42"></a>
+<a href="http://ogijun.org"><img alt="Junya Ogino" height="42" src="https://www.gravatar.com/avatar/3a82321f68500d9691a9e190979ac2f0?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Junya Ogino" width="42"></a>
 <p class="linkMark">
 <a href="http://ogijun.org">Junya Ogino</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://about.me/mackato"><img alt="Masakuni Kato" height="42" src="http://www.gravatar.com/avatar/28347314c7fc698b4ac0e01113545e25?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masakuni Kato" width="42"></a>
+<a href="http://about.me/mackato"><img alt="Masakuni Kato" height="42" src="https://www.gravatar.com/avatar/28347314c7fc698b4ac0e01113545e25?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masakuni Kato" width="42"></a>
 <p class="linkMark">
 <a href="http://about.me/mackato">Masakuni Kato</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://d.hatena.ne.jp/IWAKIRI"><img alt="IWAKIRI,Akiko" height="42" src="http://www.gravatar.com/avatar/2a02258781c7592d0da1cd5cffa627a8?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="IWAKIRI,Akiko" width="42"></a>
+<a href="http://d.hatena.ne.jp/IWAKIRI"><img alt="IWAKIRI,Akiko" height="42" src="https://www.gravatar.com/avatar/2a02258781c7592d0da1cd5cffa627a8?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="IWAKIRI,Akiko" width="42"></a>
 <p class="linkMark">
 <a href="http://d.hatena.ne.jp/IWAKIRI">IWAKIRI,Akiko</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://june29.jp/"><img alt="june29" height="42" src="http://www.gravatar.com/avatar/6fd9be5cd0196df5ad62a5a5f2be3c55?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="june29" width="42"></a>
+<a href="http://june29.jp/"><img alt="june29" height="42" src="https://www.gravatar.com/avatar/6fd9be5cd0196df5ad62a5a5f2be3c55?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="june29" width="42"></a>
 <p class="linkMark">
 <a href="http://june29.jp/">june29</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://www.socialtoprunners.jp/"><img alt="tomokazuhattanda" height="42" src="http://www.gravatar.com/avatar/19798587cb27b5220a5dcdbaa9a50d57?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="tomokazuhattanda" width="42"></a>
+<a href="http://www.socialtoprunners.jp/"><img alt="tomokazuhattanda" height="42" src="https://www.gravatar.com/avatar/19798587cb27b5220a5dcdbaa9a50d57?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="tomokazuhattanda" width="42"></a>
 <p class="linkMark">
 <a href="http://www.socialtoprunners.jp/">tomokazuhattanda</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://www.jamboree.jp/"><img alt="TOYOSHI, Ryuichiro" height="42" src="http://www.gravatar.com/avatar/203c324392b6c51241da5b42bbf888bd?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TOYOSHI, Ryuichiro" width="42"></a>
+<a href="http://www.jamboree.jp/"><img alt="TOYOSHI, Ryuichiro" height="42" src="https://www.gravatar.com/avatar/203c324392b6c51241da5b42bbf888bd?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TOYOSHI, Ryuichiro" width="42"></a>
 <p class="linkMark">
 <a href="http://www.jamboree.jp/">TOYOSHI, Ryuichiro</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://twitter.com/takano32"><img alt="たかのみつひろ" height="42" src="http://www.gravatar.com/avatar/eba4a40bdae5edfe1589601c050a2b96?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="たかのみつひろ" width="42"></a>
+<a href="http://twitter.com/takano32"><img alt="たかのみつひろ" height="42" src="https://www.gravatar.com/avatar/eba4a40bdae5edfe1589601c050a2b96?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="たかのみつひろ" width="42"></a>
 <p class="linkMark">
 <a href="http://twitter.com/takano32">たかのみつひろ</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://twitter.com/tyabe"><img alt="tyabe" height="42" src="http://www.gravatar.com/avatar/d21900444f5548d9329861593321b5a6?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="tyabe" width="42"></a>
+<a href="http://twitter.com/tyabe"><img alt="tyabe" height="42" src="https://www.gravatar.com/avatar/d21900444f5548d9329861593321b5a6?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="tyabe" width="42"></a>
 <p class="linkMark">
 <a href="http://twitter.com/tyabe">tyabe</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://twitter.com/#!/maxyz"><img alt="Masafumi Fujiwara" height="42" src="http://www.gravatar.com/avatar/4dd4d13d27559db2fb64ad069f2c49ba?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masafumi Fujiwara" width="42"></a>
+<a href="http://twitter.com/#!/maxyz"><img alt="Masafumi Fujiwara" height="42" src="https://www.gravatar.com/avatar/4dd4d13d27559db2fb64ad069f2c49ba?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masafumi Fujiwara" width="42"></a>
 <p class="linkMark">
 <a href="http://twitter.com/#!/maxyz">Masafumi Fujiwara</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://twitter.com/kdmsnr"><img alt="Masanori Kado" height="42" src="http://www.gravatar.com/avatar/70b07e6b7fe7d921d7ac542d0ccb3b2c?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masanori Kado" width="42"></a>
+<a href="http://twitter.com/kdmsnr"><img alt="Masanori Kado" height="42" src="https://www.gravatar.com/avatar/70b07e6b7fe7d921d7ac542d0ccb3b2c?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masanori Kado" width="42"></a>
 <p class="linkMark">
 <a href="http://twitter.com/kdmsnr">Masanori Kado</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://www.jitu.org/~tko"><img alt="Tomoyuki Kosimizu" height="42" src="http://www.gravatar.com/avatar/3585181753c22a9531e70a8297771b01?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomoyuki Kosimizu" width="42"></a>
+<a href="http://www.jitu.org/~tko"><img alt="Tomoyuki Kosimizu" height="42" src="https://www.gravatar.com/avatar/3585181753c22a9531e70a8297771b01?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomoyuki Kosimizu" width="42"></a>
 <p class="linkMark">
 <a href="http://www.jitu.org/~tko">Tomoyuki Kosimizu</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://twitter.com/chinmo"><img alt="Tomonori Fukuta" height="42" src="http://www.gravatar.com/avatar/7977a0896e60587b2690550891be2ea7?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomonori Fukuta" width="42"></a>
+<a href="http://twitter.com/chinmo"><img alt="Tomonori Fukuta" height="42" src="https://www.gravatar.com/avatar/7977a0896e60587b2690550891be2ea7?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomonori Fukuta" width="42"></a>
 <p class="linkMark">
 <a href="http://twitter.com/chinmo">Tomonori Fukuta</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<img alt="YOKOTA Akiko" height="42" src="http://www.gravatar.com/avatar/03e548747e667fc94cc8495868bfd85e?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="YOKOTA Akiko" width="42">
+<img alt="YOKOTA Akiko" height="42" src="https://www.gravatar.com/avatar/03e548747e667fc94cc8495868bfd85e?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="YOKOTA Akiko" width="42">
 <p>
 YOKOTA Akiko
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://nov.tdiary.net/"><img alt="Nobuhiro IMAI" height="42" src="http://www.gravatar.com/avatar/e49ab9f0774711c473660019728cde95?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Nobuhiro IMAI" width="42"></a>
+<a href="http://nov.tdiary.net/"><img alt="Nobuhiro IMAI" height="42" src="https://www.gravatar.com/avatar/e49ab9f0774711c473660019728cde95?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Nobuhiro IMAI" width="42"></a>
 <p class="linkMark">
 <a href="http://nov.tdiary.net/">Nobuhiro IMAI</a>
 </p>

--- a/2011/en/team/index.html
+++ b/2011/en/team/index.html
@@ -91,7 +91,7 @@ Team
 <div class="section">
 <h2>Chairman</h2>
 <div class="avatar">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/21a4b941766d805333e11c5766be43b4?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/21a4b941766d805333e11c5766be43b4?s=32" width="32">
 <p>
 <span class="name">Masayoshi TAKAHASHI</span>
 <span class="affiliation">Nihon Ruby-no-Kai, Chairman / tatsu-zine.com</span>
@@ -101,7 +101,7 @@ Team
 <div class="section">
 <h2>Vice Chairman</h2>
 <div class="avatar">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/63a6bff89d692e21de20868202bc8dde?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/63a6bff89d692e21de20868202bc8dde?s=32" width="32">
 <p>
 <span class="name">Shintaro KAKUTANI</span>
 <span class="affiliation">Nihon Ruby-no-Kai || Eiwa System Management</span>
@@ -111,7 +111,7 @@ Team
 <div class="section">
 <h2>Chief of Operations</h2>
 <div class="avatar">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/941b170e5a115a295cccb5f5cdf0a800?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/941b170e5a115a295cccb5f5cdf0a800?s=32" width="32">
 <p>
 <span class="name">Koji SHIMADA</span>
 <span class="affiliation">Nihon Ruby-no-Kai / Enishi Tech</span>
@@ -131,7 +131,7 @@ Team
 <div class="section">
 <h2>Sponsor Liaison</h2>
 <div class="avatar">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/2e9a2dbe335e0111e4879a9d65dcbae0?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/2e9a2dbe335e0111e4879a9d65dcbae0?s=32" width="32">
 <p>
 <span class="name">Ayumu AIZAWA</span>
 <span class="affiliation">Nihon Ruby-no-Kai, Akasaka.rb</span>
@@ -148,42 +148,42 @@ Team
 <div class="section">
 <h2>Organizers</h2>
 <div class="avatar">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/254df3f07b068f422ef943dc1a2d7e04?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/254df3f07b068f422ef943dc1a2d7e04?s=32" width="32">
 <p>
 <span class="name">Shin'ya ADZUMI</span>
 <span class="affiliation">Nihon Ruby-no-Kai, TechnoVan</span>
 </p>
 </div>
 <div class="avatar">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/f37b9a968b2326062190677906a93080?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/f37b9a968b2326062190677906a93080?s=32" width="32">
 <p>
 <span class="name">Miho SUZUKI</span>
 <span class="affiliation">@adzuki34</span>
 </p>
 </div>
 <div class="avatar">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/70762059db0218c6f0ff48042ca0756a?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/70762059db0218c6f0ff48042ca0756a?s=32" width="32">
 <p>
 <span class="name">Leonard Chin</span>
 <span class="affiliation">Nihon Ruby-no-Kai || Dwango</span>
 </p>
 </div>
 <div class="avatar">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/817b7699ccbd3a6664de66eee8c2cbd2?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/817b7699ccbd3a6664de66eee8c2cbd2?s=32" width="32">
 <p>
 <span class="name">Yoji SHIDARA</span>
 <span class="affiliation">Ruby Sapporo / Enishi Tech</span>
 </p>
 </div>
 <div class="avatar">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/6fd9be5cd0196df5ad62a5a5f2be3c55?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/6fd9be5cd0196df5ad62a5a5f2be3c55?s=32" width="32">
 <p>
 <span class="name">Jun OHWADA</span>
 <span class="affiliation">Ruby Sapporo, Scigineer</span>
 </p>
 </div>
 <div class="avatar">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/046d95b910ab412d0c059caac797ade3?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/046d95b910ab412d0c059caac797ade3?s=32" width="32">
 <p>
 <span class="name">Kei SHIRATSUCHI</span>
 <span class="affiliation">Ruby Sapporo, Scigineer</span>
@@ -197,7 +197,7 @@ Team
 </p>
 </div>
 <div class="avatar">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/9d2d4c8b739b1b4d7882ba49dcf1d276?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/9d2d4c8b739b1b4d7882ba49dcf1d276?s=32" width="32">
 <p>
 <span class="name">Toshiaki KOSHIBA</span>
 <span class="affiliation">EC Navi Company, Shibuya.rb, Chiba.rb</span>
@@ -218,7 +218,7 @@ Team
 </p>
 </div>
 <div class="avatar">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/092404bdf9897eba9ab16e61f56592db?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/092404bdf9897eba9ab16e61f56592db?s=32" width="32">
 <p>
 <span class="name">Tasuo SAKURAI</span>
 <span class="affiliation">Everyleaf</span>
@@ -232,7 +232,7 @@ Team
 </p>
 </div>
 <div class="avatar">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/9d2f78236e45a335301ba1195026105d?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/9d2f78236e45a335301ba1195026105d?s=32" width="32">
 <p>
 <span class="name">Shyouhei URABE</span>
 <span class="affiliation">Network Applied Communication Laboratory</span>
@@ -259,14 +259,14 @@ Team
 <div class="section">
 <h2>Designer</h2>
 <div class="avatar">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/00575484b5d4489619bfc52e9775ee3b?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/00575484b5d4489619bfc52e9775ee3b?s=32" width="32">
 <p>
 <span class="name">Mayuko SEKIYA</span>
 <span class="affiliation">@mayuco / Enishi Tech</span>
 </p>
 </div>
 <div class="avatar">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/465f37a716f559211948394e549a164d?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/465f37a716f559211948394e549a164d?s=32" width="32">
 <p>
 <span class="name">Norio</span>
 <span class="affiliation">@norio, pixiv Inc.</span>
@@ -276,35 +276,35 @@ Team
 <div class="section">
 <h2>KaigiFreaks::ReportTeam</h2>
 <div class="avatar">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/8f39a252784d5a99589be6e20c4553fb?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/8f39a252784d5a99589be6e20c4553fb?s=32" width="32">
 <p>
 <span class="name">Mitsutaka MIMURA</span>
 <span class="affiliation">Eiwa System Management, asakusa.rb</span>
 </p>
 </div>
 <div class="avatar">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/961126d9892ae4df45249529a0721571?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/961126d9892ae4df45249529a0721571?s=32" width="32">
 <p>
 <span class="name">Masanori SUGAWARA</span>
 <span class="affiliation">@sugamasao</span>
 </p>
 </div>
 <div class="avatar">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/15e2d5cb578d7dc3147fc2be901ecd5f?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/15e2d5cb578d7dc3147fc2be901ecd5f?s=32" width="32">
 <p>
 <span class="name">Yuki AKAMATSU</span>
 <span class="affiliation">@ukstudio</span>
 </p>
 </div>
 <div class="avatar">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/527e2af04bd5b212b479840016274cdb?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/527e2af04bd5b212b479840016274cdb?s=32" width="32">
 <p>
 <span class="name">Yutaro SUGAI</span>
 <span class="affiliation">@hokkai7go</span>
 </p>
 </div>
 <div class="avatar">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/a6945e4a032aaa4109e5818465d62b06?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/a6945e4a032aaa4109e5818465d62b06?s=32" width="32">
 <p>
 <span class="name">Noriyuki Komatsuzaki</span>
 <span class="affiliation">@oshow</span>
@@ -314,7 +314,7 @@ Team
 <div class="section">
 <h2>KaigiFreaks::NetworkTeam</h2>
 <div class="avatar">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/256838377ddbe600e85d8f446aae224d?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/256838377ddbe600e85d8f446aae224d?s=32" width="32">
 <p>
 <span class="name">Hidekazu KOIWA</span>
 <span class="affiliation">LOCAL, ESTCOSMO Co.,Ltd., 88nite</span>
@@ -331,7 +331,7 @@ Team
 </p>
 </div>
 <div class="avatar">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/8e528456ff66ec543952daa815353a01?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/8e528456ff66ec543952daa815353a01?s=32" width="32">
 <p>
 <span class="name">Norio SUZUKI</span>
 <span class="affiliation">@suzuki</span>
@@ -355,14 +355,14 @@ Team
 <div class="section">
 <h2>Staff</h2>
 <div class="avatar">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/dc03a27ae31ba428c560c00c9128cd75?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/dc03a27ae31ba428c560c00c9128cd75?s=32" width="32">
 <p>
 <span class="name">Ryunosuke SATO</span>
 <span class="affiliation">Enishi Tech Inc., Sapporo.js , @tricknotes</span>
 </p>
 </div>
 <div class="avatar">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/f8fbcb02824678dbc843748e8da20d24?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/f8fbcb02824678dbc843748e8da20d24?s=32" width="32">
 <p>
 <span class="name">Hiroki Yoshioka</span>
 <span class="affiliation">irohiroki.com</span>
@@ -390,7 +390,7 @@ Team
 </p>
 </div>
 <div class="avatar">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/de0df5acda15a9c7eeb6c28a5e5d4e8e?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/de0df5acda15a9c7eeb6c28a5e5d4e8e?s=32" width="32">
 <p>
 <span class="name">Gentaro TERADA</span>
 <span class="affiliation">Eiwa System Management, @hibariya</span>
@@ -411,14 +411,14 @@ Team
 </p>
 </div>
 <div class="avatar">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/fbcf9ed09205a5093069f0a2ccccfdf8?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/fbcf9ed09205a5093069f0a2ccccfdf8?s=32" width="32">
 <p>
 <span class="name">Kazuya NUMATA</span>
 <span class="affiliation">ESTCOSMO Co.,Ltd., LOCAL, @kaznum</span>
 </p>
 </div>
 <div class="avatar">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/164a161443835d8479c19d33241cab2a?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/164a161443835d8479c19d33241cab2a?s=32" width="32">
 <p>
 <span class="name">SASAKI Daisuke</span>
 <span class="affiliation">LOCAL, OpenSource, Inc.</span>
@@ -439,7 +439,7 @@ Team
 </p>
 </div>
 <div class="avatar">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/8a689b8579d0640762b48ecd0df2271c?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/8a689b8579d0640762b48ecd0df2271c?s=32" width="32">
 <p>
 <span class="name">Motoki Ito</span>
 <span class="affiliation">@gnnk</span>
@@ -460,14 +460,14 @@ Team
 </p>
 </div>
 <div class="avatar">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/d6fc8a819afa94f464fe322032a6687f?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/d6fc8a819afa94f464fe322032a6687f?s=32" width="32">
 <p>
 <span class="name">Mahito OGURA</span>
 <span class="affiliation">@Mahito</span>
 </p>
 </div>
 <div class="avatar">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/70405ca68e6f8779be65e75b1a90525b?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/70405ca68e6f8779be65e75b1a90525b?s=32" width="32">
 <p>
 <span class="name">Junichiro Kita</span>
 <span class="affiliation">@kitaj</span>
@@ -481,7 +481,7 @@ Team
 </p>
 </div>
 <div class="avatar">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/63ed460c175ed37b9427ebb9e397c86b?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/63ed460c175ed37b9427ebb9e397c86b?s=32" width="32">
 <p>
 <span class="name">Kai Suzuki</span>
 <span class="affiliation">@ZoAmichi</span>
@@ -543,14 +543,14 @@ Team
 <div class="section">
 <h2>LT Timer Developer &amp; Operator</h2>
 <div class="avatar">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/ea4f647d2ebc49e087fb84739194b19c?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/ea4f647d2ebc49e087fb84739194b19c?s=32" width="32">
 <p>
 <span class="name">Katsuyoshi ITO</span>
 <span class="affiliation">ITO SOFT DESIGN, Akita.m</span>
 </p>
 </div>
 <div class="avatar">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/5ad0bb268dd2605b09165d464308cb7e?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/5ad0bb268dd2605b09165d464308cb7e?s=32" width="32">
 <p>
 <span class="name">Kuniaki IGARASHI</span>
 <span class="affiliation">Everyleaf, @igaiga555</span>

--- a/2011/index.html
+++ b/2011/index.html
@@ -469,55 +469,39 @@ Gold Sponsor
 </h2>
 <ul>
 <li>
-<a href="http://shyouhei.tumblr.com"><img alt="Urabe, Shyouhei" height="32" src="http://www.gravatar.com/avatar/9d2f78236e45a335301ba1195026105d?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Urabe, Shyouhei" width="32"></a>
+<a href="http://shyouhei.tumblr.com"><img alt="Urabe, Shyouhei" height="32" src="https://www.gravatar.com/avatar/9d2f78236e45a335301ba1195026105d?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Urabe, Shyouhei" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/noplans"><img alt="TANIGUCHI Fumitake" height="32" src="http://www.gravatar.com/avatar/e514ae09c9b84e04231af57f1d1946b8?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TANIGUCHI Fumitake" width="32"></a>
+<a href="http://twitter.com/noplans"><img alt="TANIGUCHI Fumitake" height="32" src="https://www.gravatar.com/avatar/e514ae09c9b84e04231af57f1d1946b8?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TANIGUCHI Fumitake" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://jmettraux.wordpress.com"><img alt="John Mettraux" height="32" src="http://www.gravatar.com/avatar/8d96626e52beb1ff90f57a8e189e1e6f?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="John Mettraux" width="32"></a>
+<a href="http://jmettraux.wordpress.com"><img alt="John Mettraux" height="32" src="https://www.gravatar.com/avatar/8d96626e52beb1ff90f57a8e189e1e6f?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="John Mettraux" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/japanrock"><img alt="Shintaro Nozaki" height="32" src="http://www.gravatar.com/avatar/b31a258dd8f615f61b2d355297f82dc9?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shintaro Nozaki" width="32"></a>
+<a href="http://twitter.com/japanrock"><img alt="Shintaro Nozaki" height="32" src="https://www.gravatar.com/avatar/b31a258dd8f615f61b2d355297f82dc9?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shintaro Nozaki" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://blog.dio.jp"><img alt="Akira Matsuda" height="32" src="http://www.gravatar.com/avatar/76a777ff80f30bd3b390e275cce625bc?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Akira Matsuda" width="32"></a>
+<a href="http://blog.dio.jp"><img alt="Akira Matsuda" height="32" src="https://www.gravatar.com/avatar/76a777ff80f30bd3b390e275cce625bc?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Akira Matsuda" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.bovensiepen.net"><img alt="Daniel Bovensiepen" height="32" src="http://www.gravatar.com/avatar/49d6f762505615af259534deed94bc54?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Daniel Bovensiepen" width="32"></a>
+<a href="http://www.bovensiepen.net"><img alt="Daniel Bovensiepen" height="32" src="https://www.gravatar.com/avatar/49d6f762505615af259534deed94bc54?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Daniel Bovensiepen" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://firn.jp/"><img alt="Dai Akatsuka" height="32" src="http://www.gravatar.com/avatar/4efe7b5cdbe97df84e6e607948171eef?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Dai Akatsuka" width="32"></a>
+<a href="http://firn.jp/"><img alt="Dai Akatsuka" height="32" src="https://www.gravatar.com/avatar/4efe7b5cdbe97df84e6e607948171eef?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Dai Akatsuka" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.din.or.jp/~shinodas/"><img alt="Yoshihiko Hara" height="32" src="http://www.gravatar.com/avatar/8055fbffa700065178460bb7e3b8ee24?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yoshihiko Hara" width="32"></a>
+<a href="http://www.din.or.jp/~shinodas/"><img alt="Yoshihiko Hara" height="32" src="https://www.gravatar.com/avatar/8055fbffa700065178460bb7e3b8ee24?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yoshihiko Hara" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://benhoskin.gs"><img alt="Ben Hoskings" height="32" src="http://www.gravatar.com/avatar/7ed99cb90a060539d729e2491442a603?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ben Hoskings" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<img alt="Anonymous" height="32" src="/2011/images/bow_face.png?1359134037" title="Anonymous" width="32">
-<a href="#"></a>
-</li>
-<li>
-<a href="http://www.nextseed.jp/"><img alt="Hitoshi Kurokawa" height="32" src="http://www.gravatar.com/avatar/11e89e3c85d9998b2c73933bde77c71e?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hitoshi Kurokawa" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://d.hatena.ne.jp/kinpoco/"><img alt="Yutaka Kanemoto" height="32" src="http://www.gravatar.com/avatar/0e728bf538d1848bc253d80a8626bbc2?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yutaka Kanemoto" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://d.hatena.ne.jp/yuichi_katahira"><img alt="Yuichi Katahira " height="32" src="http://www.gravatar.com/avatar/3072ae08f580fc8474b47652a3d8dd0f?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yuichi Katahira " width="32"></a>
+<a href="http://benhoskin.gs"><img alt="Ben Hoskings" height="32" src="https://www.gravatar.com/avatar/7ed99cb90a060539d729e2491442a603?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ben Hoskings" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
@@ -525,87 +509,15 @@ Gold Sponsor
 <a href="#"></a>
 </li>
 <li>
-<a href="http://kitaj.no-ip.com/tdiary/"><img alt="Junichiro Kita" height="32" src="http://www.gravatar.com/avatar/70405ca68e6f8779be65e75b1a90525b?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Junichiro Kita" width="32"></a>
+<a href="http://www.nextseed.jp/"><img alt="Hitoshi Kurokawa" height="32" src="https://www.gravatar.com/avatar/11e89e3c85d9998b2c73933bde77c71e?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hitoshi Kurokawa" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/idesaku"><img alt="Daisuke Goto" height="32" src="http://www.gravatar.com/avatar/85c8086344e5f31b2a4d22f163660536?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Daisuke Goto" width="32"></a>
+<a href="http://d.hatena.ne.jp/kinpoco/"><img alt="Yutaka Kanemoto" height="32" src="https://www.gravatar.com/avatar/0e728bf538d1848bc253d80a8626bbc2?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yutaka Kanemoto" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<img alt="Anonymous" height="32" src="/2011/images/bow_face.png?1359134037" title="Anonymous" width="32">
-<a href="#"></a>
-</li>
-<li>
-<a href="http://www.on-sky.net/~hs/"><img alt="Hideki SAKAMOTO" height="32" src="http://www.gravatar.com/avatar/7038a6cfc30b8c3b00b5c08d70cda2f1?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hideki SAKAMOTO" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://twitter.com/agilekawabata"><img alt="Kawabata Mitsuyoshi" height="32" src="http://www.gravatar.com/avatar/5236eb3ad498b3c5336a4575408fb1b1?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kawabata Mitsuyoshi" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://www.kt.rim.or.jp/~kbk/"><img alt="KIMURA Koichi" height="32" src="http://www.gravatar.com/avatar/04c1a31d1e33e7fc25a7ca99930e4c70?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="KIMURA Koichi" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://d.hatena.ne.jp/takkaw/"><img alt="Takayoshi Kawada" height="32" src="http://www.gravatar.com/avatar/38bf2ca557d9cc20dcdcbd773a68664b?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takayoshi Kawada" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://www.suchi.org/"><img alt="Shigeru UCHIYAMA" height="32" src="http://www.gravatar.com/avatar/398e2dd764d43aad735c6e5bca92c3b6?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shigeru UCHIYAMA" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://twitter.com/#!/andrewjgrimm"><img alt="Andrew Grimm" height="32" src="http://www.gravatar.com/avatar/01bbb59a1c3ef9960f25a97afe7e920f?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Andrew Grimm" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://twitter.com/kimuraw"><img alt="kimura wataru" height="32" src="http://www.gravatar.com/avatar/e298234a6e5a2c159287476abd76504a?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="kimura wataru" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://saikyoline.jp/"><img alt="MIKAMI Yoshiyuki" height="32" src="http://www.gravatar.com/avatar/e0920f5f813ae29ba7859f950a7f0df3?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MIKAMI Yoshiyuki" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://jp.rubyist.net/?KansaiWorkshop"><img alt="HIGAKI Masaru" height="32" src="http://www.gravatar.com/avatar/a8192f5a7b25ef32a983740ee8593bd3?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="HIGAKI Masaru" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://twitter.com/ayumin"><img alt="Ayumu AIZAWA" height="32" src="http://www.gravatar.com/avatar/2e9a2dbe335e0111e4879a9d65dcbae0?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ayumu AIZAWA" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://shunichi-arai.blogspot.com/"><img alt="Shunichi Arai" height="32" src="http://www.gravatar.com/avatar/74daf3516e33a75968ec0f933954b5a8?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shunichi Arai" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://www.tokyodev.com"><img alt="Paul McMahon" height="32" src="http://www.gravatar.com/avatar/dd24adb5a3a430fed83a33ed552fe1b5?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Paul McMahon" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://d.hatena.ne.jp/hs9587/"><img alt="Hiroyuki Shimura" height="32" src="http://www.gravatar.com/avatar/287a899c91a7a14535188d7e4784050e?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hiroyuki Shimura" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://kakutani.com"><img alt="Kakutani Shintaro" height="32" src="http://www.gravatar.com/avatar/34fcd5f1deeb25b1138e9845137feb6e?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kakutani Shintaro" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://d.hatena.ne.jp/mrkn"><img alt="Kenta Murata" height="32" src="http://www.gravatar.com/avatar/819b3c0a25f9708fd32261b8ae2d23f6?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kenta Murata" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://rails.to"><img alt="Masatoshi Itagaki" height="32" src="http://www.gravatar.com/avatar/f8865f41777ef3caced0e4e6801ff83a?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masatoshi Itagaki" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://spring-aki.com/"><img alt="Aki" height="32" src="http://www.gravatar.com/avatar/81f2122b45f48829be4507bf972666e9?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Aki" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://twitter.com/shin_asou"><img alt="Shinichi Okada" height="32" src="http://www.gravatar.com/avatar/20805358592bd93f92bf15aa10137251?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shinichi Okada" width="32"></a>
+<a href="http://d.hatena.ne.jp/yuichi_katahira"><img alt="Yuichi Katahira " height="32" src="https://www.gravatar.com/avatar/3072ae08f580fc8474b47652a3d8dd0f?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yuichi Katahira " width="32"></a>
 <a href="#"></a>
 </li>
 <li>
@@ -613,35 +525,11 @@ Gold Sponsor
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.kumaryu.net/"><img alt="Ryuichi Sakamoto" height="32" src="http://www.gravatar.com/avatar/1b2ca00132480422c75c1f2c61e84e26?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ryuichi Sakamoto" width="32"></a>
+<a href="http://kitaj.no-ip.com/tdiary/"><img alt="Junichiro Kita" height="32" src="https://www.gravatar.com/avatar/70405ca68e6f8779be65e75b1a90525b?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Junichiro Kita" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<img alt="Eito Katagiri" height="32" src="http://www.gravatar.com/avatar/b5852cf79505d7ba513f8f16ef95a50f?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Eito Katagiri" width="32">
-<a href="#"></a>
-</li>
-<li>
-<a href="http://ukstudio.jp/"><img alt="AKAMATSU Yuki" height="32" src="http://www.gravatar.com/avatar/0c471249ee93ab17a011f3e8d2b1057a?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="AKAMATSU Yuki" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://hisashim.org"><img alt="Hisashi Morita" height="32" src="http://www.gravatar.com/avatar/b3fba7af93cd27e6ed28e7eae88a9585?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hisashi Morita" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://d.hatena.ne.jp/muryoImpl/"><img alt="Ken muryoi" height="32" src="http://www.gravatar.com/avatar/ac6dba8ce93944d17714de362ca17e54?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ken muryoi" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://d.hatena.ne.jp/nagachika/"><img alt="Tomoyuki Chikanaga" height="32" src="http://www.gravatar.com/avatar/5cf8f058a4c094bb708174fb43e7a387?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomoyuki Chikanaga" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://d.hatena.ne.jp/takeshinoda/"><img alt="Takeshi SHINODA" height="32" src="http://www.gravatar.com/avatar/06febd004d7cc9c9f6a4e0272b686bc7?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takeshi SHINODA" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://twitter.com/knsmr"><img alt="Ken Nishimura" height="32" src="http://www.gravatar.com/avatar/91fb4852880d1727cca911036e2fef5f?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ken Nishimura" width="32"></a>
+<a href="http://d.hatena.ne.jp/idesaku"><img alt="Daisuke Goto" height="32" src="https://www.gravatar.com/avatar/85c8086344e5f31b2a4d22f163660536?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Daisuke Goto" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
@@ -649,35 +537,75 @@ Gold Sponsor
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/koko_u/"><img alt="Kozaki Tsuneaki" height="32" src="http://www.gravatar.com/avatar/5b1b558d563288da615a9ea2889afdd5?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kozaki Tsuneaki" width="32"></a>
+<a href="http://www.on-sky.net/~hs/"><img alt="Hideki SAKAMOTO" height="32" src="https://www.gravatar.com/avatar/7038a6cfc30b8c3b00b5c08d70cda2f1?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hideki SAKAMOTO" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/adzuki34"><img alt="SUZUKI Miho" height="32" src="http://www.gravatar.com/avatar/f37b9a968b2326062190677906a93080?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="SUZUKI Miho" width="32"></a>
+<a href="http://twitter.com/agilekawabata"><img alt="Kawabata Mitsuyoshi" height="32" src="https://www.gravatar.com/avatar/5236eb3ad498b3c5336a4575408fb1b1?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kawabata Mitsuyoshi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/lchin"><img alt="Leonard Chin" height="32" src="http://www.gravatar.com/avatar/70762059db0218c6f0ff48042ca0756a?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Leonard Chin" width="32"></a>
+<a href="http://www.kt.rim.or.jp/~kbk/"><img alt="KIMURA Koichi" height="32" src="https://www.gravatar.com/avatar/04c1a31d1e33e7fc25a7ca99930e4c70?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="KIMURA Koichi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/suzumura_ss/"><img alt="Toshiyuki Terashita" height="32" src="http://www.gravatar.com/avatar/bb8b58cab667163b6ee53aad0e5f0414?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Toshiyuki Terashita" width="32"></a>
+<a href="http://d.hatena.ne.jp/takkaw/"><img alt="Takayoshi Kawada" height="32" src="https://www.gravatar.com/avatar/38bf2ca557d9cc20dcdcbd773a68664b?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takayoshi Kawada" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://sites.google.com/site/akihikohashimoto/"><img alt="Akihiko Hashimoto" height="32" src="http://www.gravatar.com/avatar/c8803a4130c3238e34b605d0a0cffe94?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Akihiko Hashimoto" width="32"></a>
+<a href="http://www.suchi.org/"><img alt="Shigeru UCHIYAMA" height="32" src="https://www.gravatar.com/avatar/398e2dd764d43aad735c6e5bca92c3b6?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shigeru UCHIYAMA" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<img alt="OZAWA Sakuro" height="32" src="http://www.gravatar.com/avatar/a1cbed8bf64473e2acdd0c7066cc5b29?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="OZAWA Sakuro" width="32">
+<a href="http://twitter.com/#!/andrewjgrimm"><img alt="Andrew Grimm" height="32" src="https://www.gravatar.com/avatar/01bbb59a1c3ef9960f25a97afe7e920f?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Andrew Grimm" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://fkmn.exblog.jp/"><img alt="Arinobu FUKUHARA" height="32" src="http://www.gravatar.com/avatar/85319f2b72d7b37ddef5c25a2dd40d30?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Arinobu FUKUHARA" width="32"></a>
+<a href="http://twitter.com/kimuraw"><img alt="kimura wataru" height="32" src="https://www.gravatar.com/avatar/e298234a6e5a2c159287476abd76504a?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="kimura wataru" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/shachi"><img alt="Kazuyuki Koizuka-shachi" height="32" src="http://www.gravatar.com/avatar/f51ee84097a72a8d91bee9bb98736541?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kazuyuki Koizuka-shachi" width="32"></a>
+<a href="http://saikyoline.jp/"><img alt="MIKAMI Yoshiyuki" height="32" src="https://www.gravatar.com/avatar/e0920f5f813ae29ba7859f950a7f0df3?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MIKAMI Yoshiyuki" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://jp.rubyist.net/?KansaiWorkshop"><img alt="HIGAKI Masaru" height="32" src="https://www.gravatar.com/avatar/a8192f5a7b25ef32a983740ee8593bd3?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="HIGAKI Masaru" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://twitter.com/ayumin"><img alt="Ayumu AIZAWA" height="32" src="https://www.gravatar.com/avatar/2e9a2dbe335e0111e4879a9d65dcbae0?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ayumu AIZAWA" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://shunichi-arai.blogspot.com/"><img alt="Shunichi Arai" height="32" src="https://www.gravatar.com/avatar/74daf3516e33a75968ec0f933954b5a8?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shunichi Arai" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://www.tokyodev.com"><img alt="Paul McMahon" height="32" src="https://www.gravatar.com/avatar/dd24adb5a3a430fed83a33ed552fe1b5?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Paul McMahon" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://d.hatena.ne.jp/hs9587/"><img alt="Hiroyuki Shimura" height="32" src="https://www.gravatar.com/avatar/287a899c91a7a14535188d7e4784050e?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hiroyuki Shimura" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://kakutani.com"><img alt="Kakutani Shintaro" height="32" src="https://www.gravatar.com/avatar/34fcd5f1deeb25b1138e9845137feb6e?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kakutani Shintaro" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://d.hatena.ne.jp/mrkn"><img alt="Kenta Murata" height="32" src="https://www.gravatar.com/avatar/819b3c0a25f9708fd32261b8ae2d23f6?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kenta Murata" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://rails.to"><img alt="Masatoshi Itagaki" height="32" src="https://www.gravatar.com/avatar/f8865f41777ef3caced0e4e6801ff83a?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masatoshi Itagaki" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://spring-aki.com/"><img alt="Aki" height="32" src="https://www.gravatar.com/avatar/81f2122b45f48829be4507bf972666e9?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Aki" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://twitter.com/shin_asou"><img alt="Shinichi Okada" height="32" src="https://www.gravatar.com/avatar/20805358592bd93f92bf15aa10137251?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shinichi Okada" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
@@ -685,103 +613,175 @@ Gold Sponsor
 <a href="#"></a>
 </li>
 <li>
-<a href="http://atakigu.tumblr.com/"><img alt="atakig" height="32" src="http://www.gravatar.com/avatar/8a949c60e450d226de776072273a1ffc?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="atakig" width="32"></a>
+<a href="http://www.kumaryu.net/"><img alt="Ryuichi Sakamoto" height="32" src="https://www.gravatar.com/avatar/1b2ca00132480422c75c1f2c61e84e26?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ryuichi Sakamoto" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<img alt="TSUTSUI Toshinori" height="32" src="http://www.gravatar.com/avatar/ad66fd981c429c12e0f76c436da3337e?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TSUTSUI Toshinori" width="32">
+<img alt="Eito Katagiri" height="32" src="https://www.gravatar.com/avatar/b5852cf79505d7ba513f8f16ef95a50f?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Eito Katagiri" width="32">
 <a href="#"></a>
 </li>
 <li>
-<a href="http://yugui.jp"><img alt="Yuki Sonoda (Yugui)" height="32" src="http://www.gravatar.com/avatar/1e7e007723cfe59320d994a7db4ab4cf?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yuki Sonoda (Yugui)" width="32"></a>
+<a href="http://ukstudio.jp/"><img alt="AKAMATSU Yuki" height="32" src="https://www.gravatar.com/avatar/0c471249ee93ab17a011f3e8d2b1057a?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="AKAMATSU Yuki" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/seiunsky"><img alt="sugamasao" height="32" src="http://www.gravatar.com/avatar/961126d9892ae4df45249529a0721571?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="sugamasao" width="32"></a>
+<a href="http://hisashim.org"><img alt="Hisashi Morita" height="32" src="https://www.gravatar.com/avatar/b3fba7af93cd27e6ed28e7eae88a9585?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hisashi Morita" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/mkgin/"><img alt="Makoto Kouno" height="32" src="http://www.gravatar.com/avatar/06e6dcde277cbe5c614baf5d25871025?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Makoto Kouno" width="32"></a>
+<a href="http://d.hatena.ne.jp/muryoImpl/"><img alt="Ken muryoi" height="32" src="https://www.gravatar.com/avatar/ac6dba8ce93944d17714de362ca17e54?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ken muryoi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/suzuki"><img alt="Norio Suzuki" height="32" src="http://www.gravatar.com/avatar/8e528456ff66ec543952daa815353a01?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Norio Suzuki" width="32"></a>
+<a href="http://d.hatena.ne.jp/nagachika/"><img alt="Tomoyuki Chikanaga" height="32" src="https://www.gravatar.com/avatar/5cf8f058a4c094bb708174fb43e7a387?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomoyuki Chikanaga" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.artonx.org"><img alt="Akio Tajima" height="32" src="http://www.gravatar.com/avatar/0441ff038018e53a35bb207e81105a5c?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Akio Tajima" width="32"></a>
+<a href="http://d.hatena.ne.jp/takeshinoda/"><img alt="Takeshi SHINODA" height="32" src="https://www.gravatar.com/avatar/06febd004d7cc9c9f6a4e0272b686bc7?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takeshi SHINODA" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://moonrock.jp/~don/"><img alt="Hiroyuki Iwatsuki" height="32" src="http://www.gravatar.com/avatar/cb1f0f80c3fe2729ba593656772c266d?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hiroyuki Iwatsuki" width="32"></a>
+<a href="http://twitter.com/knsmr"><img alt="Ken Nishimura" height="32" src="https://www.gravatar.com/avatar/91fb4852880d1727cca911036e2fef5f?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ken Nishimura" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/monyakata/"><img alt="MUNAKATA Akiko" height="32" src="http://www.gravatar.com/avatar/55a6db4b079c962f72adb014055e9a28?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MUNAKATA Akiko" width="32"></a>
+<img alt="Anonymous" height="32" src="/2011/images/bow_face.png?1359134037" title="Anonymous" width="32">
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.bawdo.com"><img alt="Keith Bawden" height="32" src="http://www.gravatar.com/avatar/a6cc567a6b77ee09f7363d175455593b?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Keith Bawden" width="32"></a>
+<a href="http://d.hatena.ne.jp/koko_u/"><img alt="Kozaki Tsuneaki" height="32" src="https://www.gravatar.com/avatar/5b1b558d563288da615a9ea2889afdd5?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kozaki Tsuneaki" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<img alt="Norihito Yoshioka" height="32" src="http://www.gravatar.com/avatar/c6033734a5b01f43cca06773ea9ff1fe?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Norihito Yoshioka" width="32">
+<a href="http://twitter.com/adzuki34"><img alt="SUZUKI Miho" height="32" src="https://www.gravatar.com/avatar/f37b9a968b2326062190677906a93080?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="SUZUKI Miho" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/vestige/"><img alt="makoto yonezawa" height="32" src="http://www.gravatar.com/avatar/8da7ceb361c63bd6622fe33153a0293b?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="makoto yonezawa" width="32"></a>
+<a href="http://twitter.com/lchin"><img alt="Leonard Chin" height="32" src="https://www.gravatar.com/avatar/70762059db0218c6f0ff48042ca0756a?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Leonard Chin" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="https://twitter.com/tsuboi"><img alt="Sougo TSUBOI" height="32" src="http://www.gravatar.com/avatar/847bf4e3766b2e17cafef8e83b046db1?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Sougo TSUBOI" width="32"></a>
+<a href="http://d.hatena.ne.jp/suzumura_ss/"><img alt="Toshiyuki Terashita" height="32" src="https://www.gravatar.com/avatar/bb8b58cab667163b6ee53aad0e5f0414?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Toshiyuki Terashita" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/#!/mojamoja_mixi"><img alt="MojaMoja" height="32" src="http://www.gravatar.com/avatar/7b0d6fc806322376d65cbb95d40bc176?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MojaMoja" width="32"></a>
+<a href="http://sites.google.com/site/akihikohashimoto/"><img alt="Akihiko Hashimoto" height="32" src="https://www.gravatar.com/avatar/c8803a4130c3238e34b605d0a0cffe94?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Akihiko Hashimoto" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/takkanm"><img alt="mitsutaka mimura" height="32" src="http://www.gravatar.com/avatar/8f39a252784d5a99589be6e20c4553fb?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="mitsutaka mimura" width="32"></a>
+<img alt="OZAWA Sakuro" height="32" src="https://www.gravatar.com/avatar/a1cbed8bf64473e2acdd0c7066cc5b29?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="OZAWA Sakuro" width="32">
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/dan5ya"><img alt="Dan Yamamoto" height="32" src="http://www.gravatar.com/avatar/ffaa5dad365d5bb5025f4126bb54676c?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Dan Yamamoto" width="32"></a>
+<a href="http://fkmn.exblog.jp/"><img alt="Arinobu FUKUHARA" height="32" src="https://www.gravatar.com/avatar/85319f2b72d7b37ddef5c25a2dd40d30?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Arinobu FUKUHARA" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.hsbt.org/"><img alt="SHIBATA Hiroshi" height="32" src="http://www.gravatar.com/avatar/eabad423977cfc6873b8f5df62b848a6?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="SHIBATA Hiroshi" width="32"></a>
+<a href="http://twitter.com/shachi"><img alt="Kazuyuki Koizuka-shachi" height="32" src="https://www.gravatar.com/avatar/f51ee84097a72a8d91bee9bb98736541?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kazuyuki Koizuka-shachi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/moro/"><img alt="MOROHASHI Kyosuke" height="32" src="http://www.gravatar.com/avatar/70e13d9877054026fda46d5a5b53a236?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MOROHASHI Kyosuke" width="32"></a>
+<img alt="Anonymous" height="32" src="/2011/images/bow_face.png?1359134037" title="Anonymous" width="32">
 <a href="#"></a>
 </li>
 <li>
-<a href="http://rsss.be/hibariya"><img alt="Hibariya Hi" height="32" src="http://www.gravatar.com/avatar/de0df5acda15a9c7eeb6c28a5e5d4e8e?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hibariya Hi" width="32"></a>
+<a href="http://atakigu.tumblr.com/"><img alt="atakig" height="32" src="https://www.gravatar.com/avatar/8a949c60e450d226de776072273a1ffc?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="atakig" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/kyanny"><img alt="Kensuke Nagae" height="32" src="http://www.gravatar.com/avatar/fffd8bf62b842a46803fb07792029fa4?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kensuke Nagae" width="32"></a>
+<img alt="TSUTSUI Toshinori" height="32" src="https://www.gravatar.com/avatar/ad66fd981c429c12e0f76c436da3337e?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TSUTSUI Toshinori" width="32">
 <a href="#"></a>
 </li>
 <li>
-<img alt="oku23" height="32" src="http://www.gravatar.com/avatar/3725ec1dce281fb187d798a9b9ddc9d3?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="oku23" width="32">
+<a href="http://yugui.jp"><img alt="Yuki Sonoda (Yugui)" height="32" src="https://www.gravatar.com/avatar/1e7e007723cfe59320d994a7db4ab4cf?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yuki Sonoda (Yugui)" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://ko.meadowy.net/~koichiro/diary/"><img alt="Koichiro Ohba" height="32" src="http://www.gravatar.com/avatar/1ce18b10bd8f911566c5577042b6a44c?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Koichiro Ohba" width="32"></a>
+<a href="http://d.hatena.ne.jp/seiunsky"><img alt="sugamasao" height="32" src="https://www.gravatar.com/avatar/961126d9892ae4df45249529a0721571?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="sugamasao" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.flickr.com/photos/t-seto"><img alt="せとん" height="32" src="http://www.gravatar.com/avatar/ac007a5b84f817d8cc80a3c208ea0181?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="せとん" width="32"></a>
+<a href="http://d.hatena.ne.jp/mkgin/"><img alt="Makoto Kouno" height="32" src="https://www.gravatar.com/avatar/06e6dcde277cbe5c614baf5d25871025?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Makoto Kouno" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/#!/tsuyoshikawa"><img alt="Tsuyoshi Yoshikawa" height="32" src="http://www.gravatar.com/avatar/6969ade78c1eaff0d08c76020fc80e83?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tsuyoshi Yoshikawa" width="32"></a>
+<a href="http://twitter.com/suzuki"><img alt="Norio Suzuki" height="32" src="https://www.gravatar.com/avatar/8e528456ff66ec543952daa815353a01?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Norio Suzuki" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.water-lily.biz/"><img alt="Water Lily LLC" height="32" src="http://www.gravatar.com/avatar/0734b8ec5eed71892e5db432856f4f40?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Water Lily LLC" width="32"></a>
+<a href="http://www.artonx.org"><img alt="Akio Tajima" height="32" src="https://www.gravatar.com/avatar/0441ff038018e53a35bb207e81105a5c?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Akio Tajima" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://moonrock.jp/~don/"><img alt="Hiroyuki Iwatsuki" height="32" src="https://www.gravatar.com/avatar/cb1f0f80c3fe2729ba593656772c266d?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hiroyuki Iwatsuki" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://d.hatena.ne.jp/monyakata/"><img alt="MUNAKATA Akiko" height="32" src="https://www.gravatar.com/avatar/55a6db4b079c962f72adb014055e9a28?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MUNAKATA Akiko" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://www.bawdo.com"><img alt="Keith Bawden" height="32" src="https://www.gravatar.com/avatar/a6cc567a6b77ee09f7363d175455593b?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Keith Bawden" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<img alt="Norihito Yoshioka" height="32" src="https://www.gravatar.com/avatar/c6033734a5b01f43cca06773ea9ff1fe?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Norihito Yoshioka" width="32">
+<a href="#"></a>
+</li>
+<li>
+<a href="http://d.hatena.ne.jp/vestige/"><img alt="makoto yonezawa" height="32" src="https://www.gravatar.com/avatar/8da7ceb361c63bd6622fe33153a0293b?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="makoto yonezawa" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="https://twitter.com/tsuboi"><img alt="Sougo TSUBOI" height="32" src="https://www.gravatar.com/avatar/847bf4e3766b2e17cafef8e83b046db1?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Sougo TSUBOI" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://twitter.com/#!/mojamoja_mixi"><img alt="MojaMoja" height="32" src="https://www.gravatar.com/avatar/7b0d6fc806322376d65cbb95d40bc176?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MojaMoja" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://twitter.com/takkanm"><img alt="mitsutaka mimura" height="32" src="https://www.gravatar.com/avatar/8f39a252784d5a99589be6e20c4553fb?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="mitsutaka mimura" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://twitter.com/dan5ya"><img alt="Dan Yamamoto" height="32" src="https://www.gravatar.com/avatar/ffaa5dad365d5bb5025f4126bb54676c?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Dan Yamamoto" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://www.hsbt.org/"><img alt="SHIBATA Hiroshi" height="32" src="https://www.gravatar.com/avatar/eabad423977cfc6873b8f5df62b848a6?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="SHIBATA Hiroshi" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://d.hatena.ne.jp/moro/"><img alt="MOROHASHI Kyosuke" height="32" src="https://www.gravatar.com/avatar/70e13d9877054026fda46d5a5b53a236?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MOROHASHI Kyosuke" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://rsss.be/hibariya"><img alt="Hibariya Hi" height="32" src="https://www.gravatar.com/avatar/de0df5acda15a9c7eeb6c28a5e5d4e8e?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hibariya Hi" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://twitter.com/kyanny"><img alt="Kensuke Nagae" height="32" src="https://www.gravatar.com/avatar/fffd8bf62b842a46803fb07792029fa4?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kensuke Nagae" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<img alt="oku23" height="32" src="https://www.gravatar.com/avatar/3725ec1dce281fb187d798a9b9ddc9d3?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="oku23" width="32">
+<a href="#"></a>
+</li>
+<li>
+<a href="http://ko.meadowy.net/~koichiro/diary/"><img alt="Koichiro Ohba" height="32" src="https://www.gravatar.com/avatar/1ce18b10bd8f911566c5577042b6a44c?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Koichiro Ohba" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://www.flickr.com/photos/t-seto"><img alt="せとん" height="32" src="https://www.gravatar.com/avatar/ac007a5b84f817d8cc80a3c208ea0181?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="せとん" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://twitter.com/#!/tsuyoshikawa"><img alt="Tsuyoshi Yoshikawa" height="32" src="https://www.gravatar.com/avatar/6969ade78c1eaff0d08c76020fc80e83?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tsuyoshi Yoshikawa" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://www.water-lily.biz/"><img alt="Water Lily LLC" height="32" src="https://www.gravatar.com/avatar/0734b8ec5eed71892e5db432856f4f40?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Water Lily LLC" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
@@ -789,115 +789,99 @@ Gold Sponsor
 <a href="#"></a>
 </li>
 <li>
-<a href="http://web-engineer.buyuden.net/blog/kawai/"><img alt="Takeshi Kawai" height="32" src="http://www.gravatar.com/avatar/6b53e472c9200f5ed61d7a6db0a28986?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takeshi Kawai" width="32"></a>
+<a href="http://web-engineer.buyuden.net/blog/kawai/"><img alt="Takeshi Kawai" height="32" src="https://www.gravatar.com/avatar/6b53e472c9200f5ed61d7a6db0a28986?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takeshi Kawai" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/k3c/"><img alt="KANEKO Seiji" height="32" src="http://www.gravatar.com/avatar/63d3818b5c107a6483a1d2e2767be4c5?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="KANEKO Seiji" width="32"></a>
+<a href="http://d.hatena.ne.jp/k3c/"><img alt="KANEKO Seiji" height="32" src="https://www.gravatar.com/avatar/63d3818b5c107a6483a1d2e2767be4c5?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="KANEKO Seiji" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.famlog.jp/"><img alt="Atsushi Matsuo" height="32" src="http://www.gravatar.com/avatar/0a4da00dbfd37e7f06ef8dceb58ca0c1?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Atsushi Matsuo" width="32"></a>
+<a href="http://www.famlog.jp/"><img alt="Atsushi Matsuo" height="32" src="https://www.gravatar.com/avatar/0a4da00dbfd37e7f06ef8dceb58ca0c1?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Atsushi Matsuo" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://m.igrs.jp/"><img alt="Masato Igarashi" height="32" src="http://www.gravatar.com/avatar/6fd2e23d73c26ccbd7df9e3eefacd3ae?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masato Igarashi" width="32"></a>
+<a href="http://m.igrs.jp/"><img alt="Masato Igarashi" height="32" src="https://www.gravatar.com/avatar/6fd2e23d73c26ccbd7df9e3eefacd3ae?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masato Igarashi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://resume.github.com/?walf443"><img alt="Keiji Yoshimi" height="32" src="http://www.gravatar.com/avatar/dea4fe079aec284744ad02eb3d2594f5?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Keiji Yoshimi" width="32"></a>
+<a href="http://resume.github.com/?walf443"><img alt="Keiji Yoshimi" height="32" src="https://www.gravatar.com/avatar/dea4fe079aec284744ad02eb3d2594f5?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Keiji Yoshimi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://gunjisatoshi.appspot.com/"><img alt="GUNJI Satoshi" height="32" src="http://www.gravatar.com/avatar/e6980e09fdff8f481b70f2e1f241231d?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="GUNJI Satoshi" width="32"></a>
+<a href="http://gunjisatoshi.appspot.com/"><img alt="GUNJI Satoshi" height="32" src="https://www.gravatar.com/avatar/e6980e09fdff8f481b70f2e1f241231d?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="GUNJI Satoshi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<img alt="Hisashi Yamaeda" height="32" src="http://www.gravatar.com/avatar/01ca4ebeee47c9b4d6ba9ad58db694a0?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hisashi Yamaeda" width="32">
+<img alt="Hisashi Yamaeda" height="32" src="https://www.gravatar.com/avatar/01ca4ebeee47c9b4d6ba9ad58db694a0?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hisashi Yamaeda" width="32">
 <a href="#"></a>
 </li>
 <li>
-<img alt="gekidanyonin" height="32" src="http://www.gravatar.com/avatar/2b196f1723fdbcbf7bd297b3e7f8cd3c?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="gekidanyonin" width="32">
+<img alt="gekidanyonin" height="32" src="https://www.gravatar.com/avatar/2b196f1723fdbcbf7bd297b3e7f8cd3c?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="gekidanyonin" width="32">
 <a href="#"></a>
 </li>
 <li>
-<a href="http://jp.linkedin.com/in/nakaomitsuteru"><img alt="Mitsuteru Nakao" height="32" src="http://www.gravatar.com/avatar/9090e122cba40b90124ea8eb4859bf8e?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Mitsuteru Nakao" width="32"></a>
+<a href="http://jp.linkedin.com/in/nakaomitsuteru"><img alt="Mitsuteru Nakao" height="32" src="https://www.gravatar.com/avatar/9090e122cba40b90124ea8eb4859bf8e?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Mitsuteru Nakao" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://zaki.asia"><img alt="Dezso Zoltan" height="32" src="http://www.gravatar.com/avatar/a771de8e1e49a9da61e2a602a2af42bc?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Dezso Zoltan" width="32"></a>
+<a href="http://zaki.asia"><img alt="Dezso Zoltan" height="32" src="https://www.gravatar.com/avatar/a771de8e1e49a9da61e2a602a2af42bc?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Dezso Zoltan" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.twitter.com/ope"><img alt="Takanori Nakanowatari" height="32" src="http://www.gravatar.com/avatar/55bcf6eb5de45a70e76f8a2678822ecb?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takanori Nakanowatari" width="32"></a>
+<a href="http://www.twitter.com/ope"><img alt="Takanori Nakanowatari" height="32" src="https://www.gravatar.com/avatar/55bcf6eb5de45a70e76f8a2678822ecb?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takanori Nakanowatari" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="https://github.com/zev"><img alt="Zev Blut" height="32" src="http://www.gravatar.com/avatar/1c77ad9f35746369dd1f4dd69b9f8b18?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Zev Blut" width="32"></a>
+<a href="https://github.com/zev"><img alt="Zev Blut" height="32" src="https://www.gravatar.com/avatar/1c77ad9f35746369dd1f4dd69b9f8b18?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Zev Blut" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://tako3.com/http://rubykaigi.org/rubyists/kei-s"><img alt="kei-s" height="32" src="http://www.gravatar.com/avatar/bf7ce9b68bbb0058721906b4db15b9b5?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="kei-s" width="32"></a>
+<a href="http://tako3.com/http://rubykaigi.org/rubyists/kei-s"><img alt="kei-s" height="32" src="https://www.gravatar.com/avatar/bf7ce9b68bbb0058721906b4db15b9b5?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="kei-s" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/bobbyjam99"><img alt="Tomokazu IMAI" height="32" src="http://www.gravatar.com/avatar/33814e72445b35ad3b65b1b05e699adc?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomokazu IMAI" width="32"></a>
+<a href="http://twitter.com/bobbyjam99"><img alt="Tomokazu IMAI" height="32" src="https://www.gravatar.com/avatar/33814e72445b35ad3b65b1b05e699adc?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomokazu IMAI" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/hasimo"><img alt="Tohru Hashimoto" height="32" src="http://www.gravatar.com/avatar/6e3d1578114e5d3951a7f90579fff74c?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tohru Hashimoto" width="32"></a>
+<a href="http://twitter.com/hasimo"><img alt="Tohru Hashimoto" height="32" src="https://www.gravatar.com/avatar/6e3d1578114e5d3951a7f90579fff74c?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tohru Hashimoto" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.mobalean.com/founders/michael"><img alt="Michael Reinsch" height="32" src="http://www.gravatar.com/avatar/c7915a424cbb28fdd6c1cce270be6b58?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Michael Reinsch" width="32"></a>
+<a href="http://www.mobalean.com/founders/michael"><img alt="Michael Reinsch" height="32" src="https://www.gravatar.com/avatar/c7915a424cbb28fdd6c1cce270be6b58?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Michael Reinsch" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/sandinist"><img alt="Tsuyoshi MAEHANA" height="32" src="http://www.gravatar.com/avatar/e8ebe7d4ec09c5dd77ee064706836f23?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tsuyoshi MAEHANA" width="32"></a>
+<a href="http://twitter.com/sandinist"><img alt="Tsuyoshi MAEHANA" height="32" src="https://www.gravatar.com/avatar/e8ebe7d4ec09c5dd77ee064706836f23?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tsuyoshi MAEHANA" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://sane.jp"><img alt="Murahashi Sanemat Kenichi" height="32" src="http://www.gravatar.com/avatar/5b1d016f87f05ff645ae572ccbbf0448?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Murahashi Sanemat Kenichi" width="32"></a>
+<a href="http://sane.jp"><img alt="Murahashi Sanemat Kenichi" height="32" src="https://www.gravatar.com/avatar/5b1d016f87f05ff645ae572ccbbf0448?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Murahashi Sanemat Kenichi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://aerial.st"><img alt="Masato Ikeda" height="32" src="http://www.gravatar.com/avatar/03abf5741b7bbd28670af5ec92b6141d?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masato Ikeda" width="32"></a>
+<a href="http://aerial.st"><img alt="Masato Ikeda" height="32" src="https://www.gravatar.com/avatar/03abf5741b7bbd28670af5ec92b6141d?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masato Ikeda" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/tex314"><img alt="OKAZAKI Takurou" height="32" src="http://www.gravatar.com/avatar/45c2cc1a731924edf1045d9146ca4a78?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="OKAZAKI Takurou" width="32"></a>
+<a href="http://twitter.com/tex314"><img alt="OKAZAKI Takurou" height="32" src="https://www.gravatar.com/avatar/45c2cc1a731924edf1045d9146ca4a78?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="OKAZAKI Takurou" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="https://twitter.com/toshi3221"><img alt="Toshiharu Takematsu" height="32" src="http://www.gravatar.com/avatar/3ca4621fbbb03278d4550f89e2f723ba?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Toshiharu Takematsu" width="32"></a>
+<a href="https://twitter.com/toshi3221"><img alt="Toshiharu Takematsu" height="32" src="https://www.gravatar.com/avatar/3ca4621fbbb03278d4550f89e2f723ba?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Toshiharu Takematsu" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://tdtds.jp"><img alt="TADA Tadashi" height="32" src="http://www.gravatar.com/avatar/846a80b9bf7ea7becb6c4ecd67bedd6f?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TADA Tadashi" width="32"></a>
+<a href="http://tdtds.jp"><img alt="TADA Tadashi" height="32" src="https://www.gravatar.com/avatar/846a80b9bf7ea7becb6c4ecd67bedd6f?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TADA Tadashi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://hisano.com"><img alt="HISANO Kozo" height="32" src="http://www.gravatar.com/avatar/b8fa07639c3b720c33ffdcaf89299dda?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="HISANO Kozo" width="32"></a>
+<a href="http://hisano.com"><img alt="HISANO Kozo" height="32" src="https://www.gravatar.com/avatar/b8fa07639c3b720c33ffdcaf89299dda?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="HISANO Kozo" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/kouma31/"><img alt="kmuroi" height="32" src="http://www.gravatar.com/avatar/165599097b8533c91af2aad5d7b31449?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="kmuroi" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<img alt="Anonymous" height="32" src="/2011/images/bow_face.png?1359134037" title="Anonymous" width="32">
-<a href="#"></a>
-</li>
-<li>
-<a href="http://twitter.com/h4n"><img alt="Han Kessels" height="32" src="http://www.gravatar.com/avatar/f0bd4ed83708d0af0e0d1374fc7e605b?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Han Kessels" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://twitter.com/takagi"><img alt="TAKAGI Masahiro" height="32" src="http://www.gravatar.com/avatar/c3f5a6e729b57f99cb9e7b3ca60152aa?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TAKAGI Masahiro" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://d.hatena.ne.jp/tmtms/"><img alt="TOMITA Masahiro" height="32" src="http://www.gravatar.com/avatar/e4763acee4cf0377437f614fc372a061?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TOMITA Masahiro" width="32"></a>
+<a href="http://d.hatena.ne.jp/kouma31/"><img alt="kmuroi" height="32" src="https://www.gravatar.com/avatar/165599097b8533c91af2aad5d7b31449?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="kmuroi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
@@ -905,79 +889,95 @@ Gold Sponsor
 <a href="#"></a>
 </li>
 <li>
-<a href="http://kmuto.jp/"><img alt="Kenshi Muto" height="32" src="http://www.gravatar.com/avatar/43d44fbc12adcf80c9fc24e235f48234?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kenshi Muto" width="32"></a>
+<a href="http://twitter.com/h4n"><img alt="Han Kessels" height="32" src="https://www.gravatar.com/avatar/f0bd4ed83708d0af0e0d1374fc7e605b?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Han Kessels" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<img alt="1syo" height="32" src="http://www.gravatar.com/avatar/83899fe2d00874176098a3bb71b043be?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="1syo" width="32">
+<a href="http://twitter.com/takagi"><img alt="TAKAGI Masahiro" height="32" src="https://www.gravatar.com/avatar/c3f5a6e729b57f99cb9e7b3ca60152aa?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TAKAGI Masahiro" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://fkino.net"><img alt="Fumihiko Kinoshita" height="32" src="http://www.gravatar.com/avatar/f301c0275838d562c72ea9177e7ddc68?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Fumihiko Kinoshita" width="32"></a>
+<a href="http://d.hatena.ne.jp/tmtms/"><img alt="TOMITA Masahiro" height="32" src="https://www.gravatar.com/avatar/e4763acee4cf0377437f614fc372a061?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TOMITA Masahiro" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://blog.masuidrive.jp/"><img alt="Yuichiro MASUI" height="32" src="http://www.gravatar.com/avatar/0ec58a040e1e4e959c8566484b4bba19?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yuichiro MASUI" width="32"></a>
+<img alt="Anonymous" height="32" src="/2011/images/bow_face.png?1359134037" title="Anonymous" width="32">
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/t2os/"><img alt="tatsuoSakurai" height="32" src="http://www.gravatar.com/avatar/092404bdf9897eba9ab16e61f56592db?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="tatsuoSakurai" width="32"></a>
+<a href="http://kmuto.jp/"><img alt="Kenshi Muto" height="32" src="https://www.gravatar.com/avatar/43d44fbc12adcf80c9fc24e235f48234?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kenshi Muto" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://ogijun.org"><img alt="Junya Ogino" height="32" src="http://www.gravatar.com/avatar/3a82321f68500d9691a9e190979ac2f0?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Junya Ogino" width="32"></a>
+<img alt="1syo" height="32" src="https://www.gravatar.com/avatar/83899fe2d00874176098a3bb71b043be?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="1syo" width="32">
 <a href="#"></a>
 </li>
 <li>
-<a href="http://about.me/mackato"><img alt="Masakuni Kato" height="32" src="http://www.gravatar.com/avatar/28347314c7fc698b4ac0e01113545e25?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masakuni Kato" width="32"></a>
+<a href="http://fkino.net"><img alt="Fumihiko Kinoshita" height="32" src="https://www.gravatar.com/avatar/f301c0275838d562c72ea9177e7ddc68?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Fumihiko Kinoshita" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/IWAKIRI"><img alt="IWAKIRI,Akiko" height="32" src="http://www.gravatar.com/avatar/2a02258781c7592d0da1cd5cffa627a8?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="IWAKIRI,Akiko" width="32"></a>
+<a href="http://blog.masuidrive.jp/"><img alt="Yuichiro MASUI" height="32" src="https://www.gravatar.com/avatar/0ec58a040e1e4e959c8566484b4bba19?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yuichiro MASUI" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://june29.jp/"><img alt="june29" height="32" src="http://www.gravatar.com/avatar/6fd9be5cd0196df5ad62a5a5f2be3c55?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="june29" width="32"></a>
+<a href="http://d.hatena.ne.jp/t2os/"><img alt="tatsuoSakurai" height="32" src="https://www.gravatar.com/avatar/092404bdf9897eba9ab16e61f56592db?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="tatsuoSakurai" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.socialtoprunners.jp/"><img alt="tomokazuhattanda" height="32" src="http://www.gravatar.com/avatar/19798587cb27b5220a5dcdbaa9a50d57?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="tomokazuhattanda" width="32"></a>
+<a href="http://ogijun.org"><img alt="Junya Ogino" height="32" src="https://www.gravatar.com/avatar/3a82321f68500d9691a9e190979ac2f0?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Junya Ogino" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.jamboree.jp/"><img alt="TOYOSHI, Ryuichiro" height="32" src="http://www.gravatar.com/avatar/203c324392b6c51241da5b42bbf888bd?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TOYOSHI, Ryuichiro" width="32"></a>
+<a href="http://about.me/mackato"><img alt="Masakuni Kato" height="32" src="https://www.gravatar.com/avatar/28347314c7fc698b4ac0e01113545e25?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masakuni Kato" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/takano32"><img alt="たかのみつひろ" height="32" src="http://www.gravatar.com/avatar/eba4a40bdae5edfe1589601c050a2b96?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="たかのみつひろ" width="32"></a>
+<a href="http://d.hatena.ne.jp/IWAKIRI"><img alt="IWAKIRI,Akiko" height="32" src="https://www.gravatar.com/avatar/2a02258781c7592d0da1cd5cffa627a8?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="IWAKIRI,Akiko" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/tyabe"><img alt="tyabe" height="32" src="http://www.gravatar.com/avatar/d21900444f5548d9329861593321b5a6?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="tyabe" width="32"></a>
+<a href="http://june29.jp/"><img alt="june29" height="32" src="https://www.gravatar.com/avatar/6fd9be5cd0196df5ad62a5a5f2be3c55?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="june29" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/#!/maxyz"><img alt="Masafumi Fujiwara" height="32" src="http://www.gravatar.com/avatar/4dd4d13d27559db2fb64ad069f2c49ba?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masafumi Fujiwara" width="32"></a>
+<a href="http://www.socialtoprunners.jp/"><img alt="tomokazuhattanda" height="32" src="https://www.gravatar.com/avatar/19798587cb27b5220a5dcdbaa9a50d57?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="tomokazuhattanda" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/kdmsnr"><img alt="Masanori Kado" height="32" src="http://www.gravatar.com/avatar/70b07e6b7fe7d921d7ac542d0ccb3b2c?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masanori Kado" width="32"></a>
+<a href="http://www.jamboree.jp/"><img alt="TOYOSHI, Ryuichiro" height="32" src="https://www.gravatar.com/avatar/203c324392b6c51241da5b42bbf888bd?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TOYOSHI, Ryuichiro" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.jitu.org/~tko"><img alt="Tomoyuki Kosimizu" height="32" src="http://www.gravatar.com/avatar/3585181753c22a9531e70a8297771b01?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomoyuki Kosimizu" width="32"></a>
+<a href="http://twitter.com/takano32"><img alt="たかのみつひろ" height="32" src="https://www.gravatar.com/avatar/eba4a40bdae5edfe1589601c050a2b96?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="たかのみつひろ" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/chinmo"><img alt="Tomonori Fukuta" height="32" src="http://www.gravatar.com/avatar/7977a0896e60587b2690550891be2ea7?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomonori Fukuta" width="32"></a>
+<a href="http://twitter.com/tyabe"><img alt="tyabe" height="32" src="https://www.gravatar.com/avatar/d21900444f5548d9329861593321b5a6?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="tyabe" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<img alt="YOKOTA Akiko" height="32" src="http://www.gravatar.com/avatar/03e548747e667fc94cc8495868bfd85e?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="YOKOTA Akiko" width="32">
+<a href="http://twitter.com/#!/maxyz"><img alt="Masafumi Fujiwara" height="32" src="https://www.gravatar.com/avatar/4dd4d13d27559db2fb64ad069f2c49ba?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masafumi Fujiwara" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://nov.tdiary.net/"><img alt="Nobuhiro IMAI" height="32" src="http://www.gravatar.com/avatar/e49ab9f0774711c473660019728cde95?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Nobuhiro IMAI" width="32"></a>
+<a href="http://twitter.com/kdmsnr"><img alt="Masanori Kado" height="32" src="https://www.gravatar.com/avatar/70b07e6b7fe7d921d7ac542d0ccb3b2c?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masanori Kado" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://www.jitu.org/~tko"><img alt="Tomoyuki Kosimizu" height="32" src="https://www.gravatar.com/avatar/3585181753c22a9531e70a8297771b01?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomoyuki Kosimizu" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://twitter.com/chinmo"><img alt="Tomonori Fukuta" height="32" src="https://www.gravatar.com/avatar/7977a0896e60587b2690550891be2ea7?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomonori Fukuta" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<img alt="YOKOTA Akiko" height="32" src="https://www.gravatar.com/avatar/03e548747e667fc94cc8495868bfd85e?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="YOKOTA Akiko" width="32">
+<a href="#"></a>
+</li>
+<li>
+<a href="http://nov.tdiary.net/"><img alt="Nobuhiro IMAI" height="32" src="https://www.gravatar.com/avatar/e49ab9f0774711c473660019728cde95?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Nobuhiro IMAI" width="32"></a>
 <a href="#"></a>
 </li>
 </ul>

--- a/2011/ja/about/index.html
+++ b/2011/ja/about/index.html
@@ -220,28 +220,28 @@ RubyKaigi2011のメディア・報道社向けメーリングリストに参加�
 kakutani
 <br>
 <a href="http://www.flickr.com/photos/kakutani" target="_blank">
-<img alt="kakutani" src="http://www.gravatar.com/avatar/63a6bff89d692e21de20868202bc8dde?s=32">
+<img alt="kakutani" src="https://www.gravatar.com/avatar/63a6bff89d692e21de20868202bc8dde?s=32">
 </a>
 </p>
 <p>
 snoozer05
 <br>
 <a href="http://www.flickr.com/photos/snoozer/" target="_blank">
-<img alt="" src="http://www.gravatar.com/avatar/941b170e5a115a295cccb5f5cdf0a800?s=32">
+<img alt="" src="https://www.gravatar.com/avatar/941b170e5a115a295cccb5f5cdf0a800?s=32">
 </a>
 </p>
 <p>
 tmaeda_japan
 <br>
 <a href="http://www.flickr.com/photos/tmaedax/" target="_blank">
-<img alt="" src="http://www.gravatar.com/avatar/f482a467d8202cf35b3aa7df192d3efb?s=32">
+<img alt="" src="https://www.gravatar.com/avatar/f482a467d8202cf35b3aa7df192d3efb?s=32">
 </a>
 </p>
 <p>
 Naoto Takai
 <br>
 <a href="http://www.flickr.com/photos/recompile_net/" target="_blank">
-<img alt="" src="http://www.gravatar.com/avatar/cf7b553387b247d737c60cfceabb2cea?s=32">
+<img alt="" src="https://www.gravatar.com/avatar/cf7b553387b247d737c60cfceabb2cea?s=32">
 </a>
 </p>
 </article>

--- a/2011/ja/index.html
+++ b/2011/ja/index.html
@@ -471,55 +471,39 @@ Goldスポンサー
 </h2>
 <ul>
 <li>
-<a href="http://shyouhei.tumblr.com"><img alt="Urabe, Shyouhei" height="32" src="http://www.gravatar.com/avatar/9d2f78236e45a335301ba1195026105d?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Urabe, Shyouhei" width="32"></a>
+<a href="http://shyouhei.tumblr.com"><img alt="Urabe, Shyouhei" height="32" src="https://www.gravatar.com/avatar/9d2f78236e45a335301ba1195026105d?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Urabe, Shyouhei" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/noplans"><img alt="TANIGUCHI Fumitake" height="32" src="http://www.gravatar.com/avatar/e514ae09c9b84e04231af57f1d1946b8?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TANIGUCHI Fumitake" width="32"></a>
+<a href="http://twitter.com/noplans"><img alt="TANIGUCHI Fumitake" height="32" src="https://www.gravatar.com/avatar/e514ae09c9b84e04231af57f1d1946b8?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TANIGUCHI Fumitake" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://jmettraux.wordpress.com"><img alt="John Mettraux" height="32" src="http://www.gravatar.com/avatar/8d96626e52beb1ff90f57a8e189e1e6f?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="John Mettraux" width="32"></a>
+<a href="http://jmettraux.wordpress.com"><img alt="John Mettraux" height="32" src="https://www.gravatar.com/avatar/8d96626e52beb1ff90f57a8e189e1e6f?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="John Mettraux" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/japanrock"><img alt="Shintaro Nozaki" height="32" src="http://www.gravatar.com/avatar/b31a258dd8f615f61b2d355297f82dc9?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shintaro Nozaki" width="32"></a>
+<a href="http://twitter.com/japanrock"><img alt="Shintaro Nozaki" height="32" src="https://www.gravatar.com/avatar/b31a258dd8f615f61b2d355297f82dc9?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shintaro Nozaki" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://blog.dio.jp"><img alt="Akira Matsuda" height="32" src="http://www.gravatar.com/avatar/76a777ff80f30bd3b390e275cce625bc?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Akira Matsuda" width="32"></a>
+<a href="http://blog.dio.jp"><img alt="Akira Matsuda" height="32" src="https://www.gravatar.com/avatar/76a777ff80f30bd3b390e275cce625bc?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Akira Matsuda" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.bovensiepen.net"><img alt="Daniel Bovensiepen" height="32" src="http://www.gravatar.com/avatar/49d6f762505615af259534deed94bc54?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Daniel Bovensiepen" width="32"></a>
+<a href="http://www.bovensiepen.net"><img alt="Daniel Bovensiepen" height="32" src="https://www.gravatar.com/avatar/49d6f762505615af259534deed94bc54?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Daniel Bovensiepen" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://firn.jp/"><img alt="Dai Akatsuka" height="32" src="http://www.gravatar.com/avatar/4efe7b5cdbe97df84e6e607948171eef?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Dai Akatsuka" width="32"></a>
+<a href="http://firn.jp/"><img alt="Dai Akatsuka" height="32" src="https://www.gravatar.com/avatar/4efe7b5cdbe97df84e6e607948171eef?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Dai Akatsuka" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.din.or.jp/~shinodas/"><img alt="Yoshihiko Hara" height="32" src="http://www.gravatar.com/avatar/8055fbffa700065178460bb7e3b8ee24?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yoshihiko Hara" width="32"></a>
+<a href="http://www.din.or.jp/~shinodas/"><img alt="Yoshihiko Hara" height="32" src="https://www.gravatar.com/avatar/8055fbffa700065178460bb7e3b8ee24?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yoshihiko Hara" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://benhoskin.gs"><img alt="Ben Hoskings" height="32" src="http://www.gravatar.com/avatar/7ed99cb90a060539d729e2491442a603?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ben Hoskings" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<img alt="Anonymous" height="32" src="/2011/images/bow_face.png?1359134037" title="Anonymous" width="32">
-<a href="#"></a>
-</li>
-<li>
-<a href="http://www.nextseed.jp/"><img alt="Hitoshi Kurokawa" height="32" src="http://www.gravatar.com/avatar/11e89e3c85d9998b2c73933bde77c71e?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hitoshi Kurokawa" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://d.hatena.ne.jp/kinpoco/"><img alt="Yutaka Kanemoto" height="32" src="http://www.gravatar.com/avatar/0e728bf538d1848bc253d80a8626bbc2?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yutaka Kanemoto" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://d.hatena.ne.jp/yuichi_katahira"><img alt="Yuichi Katahira " height="32" src="http://www.gravatar.com/avatar/3072ae08f580fc8474b47652a3d8dd0f?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yuichi Katahira " width="32"></a>
+<a href="http://benhoskin.gs"><img alt="Ben Hoskings" height="32" src="https://www.gravatar.com/avatar/7ed99cb90a060539d729e2491442a603?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ben Hoskings" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
@@ -527,87 +511,15 @@ Goldスポンサー
 <a href="#"></a>
 </li>
 <li>
-<a href="http://kitaj.no-ip.com/tdiary/"><img alt="Junichiro Kita" height="32" src="http://www.gravatar.com/avatar/70405ca68e6f8779be65e75b1a90525b?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Junichiro Kita" width="32"></a>
+<a href="http://www.nextseed.jp/"><img alt="Hitoshi Kurokawa" height="32" src="https://www.gravatar.com/avatar/11e89e3c85d9998b2c73933bde77c71e?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hitoshi Kurokawa" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/idesaku"><img alt="Daisuke Goto" height="32" src="http://www.gravatar.com/avatar/85c8086344e5f31b2a4d22f163660536?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Daisuke Goto" width="32"></a>
+<a href="http://d.hatena.ne.jp/kinpoco/"><img alt="Yutaka Kanemoto" height="32" src="https://www.gravatar.com/avatar/0e728bf538d1848bc253d80a8626bbc2?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yutaka Kanemoto" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<img alt="Anonymous" height="32" src="/2011/images/bow_face.png?1359134037" title="Anonymous" width="32">
-<a href="#"></a>
-</li>
-<li>
-<a href="http://www.on-sky.net/~hs/"><img alt="Hideki SAKAMOTO" height="32" src="http://www.gravatar.com/avatar/7038a6cfc30b8c3b00b5c08d70cda2f1?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hideki SAKAMOTO" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://twitter.com/agilekawabata"><img alt="Kawabata Mitsuyoshi" height="32" src="http://www.gravatar.com/avatar/5236eb3ad498b3c5336a4575408fb1b1?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kawabata Mitsuyoshi" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://www.kt.rim.or.jp/~kbk/"><img alt="KIMURA Koichi" height="32" src="http://www.gravatar.com/avatar/04c1a31d1e33e7fc25a7ca99930e4c70?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="KIMURA Koichi" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://d.hatena.ne.jp/takkaw/"><img alt="Takayoshi Kawada" height="32" src="http://www.gravatar.com/avatar/38bf2ca557d9cc20dcdcbd773a68664b?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takayoshi Kawada" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://www.suchi.org/"><img alt="Shigeru UCHIYAMA" height="32" src="http://www.gravatar.com/avatar/398e2dd764d43aad735c6e5bca92c3b6?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shigeru UCHIYAMA" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://twitter.com/#!/andrewjgrimm"><img alt="Andrew Grimm" height="32" src="http://www.gravatar.com/avatar/01bbb59a1c3ef9960f25a97afe7e920f?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Andrew Grimm" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://twitter.com/kimuraw"><img alt="kimura wataru" height="32" src="http://www.gravatar.com/avatar/e298234a6e5a2c159287476abd76504a?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="kimura wataru" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://saikyoline.jp/"><img alt="MIKAMI Yoshiyuki" height="32" src="http://www.gravatar.com/avatar/e0920f5f813ae29ba7859f950a7f0df3?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MIKAMI Yoshiyuki" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://jp.rubyist.net/?KansaiWorkshop"><img alt="HIGAKI Masaru" height="32" src="http://www.gravatar.com/avatar/a8192f5a7b25ef32a983740ee8593bd3?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="HIGAKI Masaru" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://twitter.com/ayumin"><img alt="Ayumu AIZAWA" height="32" src="http://www.gravatar.com/avatar/2e9a2dbe335e0111e4879a9d65dcbae0?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ayumu AIZAWA" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://shunichi-arai.blogspot.com/"><img alt="Shunichi Arai" height="32" src="http://www.gravatar.com/avatar/74daf3516e33a75968ec0f933954b5a8?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shunichi Arai" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://www.tokyodev.com"><img alt="Paul McMahon" height="32" src="http://www.gravatar.com/avatar/dd24adb5a3a430fed83a33ed552fe1b5?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Paul McMahon" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://d.hatena.ne.jp/hs9587/"><img alt="Hiroyuki Shimura" height="32" src="http://www.gravatar.com/avatar/287a899c91a7a14535188d7e4784050e?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hiroyuki Shimura" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://kakutani.com"><img alt="Kakutani Shintaro" height="32" src="http://www.gravatar.com/avatar/34fcd5f1deeb25b1138e9845137feb6e?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kakutani Shintaro" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://d.hatena.ne.jp/mrkn"><img alt="Kenta Murata" height="32" src="http://www.gravatar.com/avatar/819b3c0a25f9708fd32261b8ae2d23f6?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kenta Murata" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://rails.to"><img alt="Masatoshi Itagaki" height="32" src="http://www.gravatar.com/avatar/f8865f41777ef3caced0e4e6801ff83a?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masatoshi Itagaki" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://spring-aki.com/"><img alt="Aki" height="32" src="http://www.gravatar.com/avatar/81f2122b45f48829be4507bf972666e9?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Aki" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://twitter.com/shin_asou"><img alt="Shinichi Okada" height="32" src="http://www.gravatar.com/avatar/20805358592bd93f92bf15aa10137251?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shinichi Okada" width="32"></a>
+<a href="http://d.hatena.ne.jp/yuichi_katahira"><img alt="Yuichi Katahira " height="32" src="https://www.gravatar.com/avatar/3072ae08f580fc8474b47652a3d8dd0f?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yuichi Katahira " width="32"></a>
 <a href="#"></a>
 </li>
 <li>
@@ -615,35 +527,11 @@ Goldスポンサー
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.kumaryu.net/"><img alt="Ryuichi Sakamoto" height="32" src="http://www.gravatar.com/avatar/1b2ca00132480422c75c1f2c61e84e26?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ryuichi Sakamoto" width="32"></a>
+<a href="http://kitaj.no-ip.com/tdiary/"><img alt="Junichiro Kita" height="32" src="https://www.gravatar.com/avatar/70405ca68e6f8779be65e75b1a90525b?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Junichiro Kita" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<img alt="Eito Katagiri" height="32" src="http://www.gravatar.com/avatar/b5852cf79505d7ba513f8f16ef95a50f?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Eito Katagiri" width="32">
-<a href="#"></a>
-</li>
-<li>
-<a href="http://ukstudio.jp/"><img alt="AKAMATSU Yuki" height="32" src="http://www.gravatar.com/avatar/0c471249ee93ab17a011f3e8d2b1057a?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="AKAMATSU Yuki" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://hisashim.org"><img alt="Hisashi Morita" height="32" src="http://www.gravatar.com/avatar/b3fba7af93cd27e6ed28e7eae88a9585?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hisashi Morita" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://d.hatena.ne.jp/muryoImpl/"><img alt="Ken muryoi" height="32" src="http://www.gravatar.com/avatar/ac6dba8ce93944d17714de362ca17e54?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ken muryoi" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://d.hatena.ne.jp/nagachika/"><img alt="Tomoyuki Chikanaga" height="32" src="http://www.gravatar.com/avatar/5cf8f058a4c094bb708174fb43e7a387?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomoyuki Chikanaga" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://d.hatena.ne.jp/takeshinoda/"><img alt="Takeshi SHINODA" height="32" src="http://www.gravatar.com/avatar/06febd004d7cc9c9f6a4e0272b686bc7?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takeshi SHINODA" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://twitter.com/knsmr"><img alt="Ken Nishimura" height="32" src="http://www.gravatar.com/avatar/91fb4852880d1727cca911036e2fef5f?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ken Nishimura" width="32"></a>
+<a href="http://d.hatena.ne.jp/idesaku"><img alt="Daisuke Goto" height="32" src="https://www.gravatar.com/avatar/85c8086344e5f31b2a4d22f163660536?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Daisuke Goto" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
@@ -651,35 +539,75 @@ Goldスポンサー
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/koko_u/"><img alt="Kozaki Tsuneaki" height="32" src="http://www.gravatar.com/avatar/5b1b558d563288da615a9ea2889afdd5?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kozaki Tsuneaki" width="32"></a>
+<a href="http://www.on-sky.net/~hs/"><img alt="Hideki SAKAMOTO" height="32" src="https://www.gravatar.com/avatar/7038a6cfc30b8c3b00b5c08d70cda2f1?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hideki SAKAMOTO" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/adzuki34"><img alt="SUZUKI Miho" height="32" src="http://www.gravatar.com/avatar/f37b9a968b2326062190677906a93080?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="SUZUKI Miho" width="32"></a>
+<a href="http://twitter.com/agilekawabata"><img alt="Kawabata Mitsuyoshi" height="32" src="https://www.gravatar.com/avatar/5236eb3ad498b3c5336a4575408fb1b1?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kawabata Mitsuyoshi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/lchin"><img alt="Leonard Chin" height="32" src="http://www.gravatar.com/avatar/70762059db0218c6f0ff48042ca0756a?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Leonard Chin" width="32"></a>
+<a href="http://www.kt.rim.or.jp/~kbk/"><img alt="KIMURA Koichi" height="32" src="https://www.gravatar.com/avatar/04c1a31d1e33e7fc25a7ca99930e4c70?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="KIMURA Koichi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/suzumura_ss/"><img alt="Toshiyuki Terashita" height="32" src="http://www.gravatar.com/avatar/bb8b58cab667163b6ee53aad0e5f0414?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Toshiyuki Terashita" width="32"></a>
+<a href="http://d.hatena.ne.jp/takkaw/"><img alt="Takayoshi Kawada" height="32" src="https://www.gravatar.com/avatar/38bf2ca557d9cc20dcdcbd773a68664b?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takayoshi Kawada" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://sites.google.com/site/akihikohashimoto/"><img alt="Akihiko Hashimoto" height="32" src="http://www.gravatar.com/avatar/c8803a4130c3238e34b605d0a0cffe94?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Akihiko Hashimoto" width="32"></a>
+<a href="http://www.suchi.org/"><img alt="Shigeru UCHIYAMA" height="32" src="https://www.gravatar.com/avatar/398e2dd764d43aad735c6e5bca92c3b6?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shigeru UCHIYAMA" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<img alt="OZAWA Sakuro" height="32" src="http://www.gravatar.com/avatar/a1cbed8bf64473e2acdd0c7066cc5b29?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="OZAWA Sakuro" width="32">
+<a href="http://twitter.com/#!/andrewjgrimm"><img alt="Andrew Grimm" height="32" src="https://www.gravatar.com/avatar/01bbb59a1c3ef9960f25a97afe7e920f?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Andrew Grimm" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://fkmn.exblog.jp/"><img alt="Arinobu FUKUHARA" height="32" src="http://www.gravatar.com/avatar/85319f2b72d7b37ddef5c25a2dd40d30?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Arinobu FUKUHARA" width="32"></a>
+<a href="http://twitter.com/kimuraw"><img alt="kimura wataru" height="32" src="https://www.gravatar.com/avatar/e298234a6e5a2c159287476abd76504a?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="kimura wataru" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/shachi"><img alt="Kazuyuki Koizuka-shachi" height="32" src="http://www.gravatar.com/avatar/f51ee84097a72a8d91bee9bb98736541?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kazuyuki Koizuka-shachi" width="32"></a>
+<a href="http://saikyoline.jp/"><img alt="MIKAMI Yoshiyuki" height="32" src="https://www.gravatar.com/avatar/e0920f5f813ae29ba7859f950a7f0df3?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MIKAMI Yoshiyuki" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://jp.rubyist.net/?KansaiWorkshop"><img alt="HIGAKI Masaru" height="32" src="https://www.gravatar.com/avatar/a8192f5a7b25ef32a983740ee8593bd3?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="HIGAKI Masaru" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://twitter.com/ayumin"><img alt="Ayumu AIZAWA" height="32" src="https://www.gravatar.com/avatar/2e9a2dbe335e0111e4879a9d65dcbae0?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ayumu AIZAWA" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://shunichi-arai.blogspot.com/"><img alt="Shunichi Arai" height="32" src="https://www.gravatar.com/avatar/74daf3516e33a75968ec0f933954b5a8?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shunichi Arai" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://www.tokyodev.com"><img alt="Paul McMahon" height="32" src="https://www.gravatar.com/avatar/dd24adb5a3a430fed83a33ed552fe1b5?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Paul McMahon" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://d.hatena.ne.jp/hs9587/"><img alt="Hiroyuki Shimura" height="32" src="https://www.gravatar.com/avatar/287a899c91a7a14535188d7e4784050e?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hiroyuki Shimura" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://kakutani.com"><img alt="Kakutani Shintaro" height="32" src="https://www.gravatar.com/avatar/34fcd5f1deeb25b1138e9845137feb6e?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kakutani Shintaro" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://d.hatena.ne.jp/mrkn"><img alt="Kenta Murata" height="32" src="https://www.gravatar.com/avatar/819b3c0a25f9708fd32261b8ae2d23f6?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kenta Murata" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://rails.to"><img alt="Masatoshi Itagaki" height="32" src="https://www.gravatar.com/avatar/f8865f41777ef3caced0e4e6801ff83a?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masatoshi Itagaki" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://spring-aki.com/"><img alt="Aki" height="32" src="https://www.gravatar.com/avatar/81f2122b45f48829be4507bf972666e9?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Aki" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://twitter.com/shin_asou"><img alt="Shinichi Okada" height="32" src="https://www.gravatar.com/avatar/20805358592bd93f92bf15aa10137251?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shinichi Okada" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
@@ -687,103 +615,175 @@ Goldスポンサー
 <a href="#"></a>
 </li>
 <li>
-<a href="http://atakigu.tumblr.com/"><img alt="atakig" height="32" src="http://www.gravatar.com/avatar/8a949c60e450d226de776072273a1ffc?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="atakig" width="32"></a>
+<a href="http://www.kumaryu.net/"><img alt="Ryuichi Sakamoto" height="32" src="https://www.gravatar.com/avatar/1b2ca00132480422c75c1f2c61e84e26?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ryuichi Sakamoto" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<img alt="TSUTSUI Toshinori" height="32" src="http://www.gravatar.com/avatar/ad66fd981c429c12e0f76c436da3337e?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TSUTSUI Toshinori" width="32">
+<img alt="Eito Katagiri" height="32" src="https://www.gravatar.com/avatar/b5852cf79505d7ba513f8f16ef95a50f?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Eito Katagiri" width="32">
 <a href="#"></a>
 </li>
 <li>
-<a href="http://yugui.jp"><img alt="Yuki Sonoda (Yugui)" height="32" src="http://www.gravatar.com/avatar/1e7e007723cfe59320d994a7db4ab4cf?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yuki Sonoda (Yugui)" width="32"></a>
+<a href="http://ukstudio.jp/"><img alt="AKAMATSU Yuki" height="32" src="https://www.gravatar.com/avatar/0c471249ee93ab17a011f3e8d2b1057a?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="AKAMATSU Yuki" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/seiunsky"><img alt="sugamasao" height="32" src="http://www.gravatar.com/avatar/961126d9892ae4df45249529a0721571?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="sugamasao" width="32"></a>
+<a href="http://hisashim.org"><img alt="Hisashi Morita" height="32" src="https://www.gravatar.com/avatar/b3fba7af93cd27e6ed28e7eae88a9585?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hisashi Morita" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/mkgin/"><img alt="Makoto Kouno" height="32" src="http://www.gravatar.com/avatar/06e6dcde277cbe5c614baf5d25871025?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Makoto Kouno" width="32"></a>
+<a href="http://d.hatena.ne.jp/muryoImpl/"><img alt="Ken muryoi" height="32" src="https://www.gravatar.com/avatar/ac6dba8ce93944d17714de362ca17e54?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ken muryoi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/suzuki"><img alt="Norio Suzuki" height="32" src="http://www.gravatar.com/avatar/8e528456ff66ec543952daa815353a01?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Norio Suzuki" width="32"></a>
+<a href="http://d.hatena.ne.jp/nagachika/"><img alt="Tomoyuki Chikanaga" height="32" src="https://www.gravatar.com/avatar/5cf8f058a4c094bb708174fb43e7a387?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomoyuki Chikanaga" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.artonx.org"><img alt="Akio Tajima" height="32" src="http://www.gravatar.com/avatar/0441ff038018e53a35bb207e81105a5c?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Akio Tajima" width="32"></a>
+<a href="http://d.hatena.ne.jp/takeshinoda/"><img alt="Takeshi SHINODA" height="32" src="https://www.gravatar.com/avatar/06febd004d7cc9c9f6a4e0272b686bc7?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takeshi SHINODA" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://moonrock.jp/~don/"><img alt="Hiroyuki Iwatsuki" height="32" src="http://www.gravatar.com/avatar/cb1f0f80c3fe2729ba593656772c266d?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hiroyuki Iwatsuki" width="32"></a>
+<a href="http://twitter.com/knsmr"><img alt="Ken Nishimura" height="32" src="https://www.gravatar.com/avatar/91fb4852880d1727cca911036e2fef5f?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ken Nishimura" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/monyakata/"><img alt="MUNAKATA Akiko" height="32" src="http://www.gravatar.com/avatar/55a6db4b079c962f72adb014055e9a28?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MUNAKATA Akiko" width="32"></a>
+<img alt="Anonymous" height="32" src="/2011/images/bow_face.png?1359134037" title="Anonymous" width="32">
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.bawdo.com"><img alt="Keith Bawden" height="32" src="http://www.gravatar.com/avatar/a6cc567a6b77ee09f7363d175455593b?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Keith Bawden" width="32"></a>
+<a href="http://d.hatena.ne.jp/koko_u/"><img alt="Kozaki Tsuneaki" height="32" src="https://www.gravatar.com/avatar/5b1b558d563288da615a9ea2889afdd5?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kozaki Tsuneaki" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<img alt="Norihito Yoshioka" height="32" src="http://www.gravatar.com/avatar/c6033734a5b01f43cca06773ea9ff1fe?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Norihito Yoshioka" width="32">
+<a href="http://twitter.com/adzuki34"><img alt="SUZUKI Miho" height="32" src="https://www.gravatar.com/avatar/f37b9a968b2326062190677906a93080?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="SUZUKI Miho" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/vestige/"><img alt="makoto yonezawa" height="32" src="http://www.gravatar.com/avatar/8da7ceb361c63bd6622fe33153a0293b?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="makoto yonezawa" width="32"></a>
+<a href="http://twitter.com/lchin"><img alt="Leonard Chin" height="32" src="https://www.gravatar.com/avatar/70762059db0218c6f0ff48042ca0756a?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Leonard Chin" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="https://twitter.com/tsuboi"><img alt="Sougo TSUBOI" height="32" src="http://www.gravatar.com/avatar/847bf4e3766b2e17cafef8e83b046db1?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Sougo TSUBOI" width="32"></a>
+<a href="http://d.hatena.ne.jp/suzumura_ss/"><img alt="Toshiyuki Terashita" height="32" src="https://www.gravatar.com/avatar/bb8b58cab667163b6ee53aad0e5f0414?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Toshiyuki Terashita" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/#!/mojamoja_mixi"><img alt="MojaMoja" height="32" src="http://www.gravatar.com/avatar/7b0d6fc806322376d65cbb95d40bc176?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MojaMoja" width="32"></a>
+<a href="http://sites.google.com/site/akihikohashimoto/"><img alt="Akihiko Hashimoto" height="32" src="https://www.gravatar.com/avatar/c8803a4130c3238e34b605d0a0cffe94?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Akihiko Hashimoto" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/takkanm"><img alt="mitsutaka mimura" height="32" src="http://www.gravatar.com/avatar/8f39a252784d5a99589be6e20c4553fb?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="mitsutaka mimura" width="32"></a>
+<img alt="OZAWA Sakuro" height="32" src="https://www.gravatar.com/avatar/a1cbed8bf64473e2acdd0c7066cc5b29?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="OZAWA Sakuro" width="32">
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/dan5ya"><img alt="Dan Yamamoto" height="32" src="http://www.gravatar.com/avatar/ffaa5dad365d5bb5025f4126bb54676c?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Dan Yamamoto" width="32"></a>
+<a href="http://fkmn.exblog.jp/"><img alt="Arinobu FUKUHARA" height="32" src="https://www.gravatar.com/avatar/85319f2b72d7b37ddef5c25a2dd40d30?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Arinobu FUKUHARA" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.hsbt.org/"><img alt="SHIBATA Hiroshi" height="32" src="http://www.gravatar.com/avatar/eabad423977cfc6873b8f5df62b848a6?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="SHIBATA Hiroshi" width="32"></a>
+<a href="http://twitter.com/shachi"><img alt="Kazuyuki Koizuka-shachi" height="32" src="https://www.gravatar.com/avatar/f51ee84097a72a8d91bee9bb98736541?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kazuyuki Koizuka-shachi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/moro/"><img alt="MOROHASHI Kyosuke" height="32" src="http://www.gravatar.com/avatar/70e13d9877054026fda46d5a5b53a236?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MOROHASHI Kyosuke" width="32"></a>
+<img alt="Anonymous" height="32" src="/2011/images/bow_face.png?1359134037" title="Anonymous" width="32">
 <a href="#"></a>
 </li>
 <li>
-<a href="http://rsss.be/hibariya"><img alt="Hibariya Hi" height="32" src="http://www.gravatar.com/avatar/de0df5acda15a9c7eeb6c28a5e5d4e8e?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hibariya Hi" width="32"></a>
+<a href="http://atakigu.tumblr.com/"><img alt="atakig" height="32" src="https://www.gravatar.com/avatar/8a949c60e450d226de776072273a1ffc?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="atakig" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/kyanny"><img alt="Kensuke Nagae" height="32" src="http://www.gravatar.com/avatar/fffd8bf62b842a46803fb07792029fa4?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kensuke Nagae" width="32"></a>
+<img alt="TSUTSUI Toshinori" height="32" src="https://www.gravatar.com/avatar/ad66fd981c429c12e0f76c436da3337e?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TSUTSUI Toshinori" width="32">
 <a href="#"></a>
 </li>
 <li>
-<img alt="oku23" height="32" src="http://www.gravatar.com/avatar/3725ec1dce281fb187d798a9b9ddc9d3?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="oku23" width="32">
+<a href="http://yugui.jp"><img alt="Yuki Sonoda (Yugui)" height="32" src="https://www.gravatar.com/avatar/1e7e007723cfe59320d994a7db4ab4cf?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yuki Sonoda (Yugui)" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://ko.meadowy.net/~koichiro/diary/"><img alt="Koichiro Ohba" height="32" src="http://www.gravatar.com/avatar/1ce18b10bd8f911566c5577042b6a44c?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Koichiro Ohba" width="32"></a>
+<a href="http://d.hatena.ne.jp/seiunsky"><img alt="sugamasao" height="32" src="https://www.gravatar.com/avatar/961126d9892ae4df45249529a0721571?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="sugamasao" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.flickr.com/photos/t-seto"><img alt="せとん" height="32" src="http://www.gravatar.com/avatar/ac007a5b84f817d8cc80a3c208ea0181?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="せとん" width="32"></a>
+<a href="http://d.hatena.ne.jp/mkgin/"><img alt="Makoto Kouno" height="32" src="https://www.gravatar.com/avatar/06e6dcde277cbe5c614baf5d25871025?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Makoto Kouno" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/#!/tsuyoshikawa"><img alt="Tsuyoshi Yoshikawa" height="32" src="http://www.gravatar.com/avatar/6969ade78c1eaff0d08c76020fc80e83?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tsuyoshi Yoshikawa" width="32"></a>
+<a href="http://twitter.com/suzuki"><img alt="Norio Suzuki" height="32" src="https://www.gravatar.com/avatar/8e528456ff66ec543952daa815353a01?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Norio Suzuki" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.water-lily.biz/"><img alt="Water Lily LLC" height="32" src="http://www.gravatar.com/avatar/0734b8ec5eed71892e5db432856f4f40?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Water Lily LLC" width="32"></a>
+<a href="http://www.artonx.org"><img alt="Akio Tajima" height="32" src="https://www.gravatar.com/avatar/0441ff038018e53a35bb207e81105a5c?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Akio Tajima" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://moonrock.jp/~don/"><img alt="Hiroyuki Iwatsuki" height="32" src="https://www.gravatar.com/avatar/cb1f0f80c3fe2729ba593656772c266d?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hiroyuki Iwatsuki" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://d.hatena.ne.jp/monyakata/"><img alt="MUNAKATA Akiko" height="32" src="https://www.gravatar.com/avatar/55a6db4b079c962f72adb014055e9a28?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MUNAKATA Akiko" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://www.bawdo.com"><img alt="Keith Bawden" height="32" src="https://www.gravatar.com/avatar/a6cc567a6b77ee09f7363d175455593b?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Keith Bawden" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<img alt="Norihito Yoshioka" height="32" src="https://www.gravatar.com/avatar/c6033734a5b01f43cca06773ea9ff1fe?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Norihito Yoshioka" width="32">
+<a href="#"></a>
+</li>
+<li>
+<a href="http://d.hatena.ne.jp/vestige/"><img alt="makoto yonezawa" height="32" src="https://www.gravatar.com/avatar/8da7ceb361c63bd6622fe33153a0293b?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="makoto yonezawa" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="https://twitter.com/tsuboi"><img alt="Sougo TSUBOI" height="32" src="https://www.gravatar.com/avatar/847bf4e3766b2e17cafef8e83b046db1?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Sougo TSUBOI" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://twitter.com/#!/mojamoja_mixi"><img alt="MojaMoja" height="32" src="https://www.gravatar.com/avatar/7b0d6fc806322376d65cbb95d40bc176?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MojaMoja" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://twitter.com/takkanm"><img alt="mitsutaka mimura" height="32" src="https://www.gravatar.com/avatar/8f39a252784d5a99589be6e20c4553fb?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="mitsutaka mimura" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://twitter.com/dan5ya"><img alt="Dan Yamamoto" height="32" src="https://www.gravatar.com/avatar/ffaa5dad365d5bb5025f4126bb54676c?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Dan Yamamoto" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://www.hsbt.org/"><img alt="SHIBATA Hiroshi" height="32" src="https://www.gravatar.com/avatar/eabad423977cfc6873b8f5df62b848a6?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="SHIBATA Hiroshi" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://d.hatena.ne.jp/moro/"><img alt="MOROHASHI Kyosuke" height="32" src="https://www.gravatar.com/avatar/70e13d9877054026fda46d5a5b53a236?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MOROHASHI Kyosuke" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://rsss.be/hibariya"><img alt="Hibariya Hi" height="32" src="https://www.gravatar.com/avatar/de0df5acda15a9c7eeb6c28a5e5d4e8e?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hibariya Hi" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://twitter.com/kyanny"><img alt="Kensuke Nagae" height="32" src="https://www.gravatar.com/avatar/fffd8bf62b842a46803fb07792029fa4?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kensuke Nagae" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<img alt="oku23" height="32" src="https://www.gravatar.com/avatar/3725ec1dce281fb187d798a9b9ddc9d3?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="oku23" width="32">
+<a href="#"></a>
+</li>
+<li>
+<a href="http://ko.meadowy.net/~koichiro/diary/"><img alt="Koichiro Ohba" height="32" src="https://www.gravatar.com/avatar/1ce18b10bd8f911566c5577042b6a44c?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Koichiro Ohba" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://www.flickr.com/photos/t-seto"><img alt="せとん" height="32" src="https://www.gravatar.com/avatar/ac007a5b84f817d8cc80a3c208ea0181?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="せとん" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://twitter.com/#!/tsuyoshikawa"><img alt="Tsuyoshi Yoshikawa" height="32" src="https://www.gravatar.com/avatar/6969ade78c1eaff0d08c76020fc80e83?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tsuyoshi Yoshikawa" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://www.water-lily.biz/"><img alt="Water Lily LLC" height="32" src="https://www.gravatar.com/avatar/0734b8ec5eed71892e5db432856f4f40?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Water Lily LLC" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
@@ -791,115 +791,99 @@ Goldスポンサー
 <a href="#"></a>
 </li>
 <li>
-<a href="http://web-engineer.buyuden.net/blog/kawai/"><img alt="Takeshi Kawai" height="32" src="http://www.gravatar.com/avatar/6b53e472c9200f5ed61d7a6db0a28986?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takeshi Kawai" width="32"></a>
+<a href="http://web-engineer.buyuden.net/blog/kawai/"><img alt="Takeshi Kawai" height="32" src="https://www.gravatar.com/avatar/6b53e472c9200f5ed61d7a6db0a28986?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takeshi Kawai" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/k3c/"><img alt="KANEKO Seiji" height="32" src="http://www.gravatar.com/avatar/63d3818b5c107a6483a1d2e2767be4c5?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="KANEKO Seiji" width="32"></a>
+<a href="http://d.hatena.ne.jp/k3c/"><img alt="KANEKO Seiji" height="32" src="https://www.gravatar.com/avatar/63d3818b5c107a6483a1d2e2767be4c5?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="KANEKO Seiji" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.famlog.jp/"><img alt="Atsushi Matsuo" height="32" src="http://www.gravatar.com/avatar/0a4da00dbfd37e7f06ef8dceb58ca0c1?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Atsushi Matsuo" width="32"></a>
+<a href="http://www.famlog.jp/"><img alt="Atsushi Matsuo" height="32" src="https://www.gravatar.com/avatar/0a4da00dbfd37e7f06ef8dceb58ca0c1?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Atsushi Matsuo" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://m.igrs.jp/"><img alt="Masato Igarashi" height="32" src="http://www.gravatar.com/avatar/6fd2e23d73c26ccbd7df9e3eefacd3ae?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masato Igarashi" width="32"></a>
+<a href="http://m.igrs.jp/"><img alt="Masato Igarashi" height="32" src="https://www.gravatar.com/avatar/6fd2e23d73c26ccbd7df9e3eefacd3ae?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masato Igarashi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://resume.github.com/?walf443"><img alt="Keiji Yoshimi" height="32" src="http://www.gravatar.com/avatar/dea4fe079aec284744ad02eb3d2594f5?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Keiji Yoshimi" width="32"></a>
+<a href="http://resume.github.com/?walf443"><img alt="Keiji Yoshimi" height="32" src="https://www.gravatar.com/avatar/dea4fe079aec284744ad02eb3d2594f5?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Keiji Yoshimi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://gunjisatoshi.appspot.com/"><img alt="GUNJI Satoshi" height="32" src="http://www.gravatar.com/avatar/e6980e09fdff8f481b70f2e1f241231d?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="GUNJI Satoshi" width="32"></a>
+<a href="http://gunjisatoshi.appspot.com/"><img alt="GUNJI Satoshi" height="32" src="https://www.gravatar.com/avatar/e6980e09fdff8f481b70f2e1f241231d?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="GUNJI Satoshi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<img alt="Hisashi Yamaeda" height="32" src="http://www.gravatar.com/avatar/01ca4ebeee47c9b4d6ba9ad58db694a0?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hisashi Yamaeda" width="32">
+<img alt="Hisashi Yamaeda" height="32" src="https://www.gravatar.com/avatar/01ca4ebeee47c9b4d6ba9ad58db694a0?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hisashi Yamaeda" width="32">
 <a href="#"></a>
 </li>
 <li>
-<img alt="gekidanyonin" height="32" src="http://www.gravatar.com/avatar/2b196f1723fdbcbf7bd297b3e7f8cd3c?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="gekidanyonin" width="32">
+<img alt="gekidanyonin" height="32" src="https://www.gravatar.com/avatar/2b196f1723fdbcbf7bd297b3e7f8cd3c?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="gekidanyonin" width="32">
 <a href="#"></a>
 </li>
 <li>
-<a href="http://jp.linkedin.com/in/nakaomitsuteru"><img alt="Mitsuteru Nakao" height="32" src="http://www.gravatar.com/avatar/9090e122cba40b90124ea8eb4859bf8e?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Mitsuteru Nakao" width="32"></a>
+<a href="http://jp.linkedin.com/in/nakaomitsuteru"><img alt="Mitsuteru Nakao" height="32" src="https://www.gravatar.com/avatar/9090e122cba40b90124ea8eb4859bf8e?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Mitsuteru Nakao" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://zaki.asia"><img alt="Dezso Zoltan" height="32" src="http://www.gravatar.com/avatar/a771de8e1e49a9da61e2a602a2af42bc?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Dezso Zoltan" width="32"></a>
+<a href="http://zaki.asia"><img alt="Dezso Zoltan" height="32" src="https://www.gravatar.com/avatar/a771de8e1e49a9da61e2a602a2af42bc?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Dezso Zoltan" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.twitter.com/ope"><img alt="Takanori Nakanowatari" height="32" src="http://www.gravatar.com/avatar/55bcf6eb5de45a70e76f8a2678822ecb?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takanori Nakanowatari" width="32"></a>
+<a href="http://www.twitter.com/ope"><img alt="Takanori Nakanowatari" height="32" src="https://www.gravatar.com/avatar/55bcf6eb5de45a70e76f8a2678822ecb?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takanori Nakanowatari" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="https://github.com/zev"><img alt="Zev Blut" height="32" src="http://www.gravatar.com/avatar/1c77ad9f35746369dd1f4dd69b9f8b18?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Zev Blut" width="32"></a>
+<a href="https://github.com/zev"><img alt="Zev Blut" height="32" src="https://www.gravatar.com/avatar/1c77ad9f35746369dd1f4dd69b9f8b18?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Zev Blut" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://tako3.com/http://rubykaigi.org/rubyists/kei-s"><img alt="kei-s" height="32" src="http://www.gravatar.com/avatar/bf7ce9b68bbb0058721906b4db15b9b5?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="kei-s" width="32"></a>
+<a href="http://tako3.com/http://rubykaigi.org/rubyists/kei-s"><img alt="kei-s" height="32" src="https://www.gravatar.com/avatar/bf7ce9b68bbb0058721906b4db15b9b5?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="kei-s" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/bobbyjam99"><img alt="Tomokazu IMAI" height="32" src="http://www.gravatar.com/avatar/33814e72445b35ad3b65b1b05e699adc?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomokazu IMAI" width="32"></a>
+<a href="http://twitter.com/bobbyjam99"><img alt="Tomokazu IMAI" height="32" src="https://www.gravatar.com/avatar/33814e72445b35ad3b65b1b05e699adc?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomokazu IMAI" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/hasimo"><img alt="Tohru Hashimoto" height="32" src="http://www.gravatar.com/avatar/6e3d1578114e5d3951a7f90579fff74c?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tohru Hashimoto" width="32"></a>
+<a href="http://twitter.com/hasimo"><img alt="Tohru Hashimoto" height="32" src="https://www.gravatar.com/avatar/6e3d1578114e5d3951a7f90579fff74c?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tohru Hashimoto" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.mobalean.com/founders/michael"><img alt="Michael Reinsch" height="32" src="http://www.gravatar.com/avatar/c7915a424cbb28fdd6c1cce270be6b58?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Michael Reinsch" width="32"></a>
+<a href="http://www.mobalean.com/founders/michael"><img alt="Michael Reinsch" height="32" src="https://www.gravatar.com/avatar/c7915a424cbb28fdd6c1cce270be6b58?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Michael Reinsch" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/sandinist"><img alt="Tsuyoshi MAEHANA" height="32" src="http://www.gravatar.com/avatar/e8ebe7d4ec09c5dd77ee064706836f23?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tsuyoshi MAEHANA" width="32"></a>
+<a href="http://twitter.com/sandinist"><img alt="Tsuyoshi MAEHANA" height="32" src="https://www.gravatar.com/avatar/e8ebe7d4ec09c5dd77ee064706836f23?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tsuyoshi MAEHANA" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://sane.jp"><img alt="Murahashi Sanemat Kenichi" height="32" src="http://www.gravatar.com/avatar/5b1d016f87f05ff645ae572ccbbf0448?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Murahashi Sanemat Kenichi" width="32"></a>
+<a href="http://sane.jp"><img alt="Murahashi Sanemat Kenichi" height="32" src="https://www.gravatar.com/avatar/5b1d016f87f05ff645ae572ccbbf0448?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Murahashi Sanemat Kenichi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://aerial.st"><img alt="Masato Ikeda" height="32" src="http://www.gravatar.com/avatar/03abf5741b7bbd28670af5ec92b6141d?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masato Ikeda" width="32"></a>
+<a href="http://aerial.st"><img alt="Masato Ikeda" height="32" src="https://www.gravatar.com/avatar/03abf5741b7bbd28670af5ec92b6141d?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masato Ikeda" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/tex314"><img alt="OKAZAKI Takurou" height="32" src="http://www.gravatar.com/avatar/45c2cc1a731924edf1045d9146ca4a78?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="OKAZAKI Takurou" width="32"></a>
+<a href="http://twitter.com/tex314"><img alt="OKAZAKI Takurou" height="32" src="https://www.gravatar.com/avatar/45c2cc1a731924edf1045d9146ca4a78?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="OKAZAKI Takurou" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="https://twitter.com/toshi3221"><img alt="Toshiharu Takematsu" height="32" src="http://www.gravatar.com/avatar/3ca4621fbbb03278d4550f89e2f723ba?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Toshiharu Takematsu" width="32"></a>
+<a href="https://twitter.com/toshi3221"><img alt="Toshiharu Takematsu" height="32" src="https://www.gravatar.com/avatar/3ca4621fbbb03278d4550f89e2f723ba?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Toshiharu Takematsu" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://tdtds.jp"><img alt="TADA Tadashi" height="32" src="http://www.gravatar.com/avatar/846a80b9bf7ea7becb6c4ecd67bedd6f?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TADA Tadashi" width="32"></a>
+<a href="http://tdtds.jp"><img alt="TADA Tadashi" height="32" src="https://www.gravatar.com/avatar/846a80b9bf7ea7becb6c4ecd67bedd6f?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TADA Tadashi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://hisano.com"><img alt="HISANO Kozo" height="32" src="http://www.gravatar.com/avatar/b8fa07639c3b720c33ffdcaf89299dda?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="HISANO Kozo" width="32"></a>
+<a href="http://hisano.com"><img alt="HISANO Kozo" height="32" src="https://www.gravatar.com/avatar/b8fa07639c3b720c33ffdcaf89299dda?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="HISANO Kozo" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/kouma31/"><img alt="kmuroi" height="32" src="http://www.gravatar.com/avatar/165599097b8533c91af2aad5d7b31449?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="kmuroi" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<img alt="Anonymous" height="32" src="/2011/images/bow_face.png?1359134037" title="Anonymous" width="32">
-<a href="#"></a>
-</li>
-<li>
-<a href="http://twitter.com/h4n"><img alt="Han Kessels" height="32" src="http://www.gravatar.com/avatar/f0bd4ed83708d0af0e0d1374fc7e605b?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Han Kessels" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://twitter.com/takagi"><img alt="TAKAGI Masahiro" height="32" src="http://www.gravatar.com/avatar/c3f5a6e729b57f99cb9e7b3ca60152aa?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TAKAGI Masahiro" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://d.hatena.ne.jp/tmtms/"><img alt="TOMITA Masahiro" height="32" src="http://www.gravatar.com/avatar/e4763acee4cf0377437f614fc372a061?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TOMITA Masahiro" width="32"></a>
+<a href="http://d.hatena.ne.jp/kouma31/"><img alt="kmuroi" height="32" src="https://www.gravatar.com/avatar/165599097b8533c91af2aad5d7b31449?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="kmuroi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
@@ -907,79 +891,95 @@ Goldスポンサー
 <a href="#"></a>
 </li>
 <li>
-<a href="http://kmuto.jp/"><img alt="Kenshi Muto" height="32" src="http://www.gravatar.com/avatar/43d44fbc12adcf80c9fc24e235f48234?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kenshi Muto" width="32"></a>
+<a href="http://twitter.com/h4n"><img alt="Han Kessels" height="32" src="https://www.gravatar.com/avatar/f0bd4ed83708d0af0e0d1374fc7e605b?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Han Kessels" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<img alt="1syo" height="32" src="http://www.gravatar.com/avatar/83899fe2d00874176098a3bb71b043be?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="1syo" width="32">
+<a href="http://twitter.com/takagi"><img alt="TAKAGI Masahiro" height="32" src="https://www.gravatar.com/avatar/c3f5a6e729b57f99cb9e7b3ca60152aa?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TAKAGI Masahiro" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://fkino.net"><img alt="Fumihiko Kinoshita" height="32" src="http://www.gravatar.com/avatar/f301c0275838d562c72ea9177e7ddc68?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Fumihiko Kinoshita" width="32"></a>
+<a href="http://d.hatena.ne.jp/tmtms/"><img alt="TOMITA Masahiro" height="32" src="https://www.gravatar.com/avatar/e4763acee4cf0377437f614fc372a061?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TOMITA Masahiro" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://blog.masuidrive.jp/"><img alt="Yuichiro MASUI" height="32" src="http://www.gravatar.com/avatar/0ec58a040e1e4e959c8566484b4bba19?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yuichiro MASUI" width="32"></a>
+<img alt="Anonymous" height="32" src="/2011/images/bow_face.png?1359134037" title="Anonymous" width="32">
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/t2os/"><img alt="tatsuoSakurai" height="32" src="http://www.gravatar.com/avatar/092404bdf9897eba9ab16e61f56592db?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="tatsuoSakurai" width="32"></a>
+<a href="http://kmuto.jp/"><img alt="Kenshi Muto" height="32" src="https://www.gravatar.com/avatar/43d44fbc12adcf80c9fc24e235f48234?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kenshi Muto" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://ogijun.org"><img alt="Junya Ogino" height="32" src="http://www.gravatar.com/avatar/3a82321f68500d9691a9e190979ac2f0?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Junya Ogino" width="32"></a>
+<img alt="1syo" height="32" src="https://www.gravatar.com/avatar/83899fe2d00874176098a3bb71b043be?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="1syo" width="32">
 <a href="#"></a>
 </li>
 <li>
-<a href="http://about.me/mackato"><img alt="Masakuni Kato" height="32" src="http://www.gravatar.com/avatar/28347314c7fc698b4ac0e01113545e25?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masakuni Kato" width="32"></a>
+<a href="http://fkino.net"><img alt="Fumihiko Kinoshita" height="32" src="https://www.gravatar.com/avatar/f301c0275838d562c72ea9177e7ddc68?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Fumihiko Kinoshita" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/IWAKIRI"><img alt="IWAKIRI,Akiko" height="32" src="http://www.gravatar.com/avatar/2a02258781c7592d0da1cd5cffa627a8?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="IWAKIRI,Akiko" width="32"></a>
+<a href="http://blog.masuidrive.jp/"><img alt="Yuichiro MASUI" height="32" src="https://www.gravatar.com/avatar/0ec58a040e1e4e959c8566484b4bba19?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yuichiro MASUI" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://june29.jp/"><img alt="june29" height="32" src="http://www.gravatar.com/avatar/6fd9be5cd0196df5ad62a5a5f2be3c55?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="june29" width="32"></a>
+<a href="http://d.hatena.ne.jp/t2os/"><img alt="tatsuoSakurai" height="32" src="https://www.gravatar.com/avatar/092404bdf9897eba9ab16e61f56592db?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="tatsuoSakurai" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.socialtoprunners.jp/"><img alt="tomokazuhattanda" height="32" src="http://www.gravatar.com/avatar/19798587cb27b5220a5dcdbaa9a50d57?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="tomokazuhattanda" width="32"></a>
+<a href="http://ogijun.org"><img alt="Junya Ogino" height="32" src="https://www.gravatar.com/avatar/3a82321f68500d9691a9e190979ac2f0?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Junya Ogino" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.jamboree.jp/"><img alt="TOYOSHI, Ryuichiro" height="32" src="http://www.gravatar.com/avatar/203c324392b6c51241da5b42bbf888bd?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TOYOSHI, Ryuichiro" width="32"></a>
+<a href="http://about.me/mackato"><img alt="Masakuni Kato" height="32" src="https://www.gravatar.com/avatar/28347314c7fc698b4ac0e01113545e25?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masakuni Kato" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/takano32"><img alt="たかのみつひろ" height="32" src="http://www.gravatar.com/avatar/eba4a40bdae5edfe1589601c050a2b96?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="たかのみつひろ" width="32"></a>
+<a href="http://d.hatena.ne.jp/IWAKIRI"><img alt="IWAKIRI,Akiko" height="32" src="https://www.gravatar.com/avatar/2a02258781c7592d0da1cd5cffa627a8?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="IWAKIRI,Akiko" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/tyabe"><img alt="tyabe" height="32" src="http://www.gravatar.com/avatar/d21900444f5548d9329861593321b5a6?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="tyabe" width="32"></a>
+<a href="http://june29.jp/"><img alt="june29" height="32" src="https://www.gravatar.com/avatar/6fd9be5cd0196df5ad62a5a5f2be3c55?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="june29" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/#!/maxyz"><img alt="Masafumi Fujiwara" height="32" src="http://www.gravatar.com/avatar/4dd4d13d27559db2fb64ad069f2c49ba?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masafumi Fujiwara" width="32"></a>
+<a href="http://www.socialtoprunners.jp/"><img alt="tomokazuhattanda" height="32" src="https://www.gravatar.com/avatar/19798587cb27b5220a5dcdbaa9a50d57?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="tomokazuhattanda" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/kdmsnr"><img alt="Masanori Kado" height="32" src="http://www.gravatar.com/avatar/70b07e6b7fe7d921d7ac542d0ccb3b2c?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masanori Kado" width="32"></a>
+<a href="http://www.jamboree.jp/"><img alt="TOYOSHI, Ryuichiro" height="32" src="https://www.gravatar.com/avatar/203c324392b6c51241da5b42bbf888bd?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TOYOSHI, Ryuichiro" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.jitu.org/~tko"><img alt="Tomoyuki Kosimizu" height="32" src="http://www.gravatar.com/avatar/3585181753c22a9531e70a8297771b01?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomoyuki Kosimizu" width="32"></a>
+<a href="http://twitter.com/takano32"><img alt="たかのみつひろ" height="32" src="https://www.gravatar.com/avatar/eba4a40bdae5edfe1589601c050a2b96?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="たかのみつひろ" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/chinmo"><img alt="Tomonori Fukuta" height="32" src="http://www.gravatar.com/avatar/7977a0896e60587b2690550891be2ea7?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomonori Fukuta" width="32"></a>
+<a href="http://twitter.com/tyabe"><img alt="tyabe" height="32" src="https://www.gravatar.com/avatar/d21900444f5548d9329861593321b5a6?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="tyabe" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<img alt="YOKOTA Akiko" height="32" src="http://www.gravatar.com/avatar/03e548747e667fc94cc8495868bfd85e?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="YOKOTA Akiko" width="32">
+<a href="http://twitter.com/#!/maxyz"><img alt="Masafumi Fujiwara" height="32" src="https://www.gravatar.com/avatar/4dd4d13d27559db2fb64ad069f2c49ba?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masafumi Fujiwara" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://nov.tdiary.net/"><img alt="Nobuhiro IMAI" height="32" src="http://www.gravatar.com/avatar/e49ab9f0774711c473660019728cde95?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Nobuhiro IMAI" width="32"></a>
+<a href="http://twitter.com/kdmsnr"><img alt="Masanori Kado" height="32" src="https://www.gravatar.com/avatar/70b07e6b7fe7d921d7ac542d0ccb3b2c?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masanori Kado" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://www.jitu.org/~tko"><img alt="Tomoyuki Kosimizu" height="32" src="https://www.gravatar.com/avatar/3585181753c22a9531e70a8297771b01?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomoyuki Kosimizu" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://twitter.com/chinmo"><img alt="Tomonori Fukuta" height="32" src="https://www.gravatar.com/avatar/7977a0896e60587b2690550891be2ea7?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomonori Fukuta" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<img alt="YOKOTA Akiko" height="32" src="https://www.gravatar.com/avatar/03e548747e667fc94cc8495868bfd85e?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="YOKOTA Akiko" width="32">
+<a href="#"></a>
+</li>
+<li>
+<a href="http://nov.tdiary.net/"><img alt="Nobuhiro IMAI" height="32" src="https://www.gravatar.com/avatar/e49ab9f0774711c473660019728cde95?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Nobuhiro IMAI" width="32"></a>
 <a href="#"></a>
 </li>
 </ul>

--- a/2011/ja/schedule/details/16M01/index.html
+++ b/2011/ja/schedule/details/16M01/index.html
@@ -136,7 +136,7 @@ for continued success.
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/f29327647a9cff5c69618bae420792ea?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/f29327647a9cff5c69618bae420792ea?s=32" width="32">
 </a>
 <h4>
 Aaron Patterson (tenderlove)

--- a/2011/ja/schedule/details/16M03/index.html
+++ b/2011/ja/schedule/details/16M03/index.html
@@ -132,7 +132,7 @@ Ruby を利用した大規模ウェブサービスの開発・運用
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/2997ec7879942bd0415690c85731e328?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/2997ec7879942bd0415690c85731e328?s=32" width="32">
 </a>
 <h4>
 舘野祐一

--- a/2011/ja/schedule/details/16M06/index.html
+++ b/2011/ja/schedule/details/16M06/index.html
@@ -138,7 +138,7 @@ SIerがRailsを採用する背景には、高い生産性と業務の変化に�
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/2e9a2dbe335e0111e4879a9d65dcbae0?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/2e9a2dbe335e0111e4879a9d65dcbae0?s=32" width="32">
 </a>
 <h4>
 相澤 歩

--- a/2011/ja/schedule/details/16M08/index.html
+++ b/2011/ja/schedule/details/16M08/index.html
@@ -134,7 +134,7 @@ Rubyで実装する中で、効果的だと感じた点、
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/5c72a69ad460347a01aa05de9915c3e0?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/5c72a69ad460347a01aa05de9915c3e0?s=32" width="32">
 </a>
 <h4>
 江森 真由美(emorima)

--- a/2011/ja/schedule/details/16S01/index.html
+++ b/2011/ja/schedule/details/16S01/index.html
@@ -134,7 +134,7 @@ Rubyコミッタとなった自分が昔コミュニティをどう見ていた�
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/b99311b48290f8ee37311890a8edfb1d?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/b99311b48290f8ee37311890a8edfb1d?s=32" width="32">
 </a>
 <h4>
 Shota Fukumori (sora_h)

--- a/2011/ja/schedule/details/16S04/index.html
+++ b/2011/ja/schedule/details/16S04/index.html
@@ -144,7 +144,7 @@
 </div>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/0ec4920185b657a03edf01fff96b4e9b?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/0ec4920185b657a03edf01fff96b4e9b?s=32" width="32">
 </a>
 <h4>
 まつもとゆきひろ

--- a/2011/ja/schedule/details/16S05/index.html
+++ b/2011/ja/schedule/details/16S05/index.html
@@ -136,7 +136,7 @@ CRubyは現在マーク・スイープという方式のGCを採用していま�
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/9f859654c118bcd2f67cc763baf0de7a?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/9f859654c118bcd2f67cc763baf0de7a?s=32" width="32">
 </a>
 <h4>
 nari

--- a/2011/ja/schedule/details/17M01/index.html
+++ b/2011/ja/schedule/details/17M01/index.html
@@ -135,7 +135,7 @@
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/8e497efbe99e2fa051316337d03624d9?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/8e497efbe99e2fa051316337d03624d9?s=32" width="32">
 </a>
 <h4>
 西山和広

--- a/2011/ja/schedule/details/17M02/index.html
+++ b/2011/ja/schedule/details/17M02/index.html
@@ -132,7 +132,7 @@ jpmobileを使ったモバイルサイト制作のベストプラクティスを
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/d458733ada0c2ca6937f84c67a9e3fff?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/d458733ada0c2ca6937f84c67a9e3fff?s=32" width="32">
 </a>
 <h4>
 小川 伸一郎

--- a/2011/ja/schedule/details/17M03/index.html
+++ b/2011/ja/schedule/details/17M03/index.html
@@ -133,7 +133,7 @@ Rails 3.0がリリースされてから約1年間、日々の業務で、個人�
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/76a777ff80f30bd3b390e275cce625bc?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/76a777ff80f30bd3b390e275cce625bc?s=32" width="32">
 </a>
 <h4>
 松田 明

--- a/2011/ja/schedule/details/17M04/index.html
+++ b/2011/ja/schedule/details/17M04/index.html
@@ -132,7 +132,7 @@ Rubyをマスターする、つまり、Rubyで自分の作りたいものをな
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/22270b6a4e909f6b926fa272596d41b9?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/22270b6a4e909f6b926fa272596d41b9?s=32" width="32">
 </a>
 <h4>
 原　悠

--- a/2011/ja/schedule/details/17M05/index.html
+++ b/2011/ja/schedule/details/17M05/index.html
@@ -134,7 +134,7 @@ This talk will introduce their BDD syntax and its mocks feature. More important,
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/c38fd9074fb072551c0ff80ccd90d24e?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/c38fd9074fb072551c0ff80ccd90d24e?s=32" width="32">
 </a>
 <h4>
 Wen-Tien Chang

--- a/2011/ja/schedule/details/17M06/index.html
+++ b/2011/ja/schedule/details/17M06/index.html
@@ -138,7 +138,7 @@ Ruby on Railsを使ったプロジェクトにおいて、RSpecでテストを�
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/70e13d9877054026fda46d5a5b53a236?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/70e13d9877054026fda46d5a5b53a236?s=32" width="32">
 </a>
 <h4>
 諸橋 恭介

--- a/2011/ja/schedule/details/17M07/index.html
+++ b/2011/ja/schedule/details/17M07/index.html
@@ -132,7 +132,7 @@ This presentation will introduce you V8 JavaScript engine and Mike - the headles
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/16c772a254c53065066116ccd04ae146?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/16c772a254c53065066116ccd04ae146?s=32" width="32">
 </a>
 <h4>
 Chris Kowalik

--- a/2011/ja/schedule/details/17M08/index.html
+++ b/2011/ja/schedule/details/17M08/index.html
@@ -133,7 +133,7 @@ I will also talk about how nonblocking IO and network libraries can be used with
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/428167a3ec72235ba971162924492609?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/428167a3ec72235ba971162924492609?s=32" width="32">
 </a>
 <h4>
 Yehuda Katz

--- a/2011/ja/schedule/details/17M09/index.html
+++ b/2011/ja/schedule/details/17M09/index.html
@@ -132,7 +132,7 @@ RubyKaigi2007でDave Thomasは私たち日本のRubyistに「宿題」を出し�
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/63a6bff89d692e21de20868202bc8dde?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/63a6bff89d692e21de20868202bc8dde?s=32" width="32">
 </a>
 <h4>
 角谷 信太郎

--- a/2011/ja/schedule/details/17M10/index.html
+++ b/2011/ja/schedule/details/17M10/index.html
@@ -257,7 +257,7 @@ Paul McMahon
 </div>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/947a39212bd81f6f17d3ff1291432c5d?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/947a39212bd81f6f17d3ff1291432c5d?s=32" width="32">
 </a>
 <h4>
 Joseph Wilk
@@ -297,7 +297,7 @@ Florian Hanke
 </div>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/cd07d1d30d4edcc5d5c5fbdd21eb45af?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/cd07d1d30d4edcc5d5c5fbdd21eb45af?s=32" width="32">
 </a>
 <h4>
 関口 亮一

--- a/2011/ja/schedule/details/17M10_04/index.html
+++ b/2011/ja/schedule/details/17M10_04/index.html
@@ -134,7 +134,7 @@ Why don't we do the same in Programming? I want to demonstrate how we can, espec
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/947a39212bd81f6f17d3ff1291432c5d?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/947a39212bd81f6f17d3ff1291432c5d?s=32" width="32">
 </a>
 <h4>
 Joseph Wilk

--- a/2011/ja/schedule/details/17M10_09/index.html
+++ b/2011/ja/schedule/details/17M10_09/index.html
@@ -132,7 +132,7 @@ rubykaigi.orgを支える技術
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/cd07d1d30d4edcc5d5c5fbdd21eb45af?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/cd07d1d30d4edcc5d5c5fbdd21eb45af?s=32" width="32">
 </a>
 <h4>
 関口 亮一

--- a/2011/ja/schedule/details/17S01/index.html
+++ b/2011/ja/schedule/details/17S01/index.html
@@ -133,7 +133,7 @@ This talk discusses several options to use actors in Ruby.
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/c89aa4bb4813720b76ac499d98d850f2?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/c89aa4bb4813720b76ac499d98d850f2?s=32" width="32">
 </a>
 <h4>
 Elise Huard

--- a/2011/ja/schedule/details/17S03/index.html
+++ b/2011/ja/schedule/details/17S03/index.html
@@ -132,7 +132,7 @@ Writing Friendly Libraries will cover how to write libraries that are easy to us
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/58479f76374a3ba3c69b9804163f39f4?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/58479f76374a3ba3c69b9804163f39f4?s=32" width="32">
 </a>
 <h4>
 Eric Hodel

--- a/2011/ja/schedule/details/17S06/index.html
+++ b/2011/ja/schedule/details/17S06/index.html
@@ -132,7 +132,7 @@ JIS X 3017はプログラミング言語Rubyの日本国内規格である。こ
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/18a797893e6768e048c1d15429f96bb4?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/18a797893e6768e048c1d15429f96bb4?s=32" width="32">
 </a>
 <h4>
 前田 修吾

--- a/2011/ja/schedule/details/17S07/index.html
+++ b/2011/ja/schedule/details/17S07/index.html
@@ -142,7 +142,7 @@ Javaのレガシーコードを使って、Rubyコードに素敵な感じで入
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/13313ac2ec7ba7c43b1b952db034ff3b?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/13313ac2ec7ba7c43b1b952db034ff3b?s=32" width="32">
 </a>
 <h4>
 トーマス・E・エネボ
@@ -154,7 +154,7 @@ Javaのレガシーコードを使って、Rubyコードに素敵な感じで入
 </div>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/1ce18b10bd8f911566c5577042b6a44c?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/1ce18b10bd8f911566c5577042b6a44c?s=32" width="32">
 </a>
 <h4>
 大場光一郎

--- a/2011/ja/schedule/details/17S08/index.html
+++ b/2011/ja/schedule/details/17S08/index.html
@@ -137,7 +137,7 @@ Railsが到底動作するようには思えない。しかしながら、MacRub
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/0680ae0d795607a6d9d7fb24698710bd?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/0680ae0d795607a6d9d7fb24698710bd?s=32" width="32">
 </a>
 <h4>
 高尾宏治

--- a/2011/ja/schedule/details/17S09/index.html
+++ b/2011/ja/schedule/details/17S09/index.html
@@ -136,7 +136,7 @@ Method Shelters : Classboxes でも Refinements でもない別のやり方
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/a129af622d3faa2c90d448401a3f6faa?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/a129af622d3faa2c90d448401a3f6faa?s=32" width="32">
 </a>
 <h4>
 赤井駿平

--- a/2011/ja/schedule/details/17S10/index.html
+++ b/2011/ja/schedule/details/17S10/index.html
@@ -136,7 +136,7 @@ Ruby 1.9ではネイティブスレッドの採用とそれによる高速化が
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/02da662c083396641da96c1d32fc86ed?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/02da662c083396641da96c1d32fc86ed?s=32" width="32">
 </a>
 <h4>
 小崎資広

--- a/2011/ja/schedule/details/18M01/index.html
+++ b/2011/ja/schedule/details/18M01/index.html
@@ -135,7 +135,7 @@
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/21a4b941766d805333e11c5766be43b4?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/21a4b941766d805333e11c5766be43b4?s=32" width="32">
 </a>
 <h4>
 高橋征義
@@ -147,7 +147,7 @@
 </div>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/9673ac7770ee09f76ff5d839820db157?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/9673ac7770ee09f76ff5d839820db157?s=32" width="32">
 </a>
 <h4>
 okkez
@@ -159,7 +159,7 @@ okkez
 </div>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/77a29c830c1974513a335accf5cf41a1?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/77a29c830c1974513a335accf5cf41a1?s=32" width="32">
 </a>
 <h4>
 Sunao Tanabe

--- a/2011/ja/schedule/details/18M03/index.html
+++ b/2011/ja/schedule/details/18M03/index.html
@@ -132,7 +132,7 @@ All About RubyKaigi Ecosystem
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/941b170e5a115a295cccb5f5cdf0a800?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/941b170e5a115a295cccb5f5cdf0a800?s=32" width="32">
 </a>
 <h4>
 島田 浩二
@@ -146,7 +146,7 @@ All About RubyKaigi Ecosystem
 </div>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/9d2d4c8b739b1b4d7882ba49dcf1d276?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/9d2d4c8b739b1b4d7882ba49dcf1d276?s=32" width="32">
 </a>
 <h4>
 こしば としあき
@@ -158,7 +158,7 @@ All About RubyKaigi Ecosystem
 </div>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/63a6bff89d692e21de20868202bc8dde?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/63a6bff89d692e21de20868202bc8dde?s=32" width="32">
 </a>
 <h4>
 角谷 信太郎

--- a/2011/ja/schedule/details/18M05/index.html
+++ b/2011/ja/schedule/details/18M05/index.html
@@ -134,7 +134,7 @@ Ruby遺産とレガシーコード修理技術
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/eabad423977cfc6873b8f5df62b848a6?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/eabad423977cfc6873b8f5df62b848a6?s=32" width="32">
 </a>
 <h4>
 柴田博志

--- a/2011/ja/schedule/details/18M06/index.html
+++ b/2011/ja/schedule/details/18M06/index.html
@@ -134,7 +134,7 @@
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/2d9386b1504e581be390af978e05a8b9?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/2d9386b1504e581be390af978e05a8b9?s=32" width="32">
 </a>
 <h4>
 須藤功平

--- a/2011/ja/schedule/details/18M07/index.html
+++ b/2011/ja/schedule/details/18M07/index.html
@@ -132,7 +132,7 @@ Ruby on Railsホスティングサービスで知られるEngine Yard社で 働�
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/40e5e9fe36a1f85166493faac2c17499?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/40e5e9fe36a1f85166493faac2c17499?s=32" width="32">
 </a>
 <h4>
 浅里 洋嗣

--- a/2011/ja/schedule/details/18M08/index.html
+++ b/2011/ja/schedule/details/18M08/index.html
@@ -133,7 +133,7 @@ Ruby の教えてくれたこと
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/941b170e5a115a295cccb5f5cdf0a800?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/941b170e5a115a295cccb5f5cdf0a800?s=32" width="32">
 </a>
 <h4>
 島田 浩二

--- a/2011/ja/schedule/details/18M09/index.html
+++ b/2011/ja/schedule/details/18M09/index.html
@@ -303,7 +303,7 @@ C、イ㌔。
 </div>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/7e7733a4e42faad9f8072afd85134b48?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/7e7733a4e42faad9f8072afd85134b48?s=32" width="32">
 </a>
 <h4>
 塩谷啓

--- a/2011/ja/schedule/details/18M09_10/index.html
+++ b/2011/ja/schedule/details/18M09_10/index.html
@@ -132,7 +132,7 @@ pebbles: rubygemsにおけるジョークモジュールの名前空間につい
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/7e7733a4e42faad9f8072afd85134b48?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/7e7733a4e42faad9f8072afd85134b48?s=32" width="32">
 </a>
 <h4>
 塩谷啓

--- a/2011/ja/schedule/details/18M10/index.html
+++ b/2011/ja/schedule/details/18M10/index.html
@@ -132,7 +132,7 @@
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/0ec4920185b657a03edf01fff96b4e9b?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/0ec4920185b657a03edf01fff96b4e9b?s=32" width="32">
 </a>
 <h4>
 まつもとゆきひろ

--- a/2011/ja/schedule/details/18S01/index.html
+++ b/2011/ja/schedule/details/18S01/index.html
@@ -132,7 +132,7 @@ Rubyにオレオレ文法を足す方法を紹介します。Rubyの文法が定
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/9c35bab0739fc8762adf30de13d8c053?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/9c35bab0739fc8762adf30de13d8c053?s=32" width="32">
 </a>
 <h4>
 あんどうやすし

--- a/2011/ja/schedule/details/18S02/index.html
+++ b/2011/ja/schedule/details/18S02/index.html
@@ -134,7 +134,7 @@ Visual Glitch, using Ruby
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/8c98a756a956b459da8cc616ad8f9d90?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/8c98a756a956b459da8cc616ad8f9d90?s=32" width="32">
 </a>
 <h4>
 ucnv

--- a/2011/ja/schedule/details/18S03/index.html
+++ b/2011/ja/schedule/details/18S03/index.html
@@ -136,7 +136,7 @@ So accelerate your Rubies towards the speed of light and see what gets produced.
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/01bbb59a1c3ef9960f25a97afe7e920f?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/01bbb59a1c3ef9960f25a97afe7e920f?s=32" width="32">
 </a>
 <h4>
 アンドリュー グリム

--- a/2011/ja/schedule/details/18S06/index.html
+++ b/2011/ja/schedule/details/18S06/index.html
@@ -133,7 +133,7 @@ In this talk I'd like to explain why I like Ruby and how it enabled us to grow a
 </h3>
 <div class="avatar">
 <a href="#" target="_blank">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/98c2fb4c31fae25fe0b618f1c994c1f3?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/98c2fb4c31fae25fe0b618f1c994c1f3?s=32" width="32">
 </a>
 <h4>
 秋田ファビオ誠

--- a/2011/ja/schedule/grid/index.html
+++ b/2011/ja/schedule/grid/index.html
@@ -141,7 +141,7 @@ for continued success.</span>
 </h3>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/f29327647a9cff5c69618bae420792ea?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/f29327647a9cff5c69618bae420792ea?s=24" width="24">
 Aaron Patterson (tenderlove)
 </li>
 </ul>
@@ -218,7 +218,7 @@ Ruby を利用した大規模ウェブサービスの開発・運用
 </h3>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/2997ec7879942bd0415690c85731e328?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/2997ec7879942bd0415690c85731e328?s=24" width="24">
 舘野祐一
 </li>
 </ul>
@@ -258,7 +258,7 @@ Rubyとそのコミュニティと中学生の私
 </h3>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/b99311b48290f8ee37311890a8edfb1d?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/b99311b48290f8ee37311890a8edfb1d?s=24" width="24">
 Shota Fukumori (sora_h)
 </li>
 </ul>
@@ -335,7 +335,7 @@ SIerがRailsを採用する背景には、高い生産性と業務の変化に�
 </h3>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/2e9a2dbe335e0111e4879a9d65dcbae0?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/2e9a2dbe335e0111e4879a9d65dcbae0?s=24" width="24">
 相澤 歩
 </li>
 </ul>
@@ -380,7 +380,7 @@ SIerがRailsを採用する背景には、高い生産性と業務の変化に�
 </ul>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/0ec4920185b657a03edf01fff96b4e9b?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/0ec4920185b657a03edf01fff96b4e9b?s=24" width="24">
 まつもとゆきひろ
 </li>
 </ul>
@@ -438,7 +438,7 @@ Rubyで実装する中で、効果的だと感じた点、
 </h3>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/5c72a69ad460347a01aa05de9915c3e0?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/5c72a69ad460347a01aa05de9915c3e0?s=24" width="24">
 江森 真由美(emorima)
 </li>
 </ul>
@@ -462,7 +462,7 @@ CRubyGCの並列世界
 </h3>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/9f859654c118bcd2f67cc763baf0de7a?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/9f859654c118bcd2f67cc763baf0de7a?s=24" width="24">
 nari
 </li>
 </ul>
@@ -570,7 +570,7 @@ nari
 </h3>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/8e497efbe99e2fa051316337d03624d9?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/8e497efbe99e2fa051316337d03624d9?s=24" width="24">
 西山和広
 </li>
 </ul>
@@ -588,7 +588,7 @@ jpmobileのベストプラクティス
 </h3>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/d458733ada0c2ca6937f84c67a9e3fff?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/d458733ada0c2ca6937f84c67a9e3fff?s=24" width="24">
 小川 伸一郎
 </li>
 </ul>
@@ -609,7 +609,7 @@ This talk discusses several options to use actors in Ruby.</span>
 </h3>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/c89aa4bb4813720b76ac499d98d850f2?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/c89aa4bb4813720b76ac499d98d850f2?s=24" width="24">
 Elise Huard
 </li>
 </ul>
@@ -665,7 +665,7 @@ Drip: Persistent tuple space and stream.
 </h3>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/76a777ff80f30bd3b390e275cce625bc?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/76a777ff80f30bd3b390e275cce625bc?s=24" width="24">
 松田 明
 </li>
 </ul>
@@ -683,7 +683,7 @@ Rubyマスターへの道
 </h3>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/22270b6a4e909f6b926fa272596d41b9?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/22270b6a4e909f6b926fa272596d41b9?s=24" width="24">
 原　悠
 </li>
 </ul>
@@ -703,7 +703,7 @@ Writing Friendly Libraries
 </h3>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/58479f76374a3ba3c69b9804163f39f4?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/58479f76374a3ba3c69b9804163f39f4?s=24" width="24">
 Eric Hodel
 </li>
 </ul>
@@ -758,7 +758,7 @@ This talk will introduce their BDD syntax and its mocks feature. More important,
 </h3>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/c38fd9074fb072551c0ff80ccd90d24e?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/c38fd9074fb072551c0ff80ccd90d24e?s=24" width="24">
 Wen-Tien Chang
 </li>
 </ul>
@@ -782,7 +782,7 @@ Wen-Tien Chang
 </h3>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/70e13d9877054026fda46d5a5b53a236?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/70e13d9877054026fda46d5a5b53a236?s=24" width="24">
 諸橋 恭介
 </li>
 </ul>
@@ -820,7 +820,7 @@ JIS X 3017の読み方
 </h3>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/18a797893e6768e048c1d15429f96bb4?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/18a797893e6768e048c1d15429f96bb4?s=24" width="24">
 前田 修吾
 </li>
 </ul>
@@ -855,7 +855,7 @@ Efficient JavaScript integration testing with Ruby and V8 engine.
 </h3>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/16c772a254c53065066116ccd04ae146?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/16c772a254c53065066116ccd04ae146?s=24" width="24">
 Chris Kowalik
 </li>
 </ul>
@@ -874,7 +874,7 @@ I will also talk about how nonblocking IO and network libraries can be used with
 </h3>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/428167a3ec72235ba971162924492609?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/428167a3ec72235ba971162924492609?s=24" width="24">
 Yehuda Katz
 </li>
 </ul>
@@ -904,13 +904,13 @@ Javaのレガシーコードを使って、Rubyコードに素敵な感じで入
 </h3>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/13313ac2ec7ba7c43b1b952db034ff3b?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/13313ac2ec7ba7c43b1b952db034ff3b?s=24" width="24">
 トーマス・E・エネボ
 </li>
 </ul>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/1ce18b10bd8f911566c5577042b6a44c?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/1ce18b10bd8f911566c5577042b6a44c?s=24" width="24">
 大場光一郎
 </li>
 </ul>
@@ -933,7 +933,7 @@ Railsが到底動作するようには思えない。しかしながら、MacRub
 </h3>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/0680ae0d795607a6d9d7fb24698710bd?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/0680ae0d795607a6d9d7fb24698710bd?s=24" width="24">
 高尾宏治
 </li>
 </ul>
@@ -968,7 +968,7 @@ The Gate
 </h3>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/63a6bff89d692e21de20868202bc8dde?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/63a6bff89d692e21de20868202bc8dde?s=24" width="24">
 角谷 信太郎
 </li>
 </ul>
@@ -992,7 +992,7 @@ Method Shelters : Classboxes でも Refinements でもない別のやり方
 </h3>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/a129af622d3faa2c90d448401a3f6faa?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/a129af622d3faa2c90d448401a3f6faa?s=24" width="24">
 赤井駿平
 </li>
 </ul>
@@ -1014,7 +1014,7 @@ CRubyのロックデザインの解説および改善案について
 </h3>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/02da662c083396641da96c1d32fc86ed?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/02da662c083396641da96c1d32fc86ed?s=24" width="24">
 小崎資広
 </li>
 </ul>
@@ -1124,19 +1124,19 @@ Lightning talks 1
 </h3>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/21a4b941766d805333e11c5766be43b4?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/21a4b941766d805333e11c5766be43b4?s=24" width="24">
 高橋征義
 </li>
 </ul>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/9673ac7770ee09f76ff5d839820db157?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/9673ac7770ee09f76ff5d839820db157?s=24" width="24">
 okkez
 </li>
 </ul>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/77a29c830c1974513a335accf5cf41a1?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/77a29c830c1974513a335accf5cf41a1?s=24" width="24">
 Sunao Tanabe
 </li>
 </ul>
@@ -1156,7 +1156,7 @@ parse.yの歩き方
 </h3>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/9c35bab0739fc8762adf30de13d8c053?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/9c35bab0739fc8762adf30de13d8c053?s=24" width="24">
 あんどうやすし
 </li>
 </ul>
@@ -1176,7 +1176,7 @@ Visual Glitch, using Ruby
 </h3>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/8c98a756a956b459da8cc616ad8f9d90?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/8c98a756a956b459da8cc616ad8f9d90?s=24" width="24">
 ucnv
 </li>
 </ul>
@@ -1211,19 +1211,19 @@ All About RubyKaigi Ecosystem
 </h3>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/941b170e5a115a295cccb5f5cdf0a800?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/941b170e5a115a295cccb5f5cdf0a800?s=24" width="24">
 島田 浩二
 </li>
 </ul>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/9d2d4c8b739b1b4d7882ba49dcf1d276?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/9d2d4c8b739b1b4d7882ba49dcf1d276?s=24" width="24">
 こしば としあき
 </li>
 </ul>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/63a6bff89d692e21de20868202bc8dde?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/63a6bff89d692e21de20868202bc8dde?s=24" width="24">
 角谷 信太郎
 </li>
 </ul>
@@ -1247,7 +1247,7 @@ So accelerate your Rubies towards the speed of light and see what gets produced.
 </h3>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/01bbb59a1c3ef9960f25a97afe7e920f?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/01bbb59a1c3ef9960f25a97afe7e920f?s=24" width="24">
 アンドリュー グリム
 </li>
 </ul>
@@ -1312,7 +1312,7 @@ Ruby遺産とレガシーコード修理技術
 </h3>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/eabad423977cfc6873b8f5df62b848a6?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/eabad423977cfc6873b8f5df62b848a6?s=24" width="24">
 柴田博志
 </li>
 </ul>
@@ -1332,7 +1332,7 @@ Ruby遺産とレガシーコード修理技術
 </h3>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/2d9386b1504e581be390af978e05a8b9?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/2d9386b1504e581be390af978e05a8b9?s=24" width="24">
 須藤功平
 </li>
 </ul>
@@ -1371,7 +1371,7 @@ In this talk I'd like to explain why I like Ruby and how it enabled us to grow a
 </h3>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/98c2fb4c31fae25fe0b618f1c994c1f3?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/98c2fb4c31fae25fe0b618f1c994c1f3?s=24" width="24">
 秋田ファビオ誠
 </li>
 </ul>
@@ -1406,7 +1406,7 @@ Rubyを持て、世界に出よう！
 </h3>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/40e5e9fe36a1f85166493faac2c17499?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/40e5e9fe36a1f85166493faac2c17499?s=24" width="24">
 浅里 洋嗣
 </li>
 </ul>
@@ -1425,7 +1425,7 @@ Ruby の教えてくれたこと
 </h3>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/941b170e5a115a295cccb5f5cdf0a800?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/941b170e5a115a295cccb5f5cdf0a800?s=24" width="24">
 島田 浩二
 </li>
 </ul>
@@ -1529,7 +1529,7 @@ Lightning talks 2
 </h3>
 <ul class="presenter">
 <li>
-<img alt="avatar" height="24" src="http://www.gravatar.com/avatar/0ec4920185b657a03edf01fff96b4e9b?s=24" width="24">
+<img alt="avatar" height="24" src="https://www.gravatar.com/avatar/0ec4920185b657a03edf01fff96b4e9b?s=24" width="24">
 まつもとゆきひろ
 </li>
 </ul>
@@ -1708,55 +1708,39 @@ Goldスポンサー
 </h2>
 <ul>
 <li>
-<a href="http://shyouhei.tumblr.com"><img alt="Urabe, Shyouhei" height="32" src="http://www.gravatar.com/avatar/9d2f78236e45a335301ba1195026105d?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Urabe, Shyouhei" width="32"></a>
+<a href="http://shyouhei.tumblr.com"><img alt="Urabe, Shyouhei" height="32" src="https://www.gravatar.com/avatar/9d2f78236e45a335301ba1195026105d?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Urabe, Shyouhei" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/noplans"><img alt="TANIGUCHI Fumitake" height="32" src="http://www.gravatar.com/avatar/e514ae09c9b84e04231af57f1d1946b8?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TANIGUCHI Fumitake" width="32"></a>
+<a href="http://twitter.com/noplans"><img alt="TANIGUCHI Fumitake" height="32" src="https://www.gravatar.com/avatar/e514ae09c9b84e04231af57f1d1946b8?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TANIGUCHI Fumitake" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://jmettraux.wordpress.com"><img alt="John Mettraux" height="32" src="http://www.gravatar.com/avatar/8d96626e52beb1ff90f57a8e189e1e6f?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="John Mettraux" width="32"></a>
+<a href="http://jmettraux.wordpress.com"><img alt="John Mettraux" height="32" src="https://www.gravatar.com/avatar/8d96626e52beb1ff90f57a8e189e1e6f?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="John Mettraux" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/japanrock"><img alt="Shintaro Nozaki" height="32" src="http://www.gravatar.com/avatar/b31a258dd8f615f61b2d355297f82dc9?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shintaro Nozaki" width="32"></a>
+<a href="http://twitter.com/japanrock"><img alt="Shintaro Nozaki" height="32" src="https://www.gravatar.com/avatar/b31a258dd8f615f61b2d355297f82dc9?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shintaro Nozaki" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://blog.dio.jp"><img alt="Akira Matsuda" height="32" src="http://www.gravatar.com/avatar/76a777ff80f30bd3b390e275cce625bc?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Akira Matsuda" width="32"></a>
+<a href="http://blog.dio.jp"><img alt="Akira Matsuda" height="32" src="https://www.gravatar.com/avatar/76a777ff80f30bd3b390e275cce625bc?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Akira Matsuda" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.bovensiepen.net"><img alt="Daniel Bovensiepen" height="32" src="http://www.gravatar.com/avatar/49d6f762505615af259534deed94bc54?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Daniel Bovensiepen" width="32"></a>
+<a href="http://www.bovensiepen.net"><img alt="Daniel Bovensiepen" height="32" src="https://www.gravatar.com/avatar/49d6f762505615af259534deed94bc54?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Daniel Bovensiepen" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://firn.jp/"><img alt="Dai Akatsuka" height="32" src="http://www.gravatar.com/avatar/4efe7b5cdbe97df84e6e607948171eef?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Dai Akatsuka" width="32"></a>
+<a href="http://firn.jp/"><img alt="Dai Akatsuka" height="32" src="https://www.gravatar.com/avatar/4efe7b5cdbe97df84e6e607948171eef?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Dai Akatsuka" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.din.or.jp/~shinodas/"><img alt="Yoshihiko Hara" height="32" src="http://www.gravatar.com/avatar/8055fbffa700065178460bb7e3b8ee24?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yoshihiko Hara" width="32"></a>
+<a href="http://www.din.or.jp/~shinodas/"><img alt="Yoshihiko Hara" height="32" src="https://www.gravatar.com/avatar/8055fbffa700065178460bb7e3b8ee24?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yoshihiko Hara" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://benhoskin.gs"><img alt="Ben Hoskings" height="32" src="http://www.gravatar.com/avatar/7ed99cb90a060539d729e2491442a603?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ben Hoskings" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<img alt="Anonymous" height="32" src="/2011/images/bow_face.png?1359134037" title="Anonymous" width="32">
-<a href="#"></a>
-</li>
-<li>
-<a href="http://www.nextseed.jp/"><img alt="Hitoshi Kurokawa" height="32" src="http://www.gravatar.com/avatar/11e89e3c85d9998b2c73933bde77c71e?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hitoshi Kurokawa" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://d.hatena.ne.jp/kinpoco/"><img alt="Yutaka Kanemoto" height="32" src="http://www.gravatar.com/avatar/0e728bf538d1848bc253d80a8626bbc2?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yutaka Kanemoto" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://d.hatena.ne.jp/yuichi_katahira"><img alt="Yuichi Katahira " height="32" src="http://www.gravatar.com/avatar/3072ae08f580fc8474b47652a3d8dd0f?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yuichi Katahira " width="32"></a>
+<a href="http://benhoskin.gs"><img alt="Ben Hoskings" height="32" src="https://www.gravatar.com/avatar/7ed99cb90a060539d729e2491442a603?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ben Hoskings" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
@@ -1764,87 +1748,15 @@ Goldスポンサー
 <a href="#"></a>
 </li>
 <li>
-<a href="http://kitaj.no-ip.com/tdiary/"><img alt="Junichiro Kita" height="32" src="http://www.gravatar.com/avatar/70405ca68e6f8779be65e75b1a90525b?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Junichiro Kita" width="32"></a>
+<a href="http://www.nextseed.jp/"><img alt="Hitoshi Kurokawa" height="32" src="https://www.gravatar.com/avatar/11e89e3c85d9998b2c73933bde77c71e?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hitoshi Kurokawa" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/idesaku"><img alt="Daisuke Goto" height="32" src="http://www.gravatar.com/avatar/85c8086344e5f31b2a4d22f163660536?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Daisuke Goto" width="32"></a>
+<a href="http://d.hatena.ne.jp/kinpoco/"><img alt="Yutaka Kanemoto" height="32" src="https://www.gravatar.com/avatar/0e728bf538d1848bc253d80a8626bbc2?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yutaka Kanemoto" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<img alt="Anonymous" height="32" src="/2011/images/bow_face.png?1359134037" title="Anonymous" width="32">
-<a href="#"></a>
-</li>
-<li>
-<a href="http://www.on-sky.net/~hs/"><img alt="Hideki SAKAMOTO" height="32" src="http://www.gravatar.com/avatar/7038a6cfc30b8c3b00b5c08d70cda2f1?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hideki SAKAMOTO" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://twitter.com/agilekawabata"><img alt="Kawabata Mitsuyoshi" height="32" src="http://www.gravatar.com/avatar/5236eb3ad498b3c5336a4575408fb1b1?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kawabata Mitsuyoshi" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://www.kt.rim.or.jp/~kbk/"><img alt="KIMURA Koichi" height="32" src="http://www.gravatar.com/avatar/04c1a31d1e33e7fc25a7ca99930e4c70?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="KIMURA Koichi" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://d.hatena.ne.jp/takkaw/"><img alt="Takayoshi Kawada" height="32" src="http://www.gravatar.com/avatar/38bf2ca557d9cc20dcdcbd773a68664b?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takayoshi Kawada" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://www.suchi.org/"><img alt="Shigeru UCHIYAMA" height="32" src="http://www.gravatar.com/avatar/398e2dd764d43aad735c6e5bca92c3b6?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shigeru UCHIYAMA" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://twitter.com/#!/andrewjgrimm"><img alt="Andrew Grimm" height="32" src="http://www.gravatar.com/avatar/01bbb59a1c3ef9960f25a97afe7e920f?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Andrew Grimm" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://twitter.com/kimuraw"><img alt="kimura wataru" height="32" src="http://www.gravatar.com/avatar/e298234a6e5a2c159287476abd76504a?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="kimura wataru" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://saikyoline.jp/"><img alt="MIKAMI Yoshiyuki" height="32" src="http://www.gravatar.com/avatar/e0920f5f813ae29ba7859f950a7f0df3?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MIKAMI Yoshiyuki" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://jp.rubyist.net/?KansaiWorkshop"><img alt="HIGAKI Masaru" height="32" src="http://www.gravatar.com/avatar/a8192f5a7b25ef32a983740ee8593bd3?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="HIGAKI Masaru" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://twitter.com/ayumin"><img alt="Ayumu AIZAWA" height="32" src="http://www.gravatar.com/avatar/2e9a2dbe335e0111e4879a9d65dcbae0?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ayumu AIZAWA" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://shunichi-arai.blogspot.com/"><img alt="Shunichi Arai" height="32" src="http://www.gravatar.com/avatar/74daf3516e33a75968ec0f933954b5a8?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shunichi Arai" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://www.tokyodev.com"><img alt="Paul McMahon" height="32" src="http://www.gravatar.com/avatar/dd24adb5a3a430fed83a33ed552fe1b5?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Paul McMahon" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://d.hatena.ne.jp/hs9587/"><img alt="Hiroyuki Shimura" height="32" src="http://www.gravatar.com/avatar/287a899c91a7a14535188d7e4784050e?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hiroyuki Shimura" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://kakutani.com"><img alt="Kakutani Shintaro" height="32" src="http://www.gravatar.com/avatar/34fcd5f1deeb25b1138e9845137feb6e?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kakutani Shintaro" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://d.hatena.ne.jp/mrkn"><img alt="Kenta Murata" height="32" src="http://www.gravatar.com/avatar/819b3c0a25f9708fd32261b8ae2d23f6?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kenta Murata" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://rails.to"><img alt="Masatoshi Itagaki" height="32" src="http://www.gravatar.com/avatar/f8865f41777ef3caced0e4e6801ff83a?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masatoshi Itagaki" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://spring-aki.com/"><img alt="Aki" height="32" src="http://www.gravatar.com/avatar/81f2122b45f48829be4507bf972666e9?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Aki" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://twitter.com/shin_asou"><img alt="Shinichi Okada" height="32" src="http://www.gravatar.com/avatar/20805358592bd93f92bf15aa10137251?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shinichi Okada" width="32"></a>
+<a href="http://d.hatena.ne.jp/yuichi_katahira"><img alt="Yuichi Katahira " height="32" src="https://www.gravatar.com/avatar/3072ae08f580fc8474b47652a3d8dd0f?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yuichi Katahira " width="32"></a>
 <a href="#"></a>
 </li>
 <li>
@@ -1852,35 +1764,11 @@ Goldスポンサー
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.kumaryu.net/"><img alt="Ryuichi Sakamoto" height="32" src="http://www.gravatar.com/avatar/1b2ca00132480422c75c1f2c61e84e26?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ryuichi Sakamoto" width="32"></a>
+<a href="http://kitaj.no-ip.com/tdiary/"><img alt="Junichiro Kita" height="32" src="https://www.gravatar.com/avatar/70405ca68e6f8779be65e75b1a90525b?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Junichiro Kita" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<img alt="Eito Katagiri" height="32" src="http://www.gravatar.com/avatar/b5852cf79505d7ba513f8f16ef95a50f?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Eito Katagiri" width="32">
-<a href="#"></a>
-</li>
-<li>
-<a href="http://ukstudio.jp/"><img alt="AKAMATSU Yuki" height="32" src="http://www.gravatar.com/avatar/0c471249ee93ab17a011f3e8d2b1057a?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="AKAMATSU Yuki" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://hisashim.org"><img alt="Hisashi Morita" height="32" src="http://www.gravatar.com/avatar/b3fba7af93cd27e6ed28e7eae88a9585?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hisashi Morita" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://d.hatena.ne.jp/muryoImpl/"><img alt="Ken muryoi" height="32" src="http://www.gravatar.com/avatar/ac6dba8ce93944d17714de362ca17e54?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ken muryoi" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://d.hatena.ne.jp/nagachika/"><img alt="Tomoyuki Chikanaga" height="32" src="http://www.gravatar.com/avatar/5cf8f058a4c094bb708174fb43e7a387?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomoyuki Chikanaga" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://d.hatena.ne.jp/takeshinoda/"><img alt="Takeshi SHINODA" height="32" src="http://www.gravatar.com/avatar/06febd004d7cc9c9f6a4e0272b686bc7?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takeshi SHINODA" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://twitter.com/knsmr"><img alt="Ken Nishimura" height="32" src="http://www.gravatar.com/avatar/91fb4852880d1727cca911036e2fef5f?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ken Nishimura" width="32"></a>
+<a href="http://d.hatena.ne.jp/idesaku"><img alt="Daisuke Goto" height="32" src="https://www.gravatar.com/avatar/85c8086344e5f31b2a4d22f163660536?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Daisuke Goto" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
@@ -1888,35 +1776,75 @@ Goldスポンサー
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/koko_u/"><img alt="Kozaki Tsuneaki" height="32" src="http://www.gravatar.com/avatar/5b1b558d563288da615a9ea2889afdd5?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kozaki Tsuneaki" width="32"></a>
+<a href="http://www.on-sky.net/~hs/"><img alt="Hideki SAKAMOTO" height="32" src="https://www.gravatar.com/avatar/7038a6cfc30b8c3b00b5c08d70cda2f1?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hideki SAKAMOTO" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/adzuki34"><img alt="SUZUKI Miho" height="32" src="http://www.gravatar.com/avatar/f37b9a968b2326062190677906a93080?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="SUZUKI Miho" width="32"></a>
+<a href="http://twitter.com/agilekawabata"><img alt="Kawabata Mitsuyoshi" height="32" src="https://www.gravatar.com/avatar/5236eb3ad498b3c5336a4575408fb1b1?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kawabata Mitsuyoshi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/lchin"><img alt="Leonard Chin" height="32" src="http://www.gravatar.com/avatar/70762059db0218c6f0ff48042ca0756a?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Leonard Chin" width="32"></a>
+<a href="http://www.kt.rim.or.jp/~kbk/"><img alt="KIMURA Koichi" height="32" src="https://www.gravatar.com/avatar/04c1a31d1e33e7fc25a7ca99930e4c70?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="KIMURA Koichi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/suzumura_ss/"><img alt="Toshiyuki Terashita" height="32" src="http://www.gravatar.com/avatar/bb8b58cab667163b6ee53aad0e5f0414?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Toshiyuki Terashita" width="32"></a>
+<a href="http://d.hatena.ne.jp/takkaw/"><img alt="Takayoshi Kawada" height="32" src="https://www.gravatar.com/avatar/38bf2ca557d9cc20dcdcbd773a68664b?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takayoshi Kawada" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://sites.google.com/site/akihikohashimoto/"><img alt="Akihiko Hashimoto" height="32" src="http://www.gravatar.com/avatar/c8803a4130c3238e34b605d0a0cffe94?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Akihiko Hashimoto" width="32"></a>
+<a href="http://www.suchi.org/"><img alt="Shigeru UCHIYAMA" height="32" src="https://www.gravatar.com/avatar/398e2dd764d43aad735c6e5bca92c3b6?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shigeru UCHIYAMA" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<img alt="OZAWA Sakuro" height="32" src="http://www.gravatar.com/avatar/a1cbed8bf64473e2acdd0c7066cc5b29?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="OZAWA Sakuro" width="32">
+<a href="http://twitter.com/#!/andrewjgrimm"><img alt="Andrew Grimm" height="32" src="https://www.gravatar.com/avatar/01bbb59a1c3ef9960f25a97afe7e920f?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Andrew Grimm" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://fkmn.exblog.jp/"><img alt="Arinobu FUKUHARA" height="32" src="http://www.gravatar.com/avatar/85319f2b72d7b37ddef5c25a2dd40d30?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Arinobu FUKUHARA" width="32"></a>
+<a href="http://twitter.com/kimuraw"><img alt="kimura wataru" height="32" src="https://www.gravatar.com/avatar/e298234a6e5a2c159287476abd76504a?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="kimura wataru" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/shachi"><img alt="Kazuyuki Koizuka-shachi" height="32" src="http://www.gravatar.com/avatar/f51ee84097a72a8d91bee9bb98736541?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kazuyuki Koizuka-shachi" width="32"></a>
+<a href="http://saikyoline.jp/"><img alt="MIKAMI Yoshiyuki" height="32" src="https://www.gravatar.com/avatar/e0920f5f813ae29ba7859f950a7f0df3?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MIKAMI Yoshiyuki" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://jp.rubyist.net/?KansaiWorkshop"><img alt="HIGAKI Masaru" height="32" src="https://www.gravatar.com/avatar/a8192f5a7b25ef32a983740ee8593bd3?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="HIGAKI Masaru" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://twitter.com/ayumin"><img alt="Ayumu AIZAWA" height="32" src="https://www.gravatar.com/avatar/2e9a2dbe335e0111e4879a9d65dcbae0?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ayumu AIZAWA" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://shunichi-arai.blogspot.com/"><img alt="Shunichi Arai" height="32" src="https://www.gravatar.com/avatar/74daf3516e33a75968ec0f933954b5a8?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shunichi Arai" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://www.tokyodev.com"><img alt="Paul McMahon" height="32" src="https://www.gravatar.com/avatar/dd24adb5a3a430fed83a33ed552fe1b5?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Paul McMahon" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://d.hatena.ne.jp/hs9587/"><img alt="Hiroyuki Shimura" height="32" src="https://www.gravatar.com/avatar/287a899c91a7a14535188d7e4784050e?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hiroyuki Shimura" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://kakutani.com"><img alt="Kakutani Shintaro" height="32" src="https://www.gravatar.com/avatar/34fcd5f1deeb25b1138e9845137feb6e?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kakutani Shintaro" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://d.hatena.ne.jp/mrkn"><img alt="Kenta Murata" height="32" src="https://www.gravatar.com/avatar/819b3c0a25f9708fd32261b8ae2d23f6?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kenta Murata" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://rails.to"><img alt="Masatoshi Itagaki" height="32" src="https://www.gravatar.com/avatar/f8865f41777ef3caced0e4e6801ff83a?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masatoshi Itagaki" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://spring-aki.com/"><img alt="Aki" height="32" src="https://www.gravatar.com/avatar/81f2122b45f48829be4507bf972666e9?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Aki" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://twitter.com/shin_asou"><img alt="Shinichi Okada" height="32" src="https://www.gravatar.com/avatar/20805358592bd93f92bf15aa10137251?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shinichi Okada" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
@@ -1924,103 +1852,175 @@ Goldスポンサー
 <a href="#"></a>
 </li>
 <li>
-<a href="http://atakigu.tumblr.com/"><img alt="atakig" height="32" src="http://www.gravatar.com/avatar/8a949c60e450d226de776072273a1ffc?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="atakig" width="32"></a>
+<a href="http://www.kumaryu.net/"><img alt="Ryuichi Sakamoto" height="32" src="https://www.gravatar.com/avatar/1b2ca00132480422c75c1f2c61e84e26?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ryuichi Sakamoto" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<img alt="TSUTSUI Toshinori" height="32" src="http://www.gravatar.com/avatar/ad66fd981c429c12e0f76c436da3337e?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TSUTSUI Toshinori" width="32">
+<img alt="Eito Katagiri" height="32" src="https://www.gravatar.com/avatar/b5852cf79505d7ba513f8f16ef95a50f?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Eito Katagiri" width="32">
 <a href="#"></a>
 </li>
 <li>
-<a href="http://yugui.jp"><img alt="Yuki Sonoda (Yugui)" height="32" src="http://www.gravatar.com/avatar/1e7e007723cfe59320d994a7db4ab4cf?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yuki Sonoda (Yugui)" width="32"></a>
+<a href="http://ukstudio.jp/"><img alt="AKAMATSU Yuki" height="32" src="https://www.gravatar.com/avatar/0c471249ee93ab17a011f3e8d2b1057a?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="AKAMATSU Yuki" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/seiunsky"><img alt="sugamasao" height="32" src="http://www.gravatar.com/avatar/961126d9892ae4df45249529a0721571?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="sugamasao" width="32"></a>
+<a href="http://hisashim.org"><img alt="Hisashi Morita" height="32" src="https://www.gravatar.com/avatar/b3fba7af93cd27e6ed28e7eae88a9585?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hisashi Morita" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/mkgin/"><img alt="Makoto Kouno" height="32" src="http://www.gravatar.com/avatar/06e6dcde277cbe5c614baf5d25871025?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Makoto Kouno" width="32"></a>
+<a href="http://d.hatena.ne.jp/muryoImpl/"><img alt="Ken muryoi" height="32" src="https://www.gravatar.com/avatar/ac6dba8ce93944d17714de362ca17e54?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ken muryoi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/suzuki"><img alt="Norio Suzuki" height="32" src="http://www.gravatar.com/avatar/8e528456ff66ec543952daa815353a01?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Norio Suzuki" width="32"></a>
+<a href="http://d.hatena.ne.jp/nagachika/"><img alt="Tomoyuki Chikanaga" height="32" src="https://www.gravatar.com/avatar/5cf8f058a4c094bb708174fb43e7a387?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomoyuki Chikanaga" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.artonx.org"><img alt="Akio Tajima" height="32" src="http://www.gravatar.com/avatar/0441ff038018e53a35bb207e81105a5c?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Akio Tajima" width="32"></a>
+<a href="http://d.hatena.ne.jp/takeshinoda/"><img alt="Takeshi SHINODA" height="32" src="https://www.gravatar.com/avatar/06febd004d7cc9c9f6a4e0272b686bc7?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takeshi SHINODA" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://moonrock.jp/~don/"><img alt="Hiroyuki Iwatsuki" height="32" src="http://www.gravatar.com/avatar/cb1f0f80c3fe2729ba593656772c266d?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hiroyuki Iwatsuki" width="32"></a>
+<a href="http://twitter.com/knsmr"><img alt="Ken Nishimura" height="32" src="https://www.gravatar.com/avatar/91fb4852880d1727cca911036e2fef5f?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ken Nishimura" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/monyakata/"><img alt="MUNAKATA Akiko" height="32" src="http://www.gravatar.com/avatar/55a6db4b079c962f72adb014055e9a28?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MUNAKATA Akiko" width="32"></a>
+<img alt="Anonymous" height="32" src="/2011/images/bow_face.png?1359134037" title="Anonymous" width="32">
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.bawdo.com"><img alt="Keith Bawden" height="32" src="http://www.gravatar.com/avatar/a6cc567a6b77ee09f7363d175455593b?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Keith Bawden" width="32"></a>
+<a href="http://d.hatena.ne.jp/koko_u/"><img alt="Kozaki Tsuneaki" height="32" src="https://www.gravatar.com/avatar/5b1b558d563288da615a9ea2889afdd5?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kozaki Tsuneaki" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<img alt="Norihito Yoshioka" height="32" src="http://www.gravatar.com/avatar/c6033734a5b01f43cca06773ea9ff1fe?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Norihito Yoshioka" width="32">
+<a href="http://twitter.com/adzuki34"><img alt="SUZUKI Miho" height="32" src="https://www.gravatar.com/avatar/f37b9a968b2326062190677906a93080?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="SUZUKI Miho" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/vestige/"><img alt="makoto yonezawa" height="32" src="http://www.gravatar.com/avatar/8da7ceb361c63bd6622fe33153a0293b?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="makoto yonezawa" width="32"></a>
+<a href="http://twitter.com/lchin"><img alt="Leonard Chin" height="32" src="https://www.gravatar.com/avatar/70762059db0218c6f0ff48042ca0756a?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Leonard Chin" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="https://twitter.com/tsuboi"><img alt="Sougo TSUBOI" height="32" src="http://www.gravatar.com/avatar/847bf4e3766b2e17cafef8e83b046db1?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Sougo TSUBOI" width="32"></a>
+<a href="http://d.hatena.ne.jp/suzumura_ss/"><img alt="Toshiyuki Terashita" height="32" src="https://www.gravatar.com/avatar/bb8b58cab667163b6ee53aad0e5f0414?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Toshiyuki Terashita" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/#!/mojamoja_mixi"><img alt="MojaMoja" height="32" src="http://www.gravatar.com/avatar/7b0d6fc806322376d65cbb95d40bc176?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MojaMoja" width="32"></a>
+<a href="http://sites.google.com/site/akihikohashimoto/"><img alt="Akihiko Hashimoto" height="32" src="https://www.gravatar.com/avatar/c8803a4130c3238e34b605d0a0cffe94?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Akihiko Hashimoto" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/takkanm"><img alt="mitsutaka mimura" height="32" src="http://www.gravatar.com/avatar/8f39a252784d5a99589be6e20c4553fb?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="mitsutaka mimura" width="32"></a>
+<img alt="OZAWA Sakuro" height="32" src="https://www.gravatar.com/avatar/a1cbed8bf64473e2acdd0c7066cc5b29?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="OZAWA Sakuro" width="32">
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/dan5ya"><img alt="Dan Yamamoto" height="32" src="http://www.gravatar.com/avatar/ffaa5dad365d5bb5025f4126bb54676c?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Dan Yamamoto" width="32"></a>
+<a href="http://fkmn.exblog.jp/"><img alt="Arinobu FUKUHARA" height="32" src="https://www.gravatar.com/avatar/85319f2b72d7b37ddef5c25a2dd40d30?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Arinobu FUKUHARA" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.hsbt.org/"><img alt="SHIBATA Hiroshi" height="32" src="http://www.gravatar.com/avatar/eabad423977cfc6873b8f5df62b848a6?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="SHIBATA Hiroshi" width="32"></a>
+<a href="http://twitter.com/shachi"><img alt="Kazuyuki Koizuka-shachi" height="32" src="https://www.gravatar.com/avatar/f51ee84097a72a8d91bee9bb98736541?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kazuyuki Koizuka-shachi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/moro/"><img alt="MOROHASHI Kyosuke" height="32" src="http://www.gravatar.com/avatar/70e13d9877054026fda46d5a5b53a236?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MOROHASHI Kyosuke" width="32"></a>
+<img alt="Anonymous" height="32" src="/2011/images/bow_face.png?1359134037" title="Anonymous" width="32">
 <a href="#"></a>
 </li>
 <li>
-<a href="http://rsss.be/hibariya"><img alt="Hibariya Hi" height="32" src="http://www.gravatar.com/avatar/de0df5acda15a9c7eeb6c28a5e5d4e8e?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hibariya Hi" width="32"></a>
+<a href="http://atakigu.tumblr.com/"><img alt="atakig" height="32" src="https://www.gravatar.com/avatar/8a949c60e450d226de776072273a1ffc?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="atakig" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/kyanny"><img alt="Kensuke Nagae" height="32" src="http://www.gravatar.com/avatar/fffd8bf62b842a46803fb07792029fa4?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kensuke Nagae" width="32"></a>
+<img alt="TSUTSUI Toshinori" height="32" src="https://www.gravatar.com/avatar/ad66fd981c429c12e0f76c436da3337e?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TSUTSUI Toshinori" width="32">
 <a href="#"></a>
 </li>
 <li>
-<img alt="oku23" height="32" src="http://www.gravatar.com/avatar/3725ec1dce281fb187d798a9b9ddc9d3?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="oku23" width="32">
+<a href="http://yugui.jp"><img alt="Yuki Sonoda (Yugui)" height="32" src="https://www.gravatar.com/avatar/1e7e007723cfe59320d994a7db4ab4cf?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yuki Sonoda (Yugui)" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://ko.meadowy.net/~koichiro/diary/"><img alt="Koichiro Ohba" height="32" src="http://www.gravatar.com/avatar/1ce18b10bd8f911566c5577042b6a44c?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Koichiro Ohba" width="32"></a>
+<a href="http://d.hatena.ne.jp/seiunsky"><img alt="sugamasao" height="32" src="https://www.gravatar.com/avatar/961126d9892ae4df45249529a0721571?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="sugamasao" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.flickr.com/photos/t-seto"><img alt="せとん" height="32" src="http://www.gravatar.com/avatar/ac007a5b84f817d8cc80a3c208ea0181?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="せとん" width="32"></a>
+<a href="http://d.hatena.ne.jp/mkgin/"><img alt="Makoto Kouno" height="32" src="https://www.gravatar.com/avatar/06e6dcde277cbe5c614baf5d25871025?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Makoto Kouno" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/#!/tsuyoshikawa"><img alt="Tsuyoshi Yoshikawa" height="32" src="http://www.gravatar.com/avatar/6969ade78c1eaff0d08c76020fc80e83?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tsuyoshi Yoshikawa" width="32"></a>
+<a href="http://twitter.com/suzuki"><img alt="Norio Suzuki" height="32" src="https://www.gravatar.com/avatar/8e528456ff66ec543952daa815353a01?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Norio Suzuki" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.water-lily.biz/"><img alt="Water Lily LLC" height="32" src="http://www.gravatar.com/avatar/0734b8ec5eed71892e5db432856f4f40?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Water Lily LLC" width="32"></a>
+<a href="http://www.artonx.org"><img alt="Akio Tajima" height="32" src="https://www.gravatar.com/avatar/0441ff038018e53a35bb207e81105a5c?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Akio Tajima" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://moonrock.jp/~don/"><img alt="Hiroyuki Iwatsuki" height="32" src="https://www.gravatar.com/avatar/cb1f0f80c3fe2729ba593656772c266d?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hiroyuki Iwatsuki" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://d.hatena.ne.jp/monyakata/"><img alt="MUNAKATA Akiko" height="32" src="https://www.gravatar.com/avatar/55a6db4b079c962f72adb014055e9a28?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MUNAKATA Akiko" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://www.bawdo.com"><img alt="Keith Bawden" height="32" src="https://www.gravatar.com/avatar/a6cc567a6b77ee09f7363d175455593b?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Keith Bawden" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<img alt="Norihito Yoshioka" height="32" src="https://www.gravatar.com/avatar/c6033734a5b01f43cca06773ea9ff1fe?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Norihito Yoshioka" width="32">
+<a href="#"></a>
+</li>
+<li>
+<a href="http://d.hatena.ne.jp/vestige/"><img alt="makoto yonezawa" height="32" src="https://www.gravatar.com/avatar/8da7ceb361c63bd6622fe33153a0293b?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="makoto yonezawa" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="https://twitter.com/tsuboi"><img alt="Sougo TSUBOI" height="32" src="https://www.gravatar.com/avatar/847bf4e3766b2e17cafef8e83b046db1?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Sougo TSUBOI" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://twitter.com/#!/mojamoja_mixi"><img alt="MojaMoja" height="32" src="https://www.gravatar.com/avatar/7b0d6fc806322376d65cbb95d40bc176?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MojaMoja" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://twitter.com/takkanm"><img alt="mitsutaka mimura" height="32" src="https://www.gravatar.com/avatar/8f39a252784d5a99589be6e20c4553fb?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="mitsutaka mimura" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://twitter.com/dan5ya"><img alt="Dan Yamamoto" height="32" src="https://www.gravatar.com/avatar/ffaa5dad365d5bb5025f4126bb54676c?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Dan Yamamoto" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://www.hsbt.org/"><img alt="SHIBATA Hiroshi" height="32" src="https://www.gravatar.com/avatar/eabad423977cfc6873b8f5df62b848a6?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="SHIBATA Hiroshi" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://d.hatena.ne.jp/moro/"><img alt="MOROHASHI Kyosuke" height="32" src="https://www.gravatar.com/avatar/70e13d9877054026fda46d5a5b53a236?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MOROHASHI Kyosuke" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://rsss.be/hibariya"><img alt="Hibariya Hi" height="32" src="https://www.gravatar.com/avatar/de0df5acda15a9c7eeb6c28a5e5d4e8e?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hibariya Hi" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://twitter.com/kyanny"><img alt="Kensuke Nagae" height="32" src="https://www.gravatar.com/avatar/fffd8bf62b842a46803fb07792029fa4?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kensuke Nagae" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<img alt="oku23" height="32" src="https://www.gravatar.com/avatar/3725ec1dce281fb187d798a9b9ddc9d3?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="oku23" width="32">
+<a href="#"></a>
+</li>
+<li>
+<a href="http://ko.meadowy.net/~koichiro/diary/"><img alt="Koichiro Ohba" height="32" src="https://www.gravatar.com/avatar/1ce18b10bd8f911566c5577042b6a44c?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Koichiro Ohba" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://www.flickr.com/photos/t-seto"><img alt="せとん" height="32" src="https://www.gravatar.com/avatar/ac007a5b84f817d8cc80a3c208ea0181?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="せとん" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://twitter.com/#!/tsuyoshikawa"><img alt="Tsuyoshi Yoshikawa" height="32" src="https://www.gravatar.com/avatar/6969ade78c1eaff0d08c76020fc80e83?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tsuyoshi Yoshikawa" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://www.water-lily.biz/"><img alt="Water Lily LLC" height="32" src="https://www.gravatar.com/avatar/0734b8ec5eed71892e5db432856f4f40?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Water Lily LLC" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
@@ -2028,115 +2028,99 @@ Goldスポンサー
 <a href="#"></a>
 </li>
 <li>
-<a href="http://web-engineer.buyuden.net/blog/kawai/"><img alt="Takeshi Kawai" height="32" src="http://www.gravatar.com/avatar/6b53e472c9200f5ed61d7a6db0a28986?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takeshi Kawai" width="32"></a>
+<a href="http://web-engineer.buyuden.net/blog/kawai/"><img alt="Takeshi Kawai" height="32" src="https://www.gravatar.com/avatar/6b53e472c9200f5ed61d7a6db0a28986?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takeshi Kawai" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/k3c/"><img alt="KANEKO Seiji" height="32" src="http://www.gravatar.com/avatar/63d3818b5c107a6483a1d2e2767be4c5?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="KANEKO Seiji" width="32"></a>
+<a href="http://d.hatena.ne.jp/k3c/"><img alt="KANEKO Seiji" height="32" src="https://www.gravatar.com/avatar/63d3818b5c107a6483a1d2e2767be4c5?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="KANEKO Seiji" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.famlog.jp/"><img alt="Atsushi Matsuo" height="32" src="http://www.gravatar.com/avatar/0a4da00dbfd37e7f06ef8dceb58ca0c1?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Atsushi Matsuo" width="32"></a>
+<a href="http://www.famlog.jp/"><img alt="Atsushi Matsuo" height="32" src="https://www.gravatar.com/avatar/0a4da00dbfd37e7f06ef8dceb58ca0c1?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Atsushi Matsuo" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://m.igrs.jp/"><img alt="Masato Igarashi" height="32" src="http://www.gravatar.com/avatar/6fd2e23d73c26ccbd7df9e3eefacd3ae?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masato Igarashi" width="32"></a>
+<a href="http://m.igrs.jp/"><img alt="Masato Igarashi" height="32" src="https://www.gravatar.com/avatar/6fd2e23d73c26ccbd7df9e3eefacd3ae?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masato Igarashi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://resume.github.com/?walf443"><img alt="Keiji Yoshimi" height="32" src="http://www.gravatar.com/avatar/dea4fe079aec284744ad02eb3d2594f5?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Keiji Yoshimi" width="32"></a>
+<a href="http://resume.github.com/?walf443"><img alt="Keiji Yoshimi" height="32" src="https://www.gravatar.com/avatar/dea4fe079aec284744ad02eb3d2594f5?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Keiji Yoshimi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://gunjisatoshi.appspot.com/"><img alt="GUNJI Satoshi" height="32" src="http://www.gravatar.com/avatar/e6980e09fdff8f481b70f2e1f241231d?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="GUNJI Satoshi" width="32"></a>
+<a href="http://gunjisatoshi.appspot.com/"><img alt="GUNJI Satoshi" height="32" src="https://www.gravatar.com/avatar/e6980e09fdff8f481b70f2e1f241231d?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="GUNJI Satoshi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<img alt="Hisashi Yamaeda" height="32" src="http://www.gravatar.com/avatar/01ca4ebeee47c9b4d6ba9ad58db694a0?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hisashi Yamaeda" width="32">
+<img alt="Hisashi Yamaeda" height="32" src="https://www.gravatar.com/avatar/01ca4ebeee47c9b4d6ba9ad58db694a0?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hisashi Yamaeda" width="32">
 <a href="#"></a>
 </li>
 <li>
-<img alt="gekidanyonin" height="32" src="http://www.gravatar.com/avatar/2b196f1723fdbcbf7bd297b3e7f8cd3c?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="gekidanyonin" width="32">
+<img alt="gekidanyonin" height="32" src="https://www.gravatar.com/avatar/2b196f1723fdbcbf7bd297b3e7f8cd3c?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="gekidanyonin" width="32">
 <a href="#"></a>
 </li>
 <li>
-<a href="http://jp.linkedin.com/in/nakaomitsuteru"><img alt="Mitsuteru Nakao" height="32" src="http://www.gravatar.com/avatar/9090e122cba40b90124ea8eb4859bf8e?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Mitsuteru Nakao" width="32"></a>
+<a href="http://jp.linkedin.com/in/nakaomitsuteru"><img alt="Mitsuteru Nakao" height="32" src="https://www.gravatar.com/avatar/9090e122cba40b90124ea8eb4859bf8e?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Mitsuteru Nakao" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://zaki.asia"><img alt="Dezso Zoltan" height="32" src="http://www.gravatar.com/avatar/a771de8e1e49a9da61e2a602a2af42bc?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Dezso Zoltan" width="32"></a>
+<a href="http://zaki.asia"><img alt="Dezso Zoltan" height="32" src="https://www.gravatar.com/avatar/a771de8e1e49a9da61e2a602a2af42bc?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Dezso Zoltan" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.twitter.com/ope"><img alt="Takanori Nakanowatari" height="32" src="http://www.gravatar.com/avatar/55bcf6eb5de45a70e76f8a2678822ecb?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takanori Nakanowatari" width="32"></a>
+<a href="http://www.twitter.com/ope"><img alt="Takanori Nakanowatari" height="32" src="https://www.gravatar.com/avatar/55bcf6eb5de45a70e76f8a2678822ecb?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takanori Nakanowatari" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="https://github.com/zev"><img alt="Zev Blut" height="32" src="http://www.gravatar.com/avatar/1c77ad9f35746369dd1f4dd69b9f8b18?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Zev Blut" width="32"></a>
+<a href="https://github.com/zev"><img alt="Zev Blut" height="32" src="https://www.gravatar.com/avatar/1c77ad9f35746369dd1f4dd69b9f8b18?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Zev Blut" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://tako3.com/http://rubykaigi.org/rubyists/kei-s"><img alt="kei-s" height="32" src="http://www.gravatar.com/avatar/bf7ce9b68bbb0058721906b4db15b9b5?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="kei-s" width="32"></a>
+<a href="http://tako3.com/http://rubykaigi.org/rubyists/kei-s"><img alt="kei-s" height="32" src="https://www.gravatar.com/avatar/bf7ce9b68bbb0058721906b4db15b9b5?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="kei-s" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/bobbyjam99"><img alt="Tomokazu IMAI" height="32" src="http://www.gravatar.com/avatar/33814e72445b35ad3b65b1b05e699adc?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomokazu IMAI" width="32"></a>
+<a href="http://twitter.com/bobbyjam99"><img alt="Tomokazu IMAI" height="32" src="https://www.gravatar.com/avatar/33814e72445b35ad3b65b1b05e699adc?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomokazu IMAI" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/hasimo"><img alt="Tohru Hashimoto" height="32" src="http://www.gravatar.com/avatar/6e3d1578114e5d3951a7f90579fff74c?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tohru Hashimoto" width="32"></a>
+<a href="http://twitter.com/hasimo"><img alt="Tohru Hashimoto" height="32" src="https://www.gravatar.com/avatar/6e3d1578114e5d3951a7f90579fff74c?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tohru Hashimoto" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.mobalean.com/founders/michael"><img alt="Michael Reinsch" height="32" src="http://www.gravatar.com/avatar/c7915a424cbb28fdd6c1cce270be6b58?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Michael Reinsch" width="32"></a>
+<a href="http://www.mobalean.com/founders/michael"><img alt="Michael Reinsch" height="32" src="https://www.gravatar.com/avatar/c7915a424cbb28fdd6c1cce270be6b58?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Michael Reinsch" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/sandinist"><img alt="Tsuyoshi MAEHANA" height="32" src="http://www.gravatar.com/avatar/e8ebe7d4ec09c5dd77ee064706836f23?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tsuyoshi MAEHANA" width="32"></a>
+<a href="http://twitter.com/sandinist"><img alt="Tsuyoshi MAEHANA" height="32" src="https://www.gravatar.com/avatar/e8ebe7d4ec09c5dd77ee064706836f23?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tsuyoshi MAEHANA" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://sane.jp"><img alt="Murahashi Sanemat Kenichi" height="32" src="http://www.gravatar.com/avatar/5b1d016f87f05ff645ae572ccbbf0448?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Murahashi Sanemat Kenichi" width="32"></a>
+<a href="http://sane.jp"><img alt="Murahashi Sanemat Kenichi" height="32" src="https://www.gravatar.com/avatar/5b1d016f87f05ff645ae572ccbbf0448?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Murahashi Sanemat Kenichi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://aerial.st"><img alt="Masato Ikeda" height="32" src="http://www.gravatar.com/avatar/03abf5741b7bbd28670af5ec92b6141d?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masato Ikeda" width="32"></a>
+<a href="http://aerial.st"><img alt="Masato Ikeda" height="32" src="https://www.gravatar.com/avatar/03abf5741b7bbd28670af5ec92b6141d?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masato Ikeda" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/tex314"><img alt="OKAZAKI Takurou" height="32" src="http://www.gravatar.com/avatar/45c2cc1a731924edf1045d9146ca4a78?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="OKAZAKI Takurou" width="32"></a>
+<a href="http://twitter.com/tex314"><img alt="OKAZAKI Takurou" height="32" src="https://www.gravatar.com/avatar/45c2cc1a731924edf1045d9146ca4a78?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="OKAZAKI Takurou" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="https://twitter.com/toshi3221"><img alt="Toshiharu Takematsu" height="32" src="http://www.gravatar.com/avatar/3ca4621fbbb03278d4550f89e2f723ba?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Toshiharu Takematsu" width="32"></a>
+<a href="https://twitter.com/toshi3221"><img alt="Toshiharu Takematsu" height="32" src="https://www.gravatar.com/avatar/3ca4621fbbb03278d4550f89e2f723ba?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Toshiharu Takematsu" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://tdtds.jp"><img alt="TADA Tadashi" height="32" src="http://www.gravatar.com/avatar/846a80b9bf7ea7becb6c4ecd67bedd6f?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TADA Tadashi" width="32"></a>
+<a href="http://tdtds.jp"><img alt="TADA Tadashi" height="32" src="https://www.gravatar.com/avatar/846a80b9bf7ea7becb6c4ecd67bedd6f?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TADA Tadashi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://hisano.com"><img alt="HISANO Kozo" height="32" src="http://www.gravatar.com/avatar/b8fa07639c3b720c33ffdcaf89299dda?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="HISANO Kozo" width="32"></a>
+<a href="http://hisano.com"><img alt="HISANO Kozo" height="32" src="https://www.gravatar.com/avatar/b8fa07639c3b720c33ffdcaf89299dda?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="HISANO Kozo" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/kouma31/"><img alt="kmuroi" height="32" src="http://www.gravatar.com/avatar/165599097b8533c91af2aad5d7b31449?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="kmuroi" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<img alt="Anonymous" height="32" src="/2011/images/bow_face.png?1359134037" title="Anonymous" width="32">
-<a href="#"></a>
-</li>
-<li>
-<a href="http://twitter.com/h4n"><img alt="Han Kessels" height="32" src="http://www.gravatar.com/avatar/f0bd4ed83708d0af0e0d1374fc7e605b?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Han Kessels" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://twitter.com/takagi"><img alt="TAKAGI Masahiro" height="32" src="http://www.gravatar.com/avatar/c3f5a6e729b57f99cb9e7b3ca60152aa?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TAKAGI Masahiro" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://d.hatena.ne.jp/tmtms/"><img alt="TOMITA Masahiro" height="32" src="http://www.gravatar.com/avatar/e4763acee4cf0377437f614fc372a061?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TOMITA Masahiro" width="32"></a>
+<a href="http://d.hatena.ne.jp/kouma31/"><img alt="kmuroi" height="32" src="https://www.gravatar.com/avatar/165599097b8533c91af2aad5d7b31449?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="kmuroi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
@@ -2144,79 +2128,95 @@ Goldスポンサー
 <a href="#"></a>
 </li>
 <li>
-<a href="http://kmuto.jp/"><img alt="Kenshi Muto" height="32" src="http://www.gravatar.com/avatar/43d44fbc12adcf80c9fc24e235f48234?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kenshi Muto" width="32"></a>
+<a href="http://twitter.com/h4n"><img alt="Han Kessels" height="32" src="https://www.gravatar.com/avatar/f0bd4ed83708d0af0e0d1374fc7e605b?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Han Kessels" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<img alt="1syo" height="32" src="http://www.gravatar.com/avatar/83899fe2d00874176098a3bb71b043be?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="1syo" width="32">
+<a href="http://twitter.com/takagi"><img alt="TAKAGI Masahiro" height="32" src="https://www.gravatar.com/avatar/c3f5a6e729b57f99cb9e7b3ca60152aa?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TAKAGI Masahiro" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://fkino.net"><img alt="Fumihiko Kinoshita" height="32" src="http://www.gravatar.com/avatar/f301c0275838d562c72ea9177e7ddc68?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Fumihiko Kinoshita" width="32"></a>
+<a href="http://d.hatena.ne.jp/tmtms/"><img alt="TOMITA Masahiro" height="32" src="https://www.gravatar.com/avatar/e4763acee4cf0377437f614fc372a061?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TOMITA Masahiro" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://blog.masuidrive.jp/"><img alt="Yuichiro MASUI" height="32" src="http://www.gravatar.com/avatar/0ec58a040e1e4e959c8566484b4bba19?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yuichiro MASUI" width="32"></a>
+<img alt="Anonymous" height="32" src="/2011/images/bow_face.png?1359134037" title="Anonymous" width="32">
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/t2os/"><img alt="tatsuoSakurai" height="32" src="http://www.gravatar.com/avatar/092404bdf9897eba9ab16e61f56592db?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="tatsuoSakurai" width="32"></a>
+<a href="http://kmuto.jp/"><img alt="Kenshi Muto" height="32" src="https://www.gravatar.com/avatar/43d44fbc12adcf80c9fc24e235f48234?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kenshi Muto" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://ogijun.org"><img alt="Junya Ogino" height="32" src="http://www.gravatar.com/avatar/3a82321f68500d9691a9e190979ac2f0?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Junya Ogino" width="32"></a>
+<img alt="1syo" height="32" src="https://www.gravatar.com/avatar/83899fe2d00874176098a3bb71b043be?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="1syo" width="32">
 <a href="#"></a>
 </li>
 <li>
-<a href="http://about.me/mackato"><img alt="Masakuni Kato" height="32" src="http://www.gravatar.com/avatar/28347314c7fc698b4ac0e01113545e25?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masakuni Kato" width="32"></a>
+<a href="http://fkino.net"><img alt="Fumihiko Kinoshita" height="32" src="https://www.gravatar.com/avatar/f301c0275838d562c72ea9177e7ddc68?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Fumihiko Kinoshita" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/IWAKIRI"><img alt="IWAKIRI,Akiko" height="32" src="http://www.gravatar.com/avatar/2a02258781c7592d0da1cd5cffa627a8?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="IWAKIRI,Akiko" width="32"></a>
+<a href="http://blog.masuidrive.jp/"><img alt="Yuichiro MASUI" height="32" src="https://www.gravatar.com/avatar/0ec58a040e1e4e959c8566484b4bba19?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yuichiro MASUI" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://june29.jp/"><img alt="june29" height="32" src="http://www.gravatar.com/avatar/6fd9be5cd0196df5ad62a5a5f2be3c55?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="june29" width="32"></a>
+<a href="http://d.hatena.ne.jp/t2os/"><img alt="tatsuoSakurai" height="32" src="https://www.gravatar.com/avatar/092404bdf9897eba9ab16e61f56592db?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="tatsuoSakurai" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.socialtoprunners.jp/"><img alt="tomokazuhattanda" height="32" src="http://www.gravatar.com/avatar/19798587cb27b5220a5dcdbaa9a50d57?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="tomokazuhattanda" width="32"></a>
+<a href="http://ogijun.org"><img alt="Junya Ogino" height="32" src="https://www.gravatar.com/avatar/3a82321f68500d9691a9e190979ac2f0?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Junya Ogino" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.jamboree.jp/"><img alt="TOYOSHI, Ryuichiro" height="32" src="http://www.gravatar.com/avatar/203c324392b6c51241da5b42bbf888bd?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TOYOSHI, Ryuichiro" width="32"></a>
+<a href="http://about.me/mackato"><img alt="Masakuni Kato" height="32" src="https://www.gravatar.com/avatar/28347314c7fc698b4ac0e01113545e25?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masakuni Kato" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/takano32"><img alt="たかのみつひろ" height="32" src="http://www.gravatar.com/avatar/eba4a40bdae5edfe1589601c050a2b96?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="たかのみつひろ" width="32"></a>
+<a href="http://d.hatena.ne.jp/IWAKIRI"><img alt="IWAKIRI,Akiko" height="32" src="https://www.gravatar.com/avatar/2a02258781c7592d0da1cd5cffa627a8?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="IWAKIRI,Akiko" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/tyabe"><img alt="tyabe" height="32" src="http://www.gravatar.com/avatar/d21900444f5548d9329861593321b5a6?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="tyabe" width="32"></a>
+<a href="http://june29.jp/"><img alt="june29" height="32" src="https://www.gravatar.com/avatar/6fd9be5cd0196df5ad62a5a5f2be3c55?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="june29" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/#!/maxyz"><img alt="Masafumi Fujiwara" height="32" src="http://www.gravatar.com/avatar/4dd4d13d27559db2fb64ad069f2c49ba?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masafumi Fujiwara" width="32"></a>
+<a href="http://www.socialtoprunners.jp/"><img alt="tomokazuhattanda" height="32" src="https://www.gravatar.com/avatar/19798587cb27b5220a5dcdbaa9a50d57?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="tomokazuhattanda" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/kdmsnr"><img alt="Masanori Kado" height="32" src="http://www.gravatar.com/avatar/70b07e6b7fe7d921d7ac542d0ccb3b2c?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masanori Kado" width="32"></a>
+<a href="http://www.jamboree.jp/"><img alt="TOYOSHI, Ryuichiro" height="32" src="https://www.gravatar.com/avatar/203c324392b6c51241da5b42bbf888bd?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TOYOSHI, Ryuichiro" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.jitu.org/~tko"><img alt="Tomoyuki Kosimizu" height="32" src="http://www.gravatar.com/avatar/3585181753c22a9531e70a8297771b01?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomoyuki Kosimizu" width="32"></a>
+<a href="http://twitter.com/takano32"><img alt="たかのみつひろ" height="32" src="https://www.gravatar.com/avatar/eba4a40bdae5edfe1589601c050a2b96?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="たかのみつひろ" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/chinmo"><img alt="Tomonori Fukuta" height="32" src="http://www.gravatar.com/avatar/7977a0896e60587b2690550891be2ea7?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomonori Fukuta" width="32"></a>
+<a href="http://twitter.com/tyabe"><img alt="tyabe" height="32" src="https://www.gravatar.com/avatar/d21900444f5548d9329861593321b5a6?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="tyabe" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<img alt="YOKOTA Akiko" height="32" src="http://www.gravatar.com/avatar/03e548747e667fc94cc8495868bfd85e?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="YOKOTA Akiko" width="32">
+<a href="http://twitter.com/#!/maxyz"><img alt="Masafumi Fujiwara" height="32" src="https://www.gravatar.com/avatar/4dd4d13d27559db2fb64ad069f2c49ba?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masafumi Fujiwara" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://nov.tdiary.net/"><img alt="Nobuhiro IMAI" height="32" src="http://www.gravatar.com/avatar/e49ab9f0774711c473660019728cde95?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Nobuhiro IMAI" width="32"></a>
+<a href="http://twitter.com/kdmsnr"><img alt="Masanori Kado" height="32" src="https://www.gravatar.com/avatar/70b07e6b7fe7d921d7ac542d0ccb3b2c?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masanori Kado" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://www.jitu.org/~tko"><img alt="Tomoyuki Kosimizu" height="32" src="https://www.gravatar.com/avatar/3585181753c22a9531e70a8297771b01?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomoyuki Kosimizu" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://twitter.com/chinmo"><img alt="Tomonori Fukuta" height="32" src="https://www.gravatar.com/avatar/7977a0896e60587b2690550891be2ea7?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomonori Fukuta" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<img alt="YOKOTA Akiko" height="32" src="https://www.gravatar.com/avatar/03e548747e667fc94cc8495868bfd85e?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="YOKOTA Akiko" width="32">
+<a href="#"></a>
+</li>
+<li>
+<a href="http://nov.tdiary.net/"><img alt="Nobuhiro IMAI" height="32" src="https://www.gravatar.com/avatar/e49ab9f0774711c473660019728cde95?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Nobuhiro IMAI" width="32"></a>
 <a href="#"></a>
 </li>
 </ul>

--- a/2011/ja/sponsors/index.html
+++ b/2011/ja/sponsors/index.html
@@ -240,55 +240,39 @@ Goldスポンサー
 </h2>
 <ul>
 <li>
-<a href="http://shyouhei.tumblr.com"><img alt="Urabe, Shyouhei" height="32" src="http://www.gravatar.com/avatar/9d2f78236e45a335301ba1195026105d?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Urabe, Shyouhei" width="32"></a>
+<a href="http://shyouhei.tumblr.com"><img alt="Urabe, Shyouhei" height="32" src="https://www.gravatar.com/avatar/9d2f78236e45a335301ba1195026105d?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Urabe, Shyouhei" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/noplans"><img alt="TANIGUCHI Fumitake" height="32" src="http://www.gravatar.com/avatar/e514ae09c9b84e04231af57f1d1946b8?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TANIGUCHI Fumitake" width="32"></a>
+<a href="http://twitter.com/noplans"><img alt="TANIGUCHI Fumitake" height="32" src="https://www.gravatar.com/avatar/e514ae09c9b84e04231af57f1d1946b8?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TANIGUCHI Fumitake" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://jmettraux.wordpress.com"><img alt="John Mettraux" height="32" src="http://www.gravatar.com/avatar/8d96626e52beb1ff90f57a8e189e1e6f?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="John Mettraux" width="32"></a>
+<a href="http://jmettraux.wordpress.com"><img alt="John Mettraux" height="32" src="https://www.gravatar.com/avatar/8d96626e52beb1ff90f57a8e189e1e6f?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="John Mettraux" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/japanrock"><img alt="Shintaro Nozaki" height="32" src="http://www.gravatar.com/avatar/b31a258dd8f615f61b2d355297f82dc9?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shintaro Nozaki" width="32"></a>
+<a href="http://twitter.com/japanrock"><img alt="Shintaro Nozaki" height="32" src="https://www.gravatar.com/avatar/b31a258dd8f615f61b2d355297f82dc9?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shintaro Nozaki" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://blog.dio.jp"><img alt="Akira Matsuda" height="32" src="http://www.gravatar.com/avatar/76a777ff80f30bd3b390e275cce625bc?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Akira Matsuda" width="32"></a>
+<a href="http://blog.dio.jp"><img alt="Akira Matsuda" height="32" src="https://www.gravatar.com/avatar/76a777ff80f30bd3b390e275cce625bc?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Akira Matsuda" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.bovensiepen.net"><img alt="Daniel Bovensiepen" height="32" src="http://www.gravatar.com/avatar/49d6f762505615af259534deed94bc54?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Daniel Bovensiepen" width="32"></a>
+<a href="http://www.bovensiepen.net"><img alt="Daniel Bovensiepen" height="32" src="https://www.gravatar.com/avatar/49d6f762505615af259534deed94bc54?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Daniel Bovensiepen" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://firn.jp/"><img alt="Dai Akatsuka" height="32" src="http://www.gravatar.com/avatar/4efe7b5cdbe97df84e6e607948171eef?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Dai Akatsuka" width="32"></a>
+<a href="http://firn.jp/"><img alt="Dai Akatsuka" height="32" src="https://www.gravatar.com/avatar/4efe7b5cdbe97df84e6e607948171eef?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Dai Akatsuka" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.din.or.jp/~shinodas/"><img alt="Yoshihiko Hara" height="32" src="http://www.gravatar.com/avatar/8055fbffa700065178460bb7e3b8ee24?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yoshihiko Hara" width="32"></a>
+<a href="http://www.din.or.jp/~shinodas/"><img alt="Yoshihiko Hara" height="32" src="https://www.gravatar.com/avatar/8055fbffa700065178460bb7e3b8ee24?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yoshihiko Hara" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://benhoskin.gs"><img alt="Ben Hoskings" height="32" src="http://www.gravatar.com/avatar/7ed99cb90a060539d729e2491442a603?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ben Hoskings" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<img alt="Anonymous" height="32" src="/2011/images/bow_face.png?1359134037" title="Anonymous" width="32">
-<a href="#"></a>
-</li>
-<li>
-<a href="http://www.nextseed.jp/"><img alt="Hitoshi Kurokawa" height="32" src="http://www.gravatar.com/avatar/11e89e3c85d9998b2c73933bde77c71e?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hitoshi Kurokawa" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://d.hatena.ne.jp/kinpoco/"><img alt="Yutaka Kanemoto" height="32" src="http://www.gravatar.com/avatar/0e728bf538d1848bc253d80a8626bbc2?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yutaka Kanemoto" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://d.hatena.ne.jp/yuichi_katahira"><img alt="Yuichi Katahira " height="32" src="http://www.gravatar.com/avatar/3072ae08f580fc8474b47652a3d8dd0f?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yuichi Katahira " width="32"></a>
+<a href="http://benhoskin.gs"><img alt="Ben Hoskings" height="32" src="https://www.gravatar.com/avatar/7ed99cb90a060539d729e2491442a603?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ben Hoskings" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
@@ -296,87 +280,15 @@ Goldスポンサー
 <a href="#"></a>
 </li>
 <li>
-<a href="http://kitaj.no-ip.com/tdiary/"><img alt="Junichiro Kita" height="32" src="http://www.gravatar.com/avatar/70405ca68e6f8779be65e75b1a90525b?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Junichiro Kita" width="32"></a>
+<a href="http://www.nextseed.jp/"><img alt="Hitoshi Kurokawa" height="32" src="https://www.gravatar.com/avatar/11e89e3c85d9998b2c73933bde77c71e?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hitoshi Kurokawa" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/idesaku"><img alt="Daisuke Goto" height="32" src="http://www.gravatar.com/avatar/85c8086344e5f31b2a4d22f163660536?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Daisuke Goto" width="32"></a>
+<a href="http://d.hatena.ne.jp/kinpoco/"><img alt="Yutaka Kanemoto" height="32" src="https://www.gravatar.com/avatar/0e728bf538d1848bc253d80a8626bbc2?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yutaka Kanemoto" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<img alt="Anonymous" height="32" src="/2011/images/bow_face.png?1359134037" title="Anonymous" width="32">
-<a href="#"></a>
-</li>
-<li>
-<a href="http://www.on-sky.net/~hs/"><img alt="Hideki SAKAMOTO" height="32" src="http://www.gravatar.com/avatar/7038a6cfc30b8c3b00b5c08d70cda2f1?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hideki SAKAMOTO" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://twitter.com/agilekawabata"><img alt="Kawabata Mitsuyoshi" height="32" src="http://www.gravatar.com/avatar/5236eb3ad498b3c5336a4575408fb1b1?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kawabata Mitsuyoshi" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://www.kt.rim.or.jp/~kbk/"><img alt="KIMURA Koichi" height="32" src="http://www.gravatar.com/avatar/04c1a31d1e33e7fc25a7ca99930e4c70?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="KIMURA Koichi" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://d.hatena.ne.jp/takkaw/"><img alt="Takayoshi Kawada" height="32" src="http://www.gravatar.com/avatar/38bf2ca557d9cc20dcdcbd773a68664b?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takayoshi Kawada" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://www.suchi.org/"><img alt="Shigeru UCHIYAMA" height="32" src="http://www.gravatar.com/avatar/398e2dd764d43aad735c6e5bca92c3b6?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shigeru UCHIYAMA" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://twitter.com/#!/andrewjgrimm"><img alt="Andrew Grimm" height="32" src="http://www.gravatar.com/avatar/01bbb59a1c3ef9960f25a97afe7e920f?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Andrew Grimm" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://twitter.com/kimuraw"><img alt="kimura wataru" height="32" src="http://www.gravatar.com/avatar/e298234a6e5a2c159287476abd76504a?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="kimura wataru" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://saikyoline.jp/"><img alt="MIKAMI Yoshiyuki" height="32" src="http://www.gravatar.com/avatar/e0920f5f813ae29ba7859f950a7f0df3?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MIKAMI Yoshiyuki" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://jp.rubyist.net/?KansaiWorkshop"><img alt="HIGAKI Masaru" height="32" src="http://www.gravatar.com/avatar/a8192f5a7b25ef32a983740ee8593bd3?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="HIGAKI Masaru" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://twitter.com/ayumin"><img alt="Ayumu AIZAWA" height="32" src="http://www.gravatar.com/avatar/2e9a2dbe335e0111e4879a9d65dcbae0?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ayumu AIZAWA" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://shunichi-arai.blogspot.com/"><img alt="Shunichi Arai" height="32" src="http://www.gravatar.com/avatar/74daf3516e33a75968ec0f933954b5a8?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shunichi Arai" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://www.tokyodev.com"><img alt="Paul McMahon" height="32" src="http://www.gravatar.com/avatar/dd24adb5a3a430fed83a33ed552fe1b5?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Paul McMahon" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://d.hatena.ne.jp/hs9587/"><img alt="Hiroyuki Shimura" height="32" src="http://www.gravatar.com/avatar/287a899c91a7a14535188d7e4784050e?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hiroyuki Shimura" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://kakutani.com"><img alt="Kakutani Shintaro" height="32" src="http://www.gravatar.com/avatar/34fcd5f1deeb25b1138e9845137feb6e?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kakutani Shintaro" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://d.hatena.ne.jp/mrkn"><img alt="Kenta Murata" height="32" src="http://www.gravatar.com/avatar/819b3c0a25f9708fd32261b8ae2d23f6?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kenta Murata" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://rails.to"><img alt="Masatoshi Itagaki" height="32" src="http://www.gravatar.com/avatar/f8865f41777ef3caced0e4e6801ff83a?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masatoshi Itagaki" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://spring-aki.com/"><img alt="Aki" height="32" src="http://www.gravatar.com/avatar/81f2122b45f48829be4507bf972666e9?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Aki" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://twitter.com/shin_asou"><img alt="Shinichi Okada" height="32" src="http://www.gravatar.com/avatar/20805358592bd93f92bf15aa10137251?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shinichi Okada" width="32"></a>
+<a href="http://d.hatena.ne.jp/yuichi_katahira"><img alt="Yuichi Katahira " height="32" src="https://www.gravatar.com/avatar/3072ae08f580fc8474b47652a3d8dd0f?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yuichi Katahira " width="32"></a>
 <a href="#"></a>
 </li>
 <li>
@@ -384,35 +296,11 @@ Goldスポンサー
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.kumaryu.net/"><img alt="Ryuichi Sakamoto" height="32" src="http://www.gravatar.com/avatar/1b2ca00132480422c75c1f2c61e84e26?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ryuichi Sakamoto" width="32"></a>
+<a href="http://kitaj.no-ip.com/tdiary/"><img alt="Junichiro Kita" height="32" src="https://www.gravatar.com/avatar/70405ca68e6f8779be65e75b1a90525b?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Junichiro Kita" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<img alt="Eito Katagiri" height="32" src="http://www.gravatar.com/avatar/b5852cf79505d7ba513f8f16ef95a50f?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Eito Katagiri" width="32">
-<a href="#"></a>
-</li>
-<li>
-<a href="http://ukstudio.jp/"><img alt="AKAMATSU Yuki" height="32" src="http://www.gravatar.com/avatar/0c471249ee93ab17a011f3e8d2b1057a?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="AKAMATSU Yuki" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://hisashim.org"><img alt="Hisashi Morita" height="32" src="http://www.gravatar.com/avatar/b3fba7af93cd27e6ed28e7eae88a9585?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hisashi Morita" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://d.hatena.ne.jp/muryoImpl/"><img alt="Ken muryoi" height="32" src="http://www.gravatar.com/avatar/ac6dba8ce93944d17714de362ca17e54?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ken muryoi" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://d.hatena.ne.jp/nagachika/"><img alt="Tomoyuki Chikanaga" height="32" src="http://www.gravatar.com/avatar/5cf8f058a4c094bb708174fb43e7a387?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomoyuki Chikanaga" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://d.hatena.ne.jp/takeshinoda/"><img alt="Takeshi SHINODA" height="32" src="http://www.gravatar.com/avatar/06febd004d7cc9c9f6a4e0272b686bc7?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takeshi SHINODA" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://twitter.com/knsmr"><img alt="Ken Nishimura" height="32" src="http://www.gravatar.com/avatar/91fb4852880d1727cca911036e2fef5f?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ken Nishimura" width="32"></a>
+<a href="http://d.hatena.ne.jp/idesaku"><img alt="Daisuke Goto" height="32" src="https://www.gravatar.com/avatar/85c8086344e5f31b2a4d22f163660536?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Daisuke Goto" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
@@ -420,35 +308,75 @@ Goldスポンサー
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/koko_u/"><img alt="Kozaki Tsuneaki" height="32" src="http://www.gravatar.com/avatar/5b1b558d563288da615a9ea2889afdd5?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kozaki Tsuneaki" width="32"></a>
+<a href="http://www.on-sky.net/~hs/"><img alt="Hideki SAKAMOTO" height="32" src="https://www.gravatar.com/avatar/7038a6cfc30b8c3b00b5c08d70cda2f1?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hideki SAKAMOTO" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/adzuki34"><img alt="SUZUKI Miho" height="32" src="http://www.gravatar.com/avatar/f37b9a968b2326062190677906a93080?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="SUZUKI Miho" width="32"></a>
+<a href="http://twitter.com/agilekawabata"><img alt="Kawabata Mitsuyoshi" height="32" src="https://www.gravatar.com/avatar/5236eb3ad498b3c5336a4575408fb1b1?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kawabata Mitsuyoshi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/lchin"><img alt="Leonard Chin" height="32" src="http://www.gravatar.com/avatar/70762059db0218c6f0ff48042ca0756a?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Leonard Chin" width="32"></a>
+<a href="http://www.kt.rim.or.jp/~kbk/"><img alt="KIMURA Koichi" height="32" src="https://www.gravatar.com/avatar/04c1a31d1e33e7fc25a7ca99930e4c70?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="KIMURA Koichi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/suzumura_ss/"><img alt="Toshiyuki Terashita" height="32" src="http://www.gravatar.com/avatar/bb8b58cab667163b6ee53aad0e5f0414?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Toshiyuki Terashita" width="32"></a>
+<a href="http://d.hatena.ne.jp/takkaw/"><img alt="Takayoshi Kawada" height="32" src="https://www.gravatar.com/avatar/38bf2ca557d9cc20dcdcbd773a68664b?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takayoshi Kawada" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://sites.google.com/site/akihikohashimoto/"><img alt="Akihiko Hashimoto" height="32" src="http://www.gravatar.com/avatar/c8803a4130c3238e34b605d0a0cffe94?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Akihiko Hashimoto" width="32"></a>
+<a href="http://www.suchi.org/"><img alt="Shigeru UCHIYAMA" height="32" src="https://www.gravatar.com/avatar/398e2dd764d43aad735c6e5bca92c3b6?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shigeru UCHIYAMA" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<img alt="OZAWA Sakuro" height="32" src="http://www.gravatar.com/avatar/a1cbed8bf64473e2acdd0c7066cc5b29?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="OZAWA Sakuro" width="32">
+<a href="http://twitter.com/#!/andrewjgrimm"><img alt="Andrew Grimm" height="32" src="https://www.gravatar.com/avatar/01bbb59a1c3ef9960f25a97afe7e920f?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Andrew Grimm" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://fkmn.exblog.jp/"><img alt="Arinobu FUKUHARA" height="32" src="http://www.gravatar.com/avatar/85319f2b72d7b37ddef5c25a2dd40d30?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Arinobu FUKUHARA" width="32"></a>
+<a href="http://twitter.com/kimuraw"><img alt="kimura wataru" height="32" src="https://www.gravatar.com/avatar/e298234a6e5a2c159287476abd76504a?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="kimura wataru" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/shachi"><img alt="Kazuyuki Koizuka-shachi" height="32" src="http://www.gravatar.com/avatar/f51ee84097a72a8d91bee9bb98736541?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kazuyuki Koizuka-shachi" width="32"></a>
+<a href="http://saikyoline.jp/"><img alt="MIKAMI Yoshiyuki" height="32" src="https://www.gravatar.com/avatar/e0920f5f813ae29ba7859f950a7f0df3?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MIKAMI Yoshiyuki" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://jp.rubyist.net/?KansaiWorkshop"><img alt="HIGAKI Masaru" height="32" src="https://www.gravatar.com/avatar/a8192f5a7b25ef32a983740ee8593bd3?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="HIGAKI Masaru" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://twitter.com/ayumin"><img alt="Ayumu AIZAWA" height="32" src="https://www.gravatar.com/avatar/2e9a2dbe335e0111e4879a9d65dcbae0?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ayumu AIZAWA" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://shunichi-arai.blogspot.com/"><img alt="Shunichi Arai" height="32" src="https://www.gravatar.com/avatar/74daf3516e33a75968ec0f933954b5a8?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shunichi Arai" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://www.tokyodev.com"><img alt="Paul McMahon" height="32" src="https://www.gravatar.com/avatar/dd24adb5a3a430fed83a33ed552fe1b5?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Paul McMahon" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://d.hatena.ne.jp/hs9587/"><img alt="Hiroyuki Shimura" height="32" src="https://www.gravatar.com/avatar/287a899c91a7a14535188d7e4784050e?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hiroyuki Shimura" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://kakutani.com"><img alt="Kakutani Shintaro" height="32" src="https://www.gravatar.com/avatar/34fcd5f1deeb25b1138e9845137feb6e?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kakutani Shintaro" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://d.hatena.ne.jp/mrkn"><img alt="Kenta Murata" height="32" src="https://www.gravatar.com/avatar/819b3c0a25f9708fd32261b8ae2d23f6?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kenta Murata" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://rails.to"><img alt="Masatoshi Itagaki" height="32" src="https://www.gravatar.com/avatar/f8865f41777ef3caced0e4e6801ff83a?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masatoshi Itagaki" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://spring-aki.com/"><img alt="Aki" height="32" src="https://www.gravatar.com/avatar/81f2122b45f48829be4507bf972666e9?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Aki" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://twitter.com/shin_asou"><img alt="Shinichi Okada" height="32" src="https://www.gravatar.com/avatar/20805358592bd93f92bf15aa10137251?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shinichi Okada" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
@@ -456,103 +384,175 @@ Goldスポンサー
 <a href="#"></a>
 </li>
 <li>
-<a href="http://atakigu.tumblr.com/"><img alt="atakig" height="32" src="http://www.gravatar.com/avatar/8a949c60e450d226de776072273a1ffc?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="atakig" width="32"></a>
+<a href="http://www.kumaryu.net/"><img alt="Ryuichi Sakamoto" height="32" src="https://www.gravatar.com/avatar/1b2ca00132480422c75c1f2c61e84e26?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ryuichi Sakamoto" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<img alt="TSUTSUI Toshinori" height="32" src="http://www.gravatar.com/avatar/ad66fd981c429c12e0f76c436da3337e?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TSUTSUI Toshinori" width="32">
+<img alt="Eito Katagiri" height="32" src="https://www.gravatar.com/avatar/b5852cf79505d7ba513f8f16ef95a50f?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Eito Katagiri" width="32">
 <a href="#"></a>
 </li>
 <li>
-<a href="http://yugui.jp"><img alt="Yuki Sonoda (Yugui)" height="32" src="http://www.gravatar.com/avatar/1e7e007723cfe59320d994a7db4ab4cf?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yuki Sonoda (Yugui)" width="32"></a>
+<a href="http://ukstudio.jp/"><img alt="AKAMATSU Yuki" height="32" src="https://www.gravatar.com/avatar/0c471249ee93ab17a011f3e8d2b1057a?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="AKAMATSU Yuki" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/seiunsky"><img alt="sugamasao" height="32" src="http://www.gravatar.com/avatar/961126d9892ae4df45249529a0721571?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="sugamasao" width="32"></a>
+<a href="http://hisashim.org"><img alt="Hisashi Morita" height="32" src="https://www.gravatar.com/avatar/b3fba7af93cd27e6ed28e7eae88a9585?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hisashi Morita" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/mkgin/"><img alt="Makoto Kouno" height="32" src="http://www.gravatar.com/avatar/06e6dcde277cbe5c614baf5d25871025?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Makoto Kouno" width="32"></a>
+<a href="http://d.hatena.ne.jp/muryoImpl/"><img alt="Ken muryoi" height="32" src="https://www.gravatar.com/avatar/ac6dba8ce93944d17714de362ca17e54?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ken muryoi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/suzuki"><img alt="Norio Suzuki" height="32" src="http://www.gravatar.com/avatar/8e528456ff66ec543952daa815353a01?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Norio Suzuki" width="32"></a>
+<a href="http://d.hatena.ne.jp/nagachika/"><img alt="Tomoyuki Chikanaga" height="32" src="https://www.gravatar.com/avatar/5cf8f058a4c094bb708174fb43e7a387?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomoyuki Chikanaga" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.artonx.org"><img alt="Akio Tajima" height="32" src="http://www.gravatar.com/avatar/0441ff038018e53a35bb207e81105a5c?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Akio Tajima" width="32"></a>
+<a href="http://d.hatena.ne.jp/takeshinoda/"><img alt="Takeshi SHINODA" height="32" src="https://www.gravatar.com/avatar/06febd004d7cc9c9f6a4e0272b686bc7?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takeshi SHINODA" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://moonrock.jp/~don/"><img alt="Hiroyuki Iwatsuki" height="32" src="http://www.gravatar.com/avatar/cb1f0f80c3fe2729ba593656772c266d?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hiroyuki Iwatsuki" width="32"></a>
+<a href="http://twitter.com/knsmr"><img alt="Ken Nishimura" height="32" src="https://www.gravatar.com/avatar/91fb4852880d1727cca911036e2fef5f?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ken Nishimura" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/monyakata/"><img alt="MUNAKATA Akiko" height="32" src="http://www.gravatar.com/avatar/55a6db4b079c962f72adb014055e9a28?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MUNAKATA Akiko" width="32"></a>
+<img alt="Anonymous" height="32" src="/2011/images/bow_face.png?1359134037" title="Anonymous" width="32">
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.bawdo.com"><img alt="Keith Bawden" height="32" src="http://www.gravatar.com/avatar/a6cc567a6b77ee09f7363d175455593b?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Keith Bawden" width="32"></a>
+<a href="http://d.hatena.ne.jp/koko_u/"><img alt="Kozaki Tsuneaki" height="32" src="https://www.gravatar.com/avatar/5b1b558d563288da615a9ea2889afdd5?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kozaki Tsuneaki" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<img alt="Norihito Yoshioka" height="32" src="http://www.gravatar.com/avatar/c6033734a5b01f43cca06773ea9ff1fe?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Norihito Yoshioka" width="32">
+<a href="http://twitter.com/adzuki34"><img alt="SUZUKI Miho" height="32" src="https://www.gravatar.com/avatar/f37b9a968b2326062190677906a93080?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="SUZUKI Miho" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/vestige/"><img alt="makoto yonezawa" height="32" src="http://www.gravatar.com/avatar/8da7ceb361c63bd6622fe33153a0293b?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="makoto yonezawa" width="32"></a>
+<a href="http://twitter.com/lchin"><img alt="Leonard Chin" height="32" src="https://www.gravatar.com/avatar/70762059db0218c6f0ff48042ca0756a?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Leonard Chin" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="https://twitter.com/tsuboi"><img alt="Sougo TSUBOI" height="32" src="http://www.gravatar.com/avatar/847bf4e3766b2e17cafef8e83b046db1?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Sougo TSUBOI" width="32"></a>
+<a href="http://d.hatena.ne.jp/suzumura_ss/"><img alt="Toshiyuki Terashita" height="32" src="https://www.gravatar.com/avatar/bb8b58cab667163b6ee53aad0e5f0414?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Toshiyuki Terashita" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/#!/mojamoja_mixi"><img alt="MojaMoja" height="32" src="http://www.gravatar.com/avatar/7b0d6fc806322376d65cbb95d40bc176?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MojaMoja" width="32"></a>
+<a href="http://sites.google.com/site/akihikohashimoto/"><img alt="Akihiko Hashimoto" height="32" src="https://www.gravatar.com/avatar/c8803a4130c3238e34b605d0a0cffe94?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Akihiko Hashimoto" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/takkanm"><img alt="mitsutaka mimura" height="32" src="http://www.gravatar.com/avatar/8f39a252784d5a99589be6e20c4553fb?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="mitsutaka mimura" width="32"></a>
+<img alt="OZAWA Sakuro" height="32" src="https://www.gravatar.com/avatar/a1cbed8bf64473e2acdd0c7066cc5b29?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="OZAWA Sakuro" width="32">
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/dan5ya"><img alt="Dan Yamamoto" height="32" src="http://www.gravatar.com/avatar/ffaa5dad365d5bb5025f4126bb54676c?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Dan Yamamoto" width="32"></a>
+<a href="http://fkmn.exblog.jp/"><img alt="Arinobu FUKUHARA" height="32" src="https://www.gravatar.com/avatar/85319f2b72d7b37ddef5c25a2dd40d30?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Arinobu FUKUHARA" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.hsbt.org/"><img alt="SHIBATA Hiroshi" height="32" src="http://www.gravatar.com/avatar/eabad423977cfc6873b8f5df62b848a6?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="SHIBATA Hiroshi" width="32"></a>
+<a href="http://twitter.com/shachi"><img alt="Kazuyuki Koizuka-shachi" height="32" src="https://www.gravatar.com/avatar/f51ee84097a72a8d91bee9bb98736541?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kazuyuki Koizuka-shachi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/moro/"><img alt="MOROHASHI Kyosuke" height="32" src="http://www.gravatar.com/avatar/70e13d9877054026fda46d5a5b53a236?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MOROHASHI Kyosuke" width="32"></a>
+<img alt="Anonymous" height="32" src="/2011/images/bow_face.png?1359134037" title="Anonymous" width="32">
 <a href="#"></a>
 </li>
 <li>
-<a href="http://rsss.be/hibariya"><img alt="Hibariya Hi" height="32" src="http://www.gravatar.com/avatar/de0df5acda15a9c7eeb6c28a5e5d4e8e?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hibariya Hi" width="32"></a>
+<a href="http://atakigu.tumblr.com/"><img alt="atakig" height="32" src="https://www.gravatar.com/avatar/8a949c60e450d226de776072273a1ffc?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="atakig" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/kyanny"><img alt="Kensuke Nagae" height="32" src="http://www.gravatar.com/avatar/fffd8bf62b842a46803fb07792029fa4?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kensuke Nagae" width="32"></a>
+<img alt="TSUTSUI Toshinori" height="32" src="https://www.gravatar.com/avatar/ad66fd981c429c12e0f76c436da3337e?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TSUTSUI Toshinori" width="32">
 <a href="#"></a>
 </li>
 <li>
-<img alt="oku23" height="32" src="http://www.gravatar.com/avatar/3725ec1dce281fb187d798a9b9ddc9d3?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="oku23" width="32">
+<a href="http://yugui.jp"><img alt="Yuki Sonoda (Yugui)" height="32" src="https://www.gravatar.com/avatar/1e7e007723cfe59320d994a7db4ab4cf?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yuki Sonoda (Yugui)" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://ko.meadowy.net/~koichiro/diary/"><img alt="Koichiro Ohba" height="32" src="http://www.gravatar.com/avatar/1ce18b10bd8f911566c5577042b6a44c?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Koichiro Ohba" width="32"></a>
+<a href="http://d.hatena.ne.jp/seiunsky"><img alt="sugamasao" height="32" src="https://www.gravatar.com/avatar/961126d9892ae4df45249529a0721571?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="sugamasao" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.flickr.com/photos/t-seto"><img alt="せとん" height="32" src="http://www.gravatar.com/avatar/ac007a5b84f817d8cc80a3c208ea0181?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="せとん" width="32"></a>
+<a href="http://d.hatena.ne.jp/mkgin/"><img alt="Makoto Kouno" height="32" src="https://www.gravatar.com/avatar/06e6dcde277cbe5c614baf5d25871025?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Makoto Kouno" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/#!/tsuyoshikawa"><img alt="Tsuyoshi Yoshikawa" height="32" src="http://www.gravatar.com/avatar/6969ade78c1eaff0d08c76020fc80e83?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tsuyoshi Yoshikawa" width="32"></a>
+<a href="http://twitter.com/suzuki"><img alt="Norio Suzuki" height="32" src="https://www.gravatar.com/avatar/8e528456ff66ec543952daa815353a01?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Norio Suzuki" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.water-lily.biz/"><img alt="Water Lily LLC" height="32" src="http://www.gravatar.com/avatar/0734b8ec5eed71892e5db432856f4f40?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Water Lily LLC" width="32"></a>
+<a href="http://www.artonx.org"><img alt="Akio Tajima" height="32" src="https://www.gravatar.com/avatar/0441ff038018e53a35bb207e81105a5c?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Akio Tajima" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://moonrock.jp/~don/"><img alt="Hiroyuki Iwatsuki" height="32" src="https://www.gravatar.com/avatar/cb1f0f80c3fe2729ba593656772c266d?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hiroyuki Iwatsuki" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://d.hatena.ne.jp/monyakata/"><img alt="MUNAKATA Akiko" height="32" src="https://www.gravatar.com/avatar/55a6db4b079c962f72adb014055e9a28?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MUNAKATA Akiko" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://www.bawdo.com"><img alt="Keith Bawden" height="32" src="https://www.gravatar.com/avatar/a6cc567a6b77ee09f7363d175455593b?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Keith Bawden" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<img alt="Norihito Yoshioka" height="32" src="https://www.gravatar.com/avatar/c6033734a5b01f43cca06773ea9ff1fe?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Norihito Yoshioka" width="32">
+<a href="#"></a>
+</li>
+<li>
+<a href="http://d.hatena.ne.jp/vestige/"><img alt="makoto yonezawa" height="32" src="https://www.gravatar.com/avatar/8da7ceb361c63bd6622fe33153a0293b?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="makoto yonezawa" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="https://twitter.com/tsuboi"><img alt="Sougo TSUBOI" height="32" src="https://www.gravatar.com/avatar/847bf4e3766b2e17cafef8e83b046db1?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Sougo TSUBOI" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://twitter.com/#!/mojamoja_mixi"><img alt="MojaMoja" height="32" src="https://www.gravatar.com/avatar/7b0d6fc806322376d65cbb95d40bc176?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MojaMoja" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://twitter.com/takkanm"><img alt="mitsutaka mimura" height="32" src="https://www.gravatar.com/avatar/8f39a252784d5a99589be6e20c4553fb?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="mitsutaka mimura" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://twitter.com/dan5ya"><img alt="Dan Yamamoto" height="32" src="https://www.gravatar.com/avatar/ffaa5dad365d5bb5025f4126bb54676c?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Dan Yamamoto" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://www.hsbt.org/"><img alt="SHIBATA Hiroshi" height="32" src="https://www.gravatar.com/avatar/eabad423977cfc6873b8f5df62b848a6?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="SHIBATA Hiroshi" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://d.hatena.ne.jp/moro/"><img alt="MOROHASHI Kyosuke" height="32" src="https://www.gravatar.com/avatar/70e13d9877054026fda46d5a5b53a236?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MOROHASHI Kyosuke" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://rsss.be/hibariya"><img alt="Hibariya Hi" height="32" src="https://www.gravatar.com/avatar/de0df5acda15a9c7eeb6c28a5e5d4e8e?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hibariya Hi" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://twitter.com/kyanny"><img alt="Kensuke Nagae" height="32" src="https://www.gravatar.com/avatar/fffd8bf62b842a46803fb07792029fa4?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kensuke Nagae" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<img alt="oku23" height="32" src="https://www.gravatar.com/avatar/3725ec1dce281fb187d798a9b9ddc9d3?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="oku23" width="32">
+<a href="#"></a>
+</li>
+<li>
+<a href="http://ko.meadowy.net/~koichiro/diary/"><img alt="Koichiro Ohba" height="32" src="https://www.gravatar.com/avatar/1ce18b10bd8f911566c5577042b6a44c?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Koichiro Ohba" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://www.flickr.com/photos/t-seto"><img alt="せとん" height="32" src="https://www.gravatar.com/avatar/ac007a5b84f817d8cc80a3c208ea0181?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="せとん" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://twitter.com/#!/tsuyoshikawa"><img alt="Tsuyoshi Yoshikawa" height="32" src="https://www.gravatar.com/avatar/6969ade78c1eaff0d08c76020fc80e83?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tsuyoshi Yoshikawa" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://www.water-lily.biz/"><img alt="Water Lily LLC" height="32" src="https://www.gravatar.com/avatar/0734b8ec5eed71892e5db432856f4f40?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Water Lily LLC" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
@@ -560,115 +560,99 @@ Goldスポンサー
 <a href="#"></a>
 </li>
 <li>
-<a href="http://web-engineer.buyuden.net/blog/kawai/"><img alt="Takeshi Kawai" height="32" src="http://www.gravatar.com/avatar/6b53e472c9200f5ed61d7a6db0a28986?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takeshi Kawai" width="32"></a>
+<a href="http://web-engineer.buyuden.net/blog/kawai/"><img alt="Takeshi Kawai" height="32" src="https://www.gravatar.com/avatar/6b53e472c9200f5ed61d7a6db0a28986?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takeshi Kawai" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/k3c/"><img alt="KANEKO Seiji" height="32" src="http://www.gravatar.com/avatar/63d3818b5c107a6483a1d2e2767be4c5?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="KANEKO Seiji" width="32"></a>
+<a href="http://d.hatena.ne.jp/k3c/"><img alt="KANEKO Seiji" height="32" src="https://www.gravatar.com/avatar/63d3818b5c107a6483a1d2e2767be4c5?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="KANEKO Seiji" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.famlog.jp/"><img alt="Atsushi Matsuo" height="32" src="http://www.gravatar.com/avatar/0a4da00dbfd37e7f06ef8dceb58ca0c1?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Atsushi Matsuo" width="32"></a>
+<a href="http://www.famlog.jp/"><img alt="Atsushi Matsuo" height="32" src="https://www.gravatar.com/avatar/0a4da00dbfd37e7f06ef8dceb58ca0c1?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Atsushi Matsuo" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://m.igrs.jp/"><img alt="Masato Igarashi" height="32" src="http://www.gravatar.com/avatar/6fd2e23d73c26ccbd7df9e3eefacd3ae?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masato Igarashi" width="32"></a>
+<a href="http://m.igrs.jp/"><img alt="Masato Igarashi" height="32" src="https://www.gravatar.com/avatar/6fd2e23d73c26ccbd7df9e3eefacd3ae?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masato Igarashi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://resume.github.com/?walf443"><img alt="Keiji Yoshimi" height="32" src="http://www.gravatar.com/avatar/dea4fe079aec284744ad02eb3d2594f5?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Keiji Yoshimi" width="32"></a>
+<a href="http://resume.github.com/?walf443"><img alt="Keiji Yoshimi" height="32" src="https://www.gravatar.com/avatar/dea4fe079aec284744ad02eb3d2594f5?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Keiji Yoshimi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://gunjisatoshi.appspot.com/"><img alt="GUNJI Satoshi" height="32" src="http://www.gravatar.com/avatar/e6980e09fdff8f481b70f2e1f241231d?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="GUNJI Satoshi" width="32"></a>
+<a href="http://gunjisatoshi.appspot.com/"><img alt="GUNJI Satoshi" height="32" src="https://www.gravatar.com/avatar/e6980e09fdff8f481b70f2e1f241231d?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="GUNJI Satoshi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<img alt="Hisashi Yamaeda" height="32" src="http://www.gravatar.com/avatar/01ca4ebeee47c9b4d6ba9ad58db694a0?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hisashi Yamaeda" width="32">
+<img alt="Hisashi Yamaeda" height="32" src="https://www.gravatar.com/avatar/01ca4ebeee47c9b4d6ba9ad58db694a0?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hisashi Yamaeda" width="32">
 <a href="#"></a>
 </li>
 <li>
-<img alt="gekidanyonin" height="32" src="http://www.gravatar.com/avatar/2b196f1723fdbcbf7bd297b3e7f8cd3c?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="gekidanyonin" width="32">
+<img alt="gekidanyonin" height="32" src="https://www.gravatar.com/avatar/2b196f1723fdbcbf7bd297b3e7f8cd3c?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="gekidanyonin" width="32">
 <a href="#"></a>
 </li>
 <li>
-<a href="http://jp.linkedin.com/in/nakaomitsuteru"><img alt="Mitsuteru Nakao" height="32" src="http://www.gravatar.com/avatar/9090e122cba40b90124ea8eb4859bf8e?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Mitsuteru Nakao" width="32"></a>
+<a href="http://jp.linkedin.com/in/nakaomitsuteru"><img alt="Mitsuteru Nakao" height="32" src="https://www.gravatar.com/avatar/9090e122cba40b90124ea8eb4859bf8e?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Mitsuteru Nakao" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://zaki.asia"><img alt="Dezso Zoltan" height="32" src="http://www.gravatar.com/avatar/a771de8e1e49a9da61e2a602a2af42bc?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Dezso Zoltan" width="32"></a>
+<a href="http://zaki.asia"><img alt="Dezso Zoltan" height="32" src="https://www.gravatar.com/avatar/a771de8e1e49a9da61e2a602a2af42bc?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Dezso Zoltan" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.twitter.com/ope"><img alt="Takanori Nakanowatari" height="32" src="http://www.gravatar.com/avatar/55bcf6eb5de45a70e76f8a2678822ecb?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takanori Nakanowatari" width="32"></a>
+<a href="http://www.twitter.com/ope"><img alt="Takanori Nakanowatari" height="32" src="https://www.gravatar.com/avatar/55bcf6eb5de45a70e76f8a2678822ecb?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takanori Nakanowatari" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="https://github.com/zev"><img alt="Zev Blut" height="32" src="http://www.gravatar.com/avatar/1c77ad9f35746369dd1f4dd69b9f8b18?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Zev Blut" width="32"></a>
+<a href="https://github.com/zev"><img alt="Zev Blut" height="32" src="https://www.gravatar.com/avatar/1c77ad9f35746369dd1f4dd69b9f8b18?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Zev Blut" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://tako3.com/http://rubykaigi.org/rubyists/kei-s"><img alt="kei-s" height="32" src="http://www.gravatar.com/avatar/bf7ce9b68bbb0058721906b4db15b9b5?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="kei-s" width="32"></a>
+<a href="http://tako3.com/http://rubykaigi.org/rubyists/kei-s"><img alt="kei-s" height="32" src="https://www.gravatar.com/avatar/bf7ce9b68bbb0058721906b4db15b9b5?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="kei-s" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/bobbyjam99"><img alt="Tomokazu IMAI" height="32" src="http://www.gravatar.com/avatar/33814e72445b35ad3b65b1b05e699adc?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomokazu IMAI" width="32"></a>
+<a href="http://twitter.com/bobbyjam99"><img alt="Tomokazu IMAI" height="32" src="https://www.gravatar.com/avatar/33814e72445b35ad3b65b1b05e699adc?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomokazu IMAI" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/hasimo"><img alt="Tohru Hashimoto" height="32" src="http://www.gravatar.com/avatar/6e3d1578114e5d3951a7f90579fff74c?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tohru Hashimoto" width="32"></a>
+<a href="http://twitter.com/hasimo"><img alt="Tohru Hashimoto" height="32" src="https://www.gravatar.com/avatar/6e3d1578114e5d3951a7f90579fff74c?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tohru Hashimoto" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.mobalean.com/founders/michael"><img alt="Michael Reinsch" height="32" src="http://www.gravatar.com/avatar/c7915a424cbb28fdd6c1cce270be6b58?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Michael Reinsch" width="32"></a>
+<a href="http://www.mobalean.com/founders/michael"><img alt="Michael Reinsch" height="32" src="https://www.gravatar.com/avatar/c7915a424cbb28fdd6c1cce270be6b58?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Michael Reinsch" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/sandinist"><img alt="Tsuyoshi MAEHANA" height="32" src="http://www.gravatar.com/avatar/e8ebe7d4ec09c5dd77ee064706836f23?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tsuyoshi MAEHANA" width="32"></a>
+<a href="http://twitter.com/sandinist"><img alt="Tsuyoshi MAEHANA" height="32" src="https://www.gravatar.com/avatar/e8ebe7d4ec09c5dd77ee064706836f23?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tsuyoshi MAEHANA" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://sane.jp"><img alt="Murahashi Sanemat Kenichi" height="32" src="http://www.gravatar.com/avatar/5b1d016f87f05ff645ae572ccbbf0448?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Murahashi Sanemat Kenichi" width="32"></a>
+<a href="http://sane.jp"><img alt="Murahashi Sanemat Kenichi" height="32" src="https://www.gravatar.com/avatar/5b1d016f87f05ff645ae572ccbbf0448?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Murahashi Sanemat Kenichi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://aerial.st"><img alt="Masato Ikeda" height="32" src="http://www.gravatar.com/avatar/03abf5741b7bbd28670af5ec92b6141d?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masato Ikeda" width="32"></a>
+<a href="http://aerial.st"><img alt="Masato Ikeda" height="32" src="https://www.gravatar.com/avatar/03abf5741b7bbd28670af5ec92b6141d?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masato Ikeda" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/tex314"><img alt="OKAZAKI Takurou" height="32" src="http://www.gravatar.com/avatar/45c2cc1a731924edf1045d9146ca4a78?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="OKAZAKI Takurou" width="32"></a>
+<a href="http://twitter.com/tex314"><img alt="OKAZAKI Takurou" height="32" src="https://www.gravatar.com/avatar/45c2cc1a731924edf1045d9146ca4a78?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="OKAZAKI Takurou" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="https://twitter.com/toshi3221"><img alt="Toshiharu Takematsu" height="32" src="http://www.gravatar.com/avatar/3ca4621fbbb03278d4550f89e2f723ba?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Toshiharu Takematsu" width="32"></a>
+<a href="https://twitter.com/toshi3221"><img alt="Toshiharu Takematsu" height="32" src="https://www.gravatar.com/avatar/3ca4621fbbb03278d4550f89e2f723ba?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Toshiharu Takematsu" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://tdtds.jp"><img alt="TADA Tadashi" height="32" src="http://www.gravatar.com/avatar/846a80b9bf7ea7becb6c4ecd67bedd6f?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TADA Tadashi" width="32"></a>
+<a href="http://tdtds.jp"><img alt="TADA Tadashi" height="32" src="https://www.gravatar.com/avatar/846a80b9bf7ea7becb6c4ecd67bedd6f?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TADA Tadashi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://hisano.com"><img alt="HISANO Kozo" height="32" src="http://www.gravatar.com/avatar/b8fa07639c3b720c33ffdcaf89299dda?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="HISANO Kozo" width="32"></a>
+<a href="http://hisano.com"><img alt="HISANO Kozo" height="32" src="https://www.gravatar.com/avatar/b8fa07639c3b720c33ffdcaf89299dda?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="HISANO Kozo" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/kouma31/"><img alt="kmuroi" height="32" src="http://www.gravatar.com/avatar/165599097b8533c91af2aad5d7b31449?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="kmuroi" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<img alt="Anonymous" height="32" src="/2011/images/bow_face.png?1359134037" title="Anonymous" width="32">
-<a href="#"></a>
-</li>
-<li>
-<a href="http://twitter.com/h4n"><img alt="Han Kessels" height="32" src="http://www.gravatar.com/avatar/f0bd4ed83708d0af0e0d1374fc7e605b?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Han Kessels" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://twitter.com/takagi"><img alt="TAKAGI Masahiro" height="32" src="http://www.gravatar.com/avatar/c3f5a6e729b57f99cb9e7b3ca60152aa?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TAKAGI Masahiro" width="32"></a>
-<a href="#"></a>
-</li>
-<li>
-<a href="http://d.hatena.ne.jp/tmtms/"><img alt="TOMITA Masahiro" height="32" src="http://www.gravatar.com/avatar/e4763acee4cf0377437f614fc372a061?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TOMITA Masahiro" width="32"></a>
+<a href="http://d.hatena.ne.jp/kouma31/"><img alt="kmuroi" height="32" src="https://www.gravatar.com/avatar/165599097b8533c91af2aad5d7b31449?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="kmuroi" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
@@ -676,79 +660,95 @@ Goldスポンサー
 <a href="#"></a>
 </li>
 <li>
-<a href="http://kmuto.jp/"><img alt="Kenshi Muto" height="32" src="http://www.gravatar.com/avatar/43d44fbc12adcf80c9fc24e235f48234?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kenshi Muto" width="32"></a>
+<a href="http://twitter.com/h4n"><img alt="Han Kessels" height="32" src="https://www.gravatar.com/avatar/f0bd4ed83708d0af0e0d1374fc7e605b?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Han Kessels" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<img alt="1syo" height="32" src="http://www.gravatar.com/avatar/83899fe2d00874176098a3bb71b043be?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="1syo" width="32">
+<a href="http://twitter.com/takagi"><img alt="TAKAGI Masahiro" height="32" src="https://www.gravatar.com/avatar/c3f5a6e729b57f99cb9e7b3ca60152aa?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TAKAGI Masahiro" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://fkino.net"><img alt="Fumihiko Kinoshita" height="32" src="http://www.gravatar.com/avatar/f301c0275838d562c72ea9177e7ddc68?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Fumihiko Kinoshita" width="32"></a>
+<a href="http://d.hatena.ne.jp/tmtms/"><img alt="TOMITA Masahiro" height="32" src="https://www.gravatar.com/avatar/e4763acee4cf0377437f614fc372a061?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TOMITA Masahiro" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://blog.masuidrive.jp/"><img alt="Yuichiro MASUI" height="32" src="http://www.gravatar.com/avatar/0ec58a040e1e4e959c8566484b4bba19?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yuichiro MASUI" width="32"></a>
+<img alt="Anonymous" height="32" src="/2011/images/bow_face.png?1359134037" title="Anonymous" width="32">
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/t2os/"><img alt="tatsuoSakurai" height="32" src="http://www.gravatar.com/avatar/092404bdf9897eba9ab16e61f56592db?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="tatsuoSakurai" width="32"></a>
+<a href="http://kmuto.jp/"><img alt="Kenshi Muto" height="32" src="https://www.gravatar.com/avatar/43d44fbc12adcf80c9fc24e235f48234?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kenshi Muto" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://ogijun.org"><img alt="Junya Ogino" height="32" src="http://www.gravatar.com/avatar/3a82321f68500d9691a9e190979ac2f0?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Junya Ogino" width="32"></a>
+<img alt="1syo" height="32" src="https://www.gravatar.com/avatar/83899fe2d00874176098a3bb71b043be?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="1syo" width="32">
 <a href="#"></a>
 </li>
 <li>
-<a href="http://about.me/mackato"><img alt="Masakuni Kato" height="32" src="http://www.gravatar.com/avatar/28347314c7fc698b4ac0e01113545e25?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masakuni Kato" width="32"></a>
+<a href="http://fkino.net"><img alt="Fumihiko Kinoshita" height="32" src="https://www.gravatar.com/avatar/f301c0275838d562c72ea9177e7ddc68?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Fumihiko Kinoshita" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://d.hatena.ne.jp/IWAKIRI"><img alt="IWAKIRI,Akiko" height="32" src="http://www.gravatar.com/avatar/2a02258781c7592d0da1cd5cffa627a8?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="IWAKIRI,Akiko" width="32"></a>
+<a href="http://blog.masuidrive.jp/"><img alt="Yuichiro MASUI" height="32" src="https://www.gravatar.com/avatar/0ec58a040e1e4e959c8566484b4bba19?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yuichiro MASUI" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://june29.jp/"><img alt="june29" height="32" src="http://www.gravatar.com/avatar/6fd9be5cd0196df5ad62a5a5f2be3c55?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="june29" width="32"></a>
+<a href="http://d.hatena.ne.jp/t2os/"><img alt="tatsuoSakurai" height="32" src="https://www.gravatar.com/avatar/092404bdf9897eba9ab16e61f56592db?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="tatsuoSakurai" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.socialtoprunners.jp/"><img alt="tomokazuhattanda" height="32" src="http://www.gravatar.com/avatar/19798587cb27b5220a5dcdbaa9a50d57?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="tomokazuhattanda" width="32"></a>
+<a href="http://ogijun.org"><img alt="Junya Ogino" height="32" src="https://www.gravatar.com/avatar/3a82321f68500d9691a9e190979ac2f0?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Junya Ogino" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.jamboree.jp/"><img alt="TOYOSHI, Ryuichiro" height="32" src="http://www.gravatar.com/avatar/203c324392b6c51241da5b42bbf888bd?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TOYOSHI, Ryuichiro" width="32"></a>
+<a href="http://about.me/mackato"><img alt="Masakuni Kato" height="32" src="https://www.gravatar.com/avatar/28347314c7fc698b4ac0e01113545e25?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masakuni Kato" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/takano32"><img alt="たかのみつひろ" height="32" src="http://www.gravatar.com/avatar/eba4a40bdae5edfe1589601c050a2b96?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="たかのみつひろ" width="32"></a>
+<a href="http://d.hatena.ne.jp/IWAKIRI"><img alt="IWAKIRI,Akiko" height="32" src="https://www.gravatar.com/avatar/2a02258781c7592d0da1cd5cffa627a8?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="IWAKIRI,Akiko" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/tyabe"><img alt="tyabe" height="32" src="http://www.gravatar.com/avatar/d21900444f5548d9329861593321b5a6?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="tyabe" width="32"></a>
+<a href="http://june29.jp/"><img alt="june29" height="32" src="https://www.gravatar.com/avatar/6fd9be5cd0196df5ad62a5a5f2be3c55?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="june29" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/#!/maxyz"><img alt="Masafumi Fujiwara" height="32" src="http://www.gravatar.com/avatar/4dd4d13d27559db2fb64ad069f2c49ba?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masafumi Fujiwara" width="32"></a>
+<a href="http://www.socialtoprunners.jp/"><img alt="tomokazuhattanda" height="32" src="https://www.gravatar.com/avatar/19798587cb27b5220a5dcdbaa9a50d57?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="tomokazuhattanda" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/kdmsnr"><img alt="Masanori Kado" height="32" src="http://www.gravatar.com/avatar/70b07e6b7fe7d921d7ac542d0ccb3b2c?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masanori Kado" width="32"></a>
+<a href="http://www.jamboree.jp/"><img alt="TOYOSHI, Ryuichiro" height="32" src="https://www.gravatar.com/avatar/203c324392b6c51241da5b42bbf888bd?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TOYOSHI, Ryuichiro" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://www.jitu.org/~tko"><img alt="Tomoyuki Kosimizu" height="32" src="http://www.gravatar.com/avatar/3585181753c22a9531e70a8297771b01?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomoyuki Kosimizu" width="32"></a>
+<a href="http://twitter.com/takano32"><img alt="たかのみつひろ" height="32" src="https://www.gravatar.com/avatar/eba4a40bdae5edfe1589601c050a2b96?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="たかのみつひろ" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://twitter.com/chinmo"><img alt="Tomonori Fukuta" height="32" src="http://www.gravatar.com/avatar/7977a0896e60587b2690550891be2ea7?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomonori Fukuta" width="32"></a>
+<a href="http://twitter.com/tyabe"><img alt="tyabe" height="32" src="https://www.gravatar.com/avatar/d21900444f5548d9329861593321b5a6?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="tyabe" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<img alt="YOKOTA Akiko" height="32" src="http://www.gravatar.com/avatar/03e548747e667fc94cc8495868bfd85e?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="YOKOTA Akiko" width="32">
+<a href="http://twitter.com/#!/maxyz"><img alt="Masafumi Fujiwara" height="32" src="https://www.gravatar.com/avatar/4dd4d13d27559db2fb64ad069f2c49ba?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masafumi Fujiwara" width="32"></a>
 <a href="#"></a>
 </li>
 <li>
-<a href="http://nov.tdiary.net/"><img alt="Nobuhiro IMAI" height="32" src="http://www.gravatar.com/avatar/e49ab9f0774711c473660019728cde95?s=32&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Nobuhiro IMAI" width="32"></a>
+<a href="http://twitter.com/kdmsnr"><img alt="Masanori Kado" height="32" src="https://www.gravatar.com/avatar/70b07e6b7fe7d921d7ac542d0ccb3b2c?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masanori Kado" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://www.jitu.org/~tko"><img alt="Tomoyuki Kosimizu" height="32" src="https://www.gravatar.com/avatar/3585181753c22a9531e70a8297771b01?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomoyuki Kosimizu" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<a href="http://twitter.com/chinmo"><img alt="Tomonori Fukuta" height="32" src="https://www.gravatar.com/avatar/7977a0896e60587b2690550891be2ea7?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomonori Fukuta" width="32"></a>
+<a href="#"></a>
+</li>
+<li>
+<img alt="YOKOTA Akiko" height="32" src="https://www.gravatar.com/avatar/03e548747e667fc94cc8495868bfd85e?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="YOKOTA Akiko" width="32">
+<a href="#"></a>
+</li>
+<li>
+<a href="http://nov.tdiary.net/"><img alt="Nobuhiro IMAI" height="32" src="https://www.gravatar.com/avatar/e49ab9f0774711c473660019728cde95?s=32&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Nobuhiro IMAI" width="32"></a>
 <a href="#"></a>
 </li>
 </ul>

--- a/2011/ja/sponsors_individual/index.html
+++ b/2011/ja/sponsors_individual/index.html
@@ -89,63 +89,63 @@
 </h1>
 <article>
 <div class="avatar">
-<a href="http://shyouhei.tumblr.com"><img alt="Urabe, Shyouhei" height="42" src="http://www.gravatar.com/avatar/9d2f78236e45a335301ba1195026105d?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Urabe, Shyouhei" width="42"></a>
+<a href="http://shyouhei.tumblr.com"><img alt="Urabe, Shyouhei" height="42" src="https://www.gravatar.com/avatar/9d2f78236e45a335301ba1195026105d?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Urabe, Shyouhei" width="42"></a>
 <p class="linkMark">
 <a href="http://shyouhei.tumblr.com">Urabe, Shyouhei</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://twitter.com/noplans"><img alt="TANIGUCHI Fumitake" height="42" src="http://www.gravatar.com/avatar/e514ae09c9b84e04231af57f1d1946b8?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TANIGUCHI Fumitake" width="42"></a>
+<a href="http://twitter.com/noplans"><img alt="TANIGUCHI Fumitake" height="42" src="https://www.gravatar.com/avatar/e514ae09c9b84e04231af57f1d1946b8?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TANIGUCHI Fumitake" width="42"></a>
 <p class="linkMark">
 <a href="http://twitter.com/noplans">TANIGUCHI Fumitake</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://jmettraux.wordpress.com"><img alt="John Mettraux" height="42" src="http://www.gravatar.com/avatar/8d96626e52beb1ff90f57a8e189e1e6f?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="John Mettraux" width="42"></a>
+<a href="http://jmettraux.wordpress.com"><img alt="John Mettraux" height="42" src="https://www.gravatar.com/avatar/8d96626e52beb1ff90f57a8e189e1e6f?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="John Mettraux" width="42"></a>
 <p class="linkMark">
 <a href="http://jmettraux.wordpress.com">John Mettraux</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://twitter.com/japanrock"><img alt="Shintaro Nozaki" height="42" src="http://www.gravatar.com/avatar/b31a258dd8f615f61b2d355297f82dc9?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shintaro Nozaki" width="42"></a>
+<a href="http://twitter.com/japanrock"><img alt="Shintaro Nozaki" height="42" src="https://www.gravatar.com/avatar/b31a258dd8f615f61b2d355297f82dc9?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shintaro Nozaki" width="42"></a>
 <p class="linkMark">
 <a href="http://twitter.com/japanrock">Shintaro Nozaki</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://blog.dio.jp"><img alt="Akira Matsuda" height="42" src="http://www.gravatar.com/avatar/76a777ff80f30bd3b390e275cce625bc?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Akira Matsuda" width="42"></a>
+<a href="http://blog.dio.jp"><img alt="Akira Matsuda" height="42" src="https://www.gravatar.com/avatar/76a777ff80f30bd3b390e275cce625bc?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Akira Matsuda" width="42"></a>
 <p class="linkMark">
 <a href="http://blog.dio.jp">Akira Matsuda</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://www.bovensiepen.net"><img alt="Daniel Bovensiepen" height="42" src="http://www.gravatar.com/avatar/49d6f762505615af259534deed94bc54?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Daniel Bovensiepen" width="42"></a>
+<a href="http://www.bovensiepen.net"><img alt="Daniel Bovensiepen" height="42" src="https://www.gravatar.com/avatar/49d6f762505615af259534deed94bc54?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Daniel Bovensiepen" width="42"></a>
 <p class="linkMark">
 <a href="http://www.bovensiepen.net">Daniel Bovensiepen</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://firn.jp/"><img alt="Dai Akatsuka" height="42" src="http://www.gravatar.com/avatar/4efe7b5cdbe97df84e6e607948171eef?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Dai Akatsuka" width="42"></a>
+<a href="http://firn.jp/"><img alt="Dai Akatsuka" height="42" src="https://www.gravatar.com/avatar/4efe7b5cdbe97df84e6e607948171eef?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Dai Akatsuka" width="42"></a>
 <p class="linkMark">
 <a href="http://firn.jp/">Dai Akatsuka</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://www.din.or.jp/~shinodas/"><img alt="Yoshihiko Hara" height="42" src="http://www.gravatar.com/avatar/8055fbffa700065178460bb7e3b8ee24?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yoshihiko Hara" width="42"></a>
+<a href="http://www.din.or.jp/~shinodas/"><img alt="Yoshihiko Hara" height="42" src="https://www.gravatar.com/avatar/8055fbffa700065178460bb7e3b8ee24?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yoshihiko Hara" width="42"></a>
 <p class="linkMark">
 <a href="http://www.din.or.jp/~shinodas/">Yoshihiko Hara</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://benhoskin.gs"><img alt="Ben Hoskings" height="42" src="http://www.gravatar.com/avatar/7ed99cb90a060539d729e2491442a603?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ben Hoskings" width="42"></a>
+<a href="http://benhoskin.gs"><img alt="Ben Hoskings" height="42" src="https://www.gravatar.com/avatar/7ed99cb90a060539d729e2491442a603?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ben Hoskings" width="42"></a>
 <p class="linkMark">
 <a href="http://benhoskin.gs">Ben Hoskings</a>
 </p>
@@ -159,21 +159,21 @@ Anonymous
 </div>
 <hr>
 <div class="avatar">
-<a href="http://www.nextseed.jp/"><img alt="Hitoshi Kurokawa" height="42" src="http://www.gravatar.com/avatar/11e89e3c85d9998b2c73933bde77c71e?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hitoshi Kurokawa" width="42"></a>
+<a href="http://www.nextseed.jp/"><img alt="Hitoshi Kurokawa" height="42" src="https://www.gravatar.com/avatar/11e89e3c85d9998b2c73933bde77c71e?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hitoshi Kurokawa" width="42"></a>
 <p class="linkMark">
 <a href="http://www.nextseed.jp/">Hitoshi Kurokawa</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://d.hatena.ne.jp/kinpoco/"><img alt="Yutaka Kanemoto" height="42" src="http://www.gravatar.com/avatar/0e728bf538d1848bc253d80a8626bbc2?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yutaka Kanemoto" width="42"></a>
+<a href="http://d.hatena.ne.jp/kinpoco/"><img alt="Yutaka Kanemoto" height="42" src="https://www.gravatar.com/avatar/0e728bf538d1848bc253d80a8626bbc2?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yutaka Kanemoto" width="42"></a>
 <p class="linkMark">
 <a href="http://d.hatena.ne.jp/kinpoco/">Yutaka Kanemoto</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://d.hatena.ne.jp/yuichi_katahira"><img alt="Yuichi Katahira " height="42" src="http://www.gravatar.com/avatar/3072ae08f580fc8474b47652a3d8dd0f?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yuichi Katahira " width="42"></a>
+<a href="http://d.hatena.ne.jp/yuichi_katahira"><img alt="Yuichi Katahira " height="42" src="https://www.gravatar.com/avatar/3072ae08f580fc8474b47652a3d8dd0f?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yuichi Katahira " width="42"></a>
 <p class="linkMark">
 <a href="http://d.hatena.ne.jp/yuichi_katahira">Yuichi Katahira </a>
 </p>
@@ -187,14 +187,14 @@ Anonymous
 </div>
 <hr>
 <div class="avatar">
-<a href="http://kitaj.no-ip.com/tdiary/"><img alt="Junichiro Kita" height="42" src="http://www.gravatar.com/avatar/70405ca68e6f8779be65e75b1a90525b?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Junichiro Kita" width="42"></a>
+<a href="http://kitaj.no-ip.com/tdiary/"><img alt="Junichiro Kita" height="42" src="https://www.gravatar.com/avatar/70405ca68e6f8779be65e75b1a90525b?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Junichiro Kita" width="42"></a>
 <p class="linkMark">
 <a href="http://kitaj.no-ip.com/tdiary/">Junichiro Kita</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://d.hatena.ne.jp/idesaku"><img alt="Daisuke Goto" height="42" src="http://www.gravatar.com/avatar/85c8086344e5f31b2a4d22f163660536?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Daisuke Goto" width="42"></a>
+<a href="http://d.hatena.ne.jp/idesaku"><img alt="Daisuke Goto" height="42" src="https://www.gravatar.com/avatar/85c8086344e5f31b2a4d22f163660536?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Daisuke Goto" width="42"></a>
 <p class="linkMark">
 <a href="http://d.hatena.ne.jp/idesaku">Daisuke Goto</a>
 </p>
@@ -208,126 +208,126 @@ Anonymous
 </div>
 <hr>
 <div class="avatar">
-<a href="http://www.on-sky.net/~hs/"><img alt="Hideki SAKAMOTO" height="42" src="http://www.gravatar.com/avatar/7038a6cfc30b8c3b00b5c08d70cda2f1?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hideki SAKAMOTO" width="42"></a>
+<a href="http://www.on-sky.net/~hs/"><img alt="Hideki SAKAMOTO" height="42" src="https://www.gravatar.com/avatar/7038a6cfc30b8c3b00b5c08d70cda2f1?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hideki SAKAMOTO" width="42"></a>
 <p class="linkMark">
 <a href="http://www.on-sky.net/~hs/">Hideki SAKAMOTO</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://twitter.com/agilekawabata"><img alt="Kawabata Mitsuyoshi" height="42" src="http://www.gravatar.com/avatar/5236eb3ad498b3c5336a4575408fb1b1?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kawabata Mitsuyoshi" width="42"></a>
+<a href="http://twitter.com/agilekawabata"><img alt="Kawabata Mitsuyoshi" height="42" src="https://www.gravatar.com/avatar/5236eb3ad498b3c5336a4575408fb1b1?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kawabata Mitsuyoshi" width="42"></a>
 <p class="linkMark">
 <a href="http://twitter.com/agilekawabata">Kawabata Mitsuyoshi</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://www.kt.rim.or.jp/~kbk/"><img alt="KIMURA Koichi" height="42" src="http://www.gravatar.com/avatar/04c1a31d1e33e7fc25a7ca99930e4c70?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="KIMURA Koichi" width="42"></a>
+<a href="http://www.kt.rim.or.jp/~kbk/"><img alt="KIMURA Koichi" height="42" src="https://www.gravatar.com/avatar/04c1a31d1e33e7fc25a7ca99930e4c70?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="KIMURA Koichi" width="42"></a>
 <p class="linkMark">
 <a href="http://www.kt.rim.or.jp/~kbk/">KIMURA Koichi</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://d.hatena.ne.jp/takkaw/"><img alt="Takayoshi Kawada" height="42" src="http://www.gravatar.com/avatar/38bf2ca557d9cc20dcdcbd773a68664b?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takayoshi Kawada" width="42"></a>
+<a href="http://d.hatena.ne.jp/takkaw/"><img alt="Takayoshi Kawada" height="42" src="https://www.gravatar.com/avatar/38bf2ca557d9cc20dcdcbd773a68664b?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takayoshi Kawada" width="42"></a>
 <p class="linkMark">
 <a href="http://d.hatena.ne.jp/takkaw/">Takayoshi Kawada</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://www.suchi.org/"><img alt="Shigeru UCHIYAMA" height="42" src="http://www.gravatar.com/avatar/398e2dd764d43aad735c6e5bca92c3b6?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shigeru UCHIYAMA" width="42"></a>
+<a href="http://www.suchi.org/"><img alt="Shigeru UCHIYAMA" height="42" src="https://www.gravatar.com/avatar/398e2dd764d43aad735c6e5bca92c3b6?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shigeru UCHIYAMA" width="42"></a>
 <p class="linkMark">
 <a href="http://www.suchi.org/">Shigeru UCHIYAMA</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://twitter.com/#!/andrewjgrimm"><img alt="Andrew Grimm" height="42" src="http://www.gravatar.com/avatar/01bbb59a1c3ef9960f25a97afe7e920f?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Andrew Grimm" width="42"></a>
+<a href="http://twitter.com/#!/andrewjgrimm"><img alt="Andrew Grimm" height="42" src="https://www.gravatar.com/avatar/01bbb59a1c3ef9960f25a97afe7e920f?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Andrew Grimm" width="42"></a>
 <p class="linkMark">
 <a href="http://twitter.com/#!/andrewjgrimm">Andrew Grimm</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://twitter.com/kimuraw"><img alt="kimura wataru" height="42" src="http://www.gravatar.com/avatar/e298234a6e5a2c159287476abd76504a?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="kimura wataru" width="42"></a>
+<a href="http://twitter.com/kimuraw"><img alt="kimura wataru" height="42" src="https://www.gravatar.com/avatar/e298234a6e5a2c159287476abd76504a?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="kimura wataru" width="42"></a>
 <p class="linkMark">
 <a href="http://twitter.com/kimuraw">kimura wataru</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://saikyoline.jp/"><img alt="MIKAMI Yoshiyuki" height="42" src="http://www.gravatar.com/avatar/e0920f5f813ae29ba7859f950a7f0df3?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MIKAMI Yoshiyuki" width="42"></a>
+<a href="http://saikyoline.jp/"><img alt="MIKAMI Yoshiyuki" height="42" src="https://www.gravatar.com/avatar/e0920f5f813ae29ba7859f950a7f0df3?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MIKAMI Yoshiyuki" width="42"></a>
 <p class="linkMark">
 <a href="http://saikyoline.jp/">MIKAMI Yoshiyuki</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://jp.rubyist.net/?KansaiWorkshop"><img alt="HIGAKI Masaru" height="42" src="http://www.gravatar.com/avatar/a8192f5a7b25ef32a983740ee8593bd3?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="HIGAKI Masaru" width="42"></a>
+<a href="http://jp.rubyist.net/?KansaiWorkshop"><img alt="HIGAKI Masaru" height="42" src="https://www.gravatar.com/avatar/a8192f5a7b25ef32a983740ee8593bd3?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="HIGAKI Masaru" width="42"></a>
 <p class="linkMark">
 <a href="http://jp.rubyist.net/?KansaiWorkshop">HIGAKI Masaru</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://twitter.com/ayumin"><img alt="Ayumu AIZAWA" height="42" src="http://www.gravatar.com/avatar/2e9a2dbe335e0111e4879a9d65dcbae0?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ayumu AIZAWA" width="42"></a>
+<a href="http://twitter.com/ayumin"><img alt="Ayumu AIZAWA" height="42" src="https://www.gravatar.com/avatar/2e9a2dbe335e0111e4879a9d65dcbae0?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ayumu AIZAWA" width="42"></a>
 <p class="linkMark">
 <a href="http://twitter.com/ayumin">Ayumu AIZAWA</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://shunichi-arai.blogspot.com/"><img alt="Shunichi Arai" height="42" src="http://www.gravatar.com/avatar/74daf3516e33a75968ec0f933954b5a8?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shunichi Arai" width="42"></a>
+<a href="http://shunichi-arai.blogspot.com/"><img alt="Shunichi Arai" height="42" src="https://www.gravatar.com/avatar/74daf3516e33a75968ec0f933954b5a8?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shunichi Arai" width="42"></a>
 <p class="linkMark">
 <a href="http://shunichi-arai.blogspot.com/">Shunichi Arai</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://www.tokyodev.com"><img alt="Paul McMahon" height="42" src="http://www.gravatar.com/avatar/dd24adb5a3a430fed83a33ed552fe1b5?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Paul McMahon" width="42"></a>
+<a href="http://www.tokyodev.com"><img alt="Paul McMahon" height="42" src="https://www.gravatar.com/avatar/dd24adb5a3a430fed83a33ed552fe1b5?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Paul McMahon" width="42"></a>
 <p class="linkMark">
 <a href="http://www.tokyodev.com">Paul McMahon</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://d.hatena.ne.jp/hs9587/"><img alt="Hiroyuki Shimura" height="42" src="http://www.gravatar.com/avatar/287a899c91a7a14535188d7e4784050e?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hiroyuki Shimura" width="42"></a>
+<a href="http://d.hatena.ne.jp/hs9587/"><img alt="Hiroyuki Shimura" height="42" src="https://www.gravatar.com/avatar/287a899c91a7a14535188d7e4784050e?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hiroyuki Shimura" width="42"></a>
 <p class="linkMark">
 <a href="http://d.hatena.ne.jp/hs9587/">Hiroyuki Shimura</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://kakutani.com"><img alt="Kakutani Shintaro" height="42" src="http://www.gravatar.com/avatar/34fcd5f1deeb25b1138e9845137feb6e?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kakutani Shintaro" width="42"></a>
+<a href="http://kakutani.com"><img alt="Kakutani Shintaro" height="42" src="https://www.gravatar.com/avatar/34fcd5f1deeb25b1138e9845137feb6e?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kakutani Shintaro" width="42"></a>
 <p class="linkMark">
 <a href="http://kakutani.com">Kakutani Shintaro</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://d.hatena.ne.jp/mrkn"><img alt="Kenta Murata" height="42" src="http://www.gravatar.com/avatar/819b3c0a25f9708fd32261b8ae2d23f6?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kenta Murata" width="42"></a>
+<a href="http://d.hatena.ne.jp/mrkn"><img alt="Kenta Murata" height="42" src="https://www.gravatar.com/avatar/819b3c0a25f9708fd32261b8ae2d23f6?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kenta Murata" width="42"></a>
 <p class="linkMark">
 <a href="http://d.hatena.ne.jp/mrkn">Kenta Murata</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://rails.to"><img alt="Masatoshi Itagaki" height="42" src="http://www.gravatar.com/avatar/f8865f41777ef3caced0e4e6801ff83a?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masatoshi Itagaki" width="42"></a>
+<a href="http://rails.to"><img alt="Masatoshi Itagaki" height="42" src="https://www.gravatar.com/avatar/f8865f41777ef3caced0e4e6801ff83a?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masatoshi Itagaki" width="42"></a>
 <p class="linkMark">
 <a href="http://rails.to">Masatoshi Itagaki</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://spring-aki.com/"><img alt="Aki" height="42" src="http://www.gravatar.com/avatar/81f2122b45f48829be4507bf972666e9?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Aki" width="42"></a>
+<a href="http://spring-aki.com/"><img alt="Aki" height="42" src="https://www.gravatar.com/avatar/81f2122b45f48829be4507bf972666e9?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Aki" width="42"></a>
 <p class="linkMark">
 <a href="http://spring-aki.com/">Aki</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://twitter.com/shin_asou"><img alt="Shinichi Okada" height="42" src="http://www.gravatar.com/avatar/20805358592bd93f92bf15aa10137251?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shinichi Okada" width="42"></a>
+<a href="http://twitter.com/shin_asou"><img alt="Shinichi Okada" height="42" src="https://www.gravatar.com/avatar/20805358592bd93f92bf15aa10137251?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Shinichi Okada" width="42"></a>
 <p class="linkMark">
 <a href="http://twitter.com/shin_asou">Shinichi Okada</a>
 </p>
@@ -341,56 +341,56 @@ Anonymous
 </div>
 <hr>
 <div class="avatar">
-<a href="http://www.kumaryu.net/"><img alt="Ryuichi Sakamoto" height="42" src="http://www.gravatar.com/avatar/1b2ca00132480422c75c1f2c61e84e26?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ryuichi Sakamoto" width="42"></a>
+<a href="http://www.kumaryu.net/"><img alt="Ryuichi Sakamoto" height="42" src="https://www.gravatar.com/avatar/1b2ca00132480422c75c1f2c61e84e26?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ryuichi Sakamoto" width="42"></a>
 <p class="linkMark">
 <a href="http://www.kumaryu.net/">Ryuichi Sakamoto</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<img alt="Eito Katagiri" height="42" src="http://www.gravatar.com/avatar/b5852cf79505d7ba513f8f16ef95a50f?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Eito Katagiri" width="42">
+<img alt="Eito Katagiri" height="42" src="https://www.gravatar.com/avatar/b5852cf79505d7ba513f8f16ef95a50f?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Eito Katagiri" width="42">
 <p>
 Eito Katagiri
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://ukstudio.jp/"><img alt="AKAMATSU Yuki" height="42" src="http://www.gravatar.com/avatar/0c471249ee93ab17a011f3e8d2b1057a?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="AKAMATSU Yuki" width="42"></a>
+<a href="http://ukstudio.jp/"><img alt="AKAMATSU Yuki" height="42" src="https://www.gravatar.com/avatar/0c471249ee93ab17a011f3e8d2b1057a?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="AKAMATSU Yuki" width="42"></a>
 <p class="linkMark">
 <a href="http://ukstudio.jp/">AKAMATSU Yuki</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://hisashim.org"><img alt="Hisashi Morita" height="42" src="http://www.gravatar.com/avatar/b3fba7af93cd27e6ed28e7eae88a9585?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hisashi Morita" width="42"></a>
+<a href="http://hisashim.org"><img alt="Hisashi Morita" height="42" src="https://www.gravatar.com/avatar/b3fba7af93cd27e6ed28e7eae88a9585?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hisashi Morita" width="42"></a>
 <p class="linkMark">
 <a href="http://hisashim.org">Hisashi Morita</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://d.hatena.ne.jp/muryoImpl/"><img alt="Ken muryoi" height="42" src="http://www.gravatar.com/avatar/ac6dba8ce93944d17714de362ca17e54?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ken muryoi" width="42"></a>
+<a href="http://d.hatena.ne.jp/muryoImpl/"><img alt="Ken muryoi" height="42" src="https://www.gravatar.com/avatar/ac6dba8ce93944d17714de362ca17e54?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ken muryoi" width="42"></a>
 <p class="linkMark">
 <a href="http://d.hatena.ne.jp/muryoImpl/">Ken muryoi</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://d.hatena.ne.jp/nagachika/"><img alt="Tomoyuki Chikanaga" height="42" src="http://www.gravatar.com/avatar/5cf8f058a4c094bb708174fb43e7a387?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomoyuki Chikanaga" width="42"></a>
+<a href="http://d.hatena.ne.jp/nagachika/"><img alt="Tomoyuki Chikanaga" height="42" src="https://www.gravatar.com/avatar/5cf8f058a4c094bb708174fb43e7a387?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomoyuki Chikanaga" width="42"></a>
 <p class="linkMark">
 <a href="http://d.hatena.ne.jp/nagachika/">Tomoyuki Chikanaga</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://d.hatena.ne.jp/takeshinoda/"><img alt="Takeshi SHINODA" height="42" src="http://www.gravatar.com/avatar/06febd004d7cc9c9f6a4e0272b686bc7?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takeshi SHINODA" width="42"></a>
+<a href="http://d.hatena.ne.jp/takeshinoda/"><img alt="Takeshi SHINODA" height="42" src="https://www.gravatar.com/avatar/06febd004d7cc9c9f6a4e0272b686bc7?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takeshi SHINODA" width="42"></a>
 <p class="linkMark">
 <a href="http://d.hatena.ne.jp/takeshinoda/">Takeshi SHINODA</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://twitter.com/knsmr"><img alt="Ken Nishimura" height="42" src="http://www.gravatar.com/avatar/91fb4852880d1727cca911036e2fef5f?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ken Nishimura" width="42"></a>
+<a href="http://twitter.com/knsmr"><img alt="Ken Nishimura" height="42" src="https://www.gravatar.com/avatar/91fb4852880d1727cca911036e2fef5f?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Ken Nishimura" width="42"></a>
 <p class="linkMark">
 <a href="http://twitter.com/knsmr">Ken Nishimura</a>
 </p>
@@ -404,56 +404,56 @@ Anonymous
 </div>
 <hr>
 <div class="avatar">
-<a href="http://d.hatena.ne.jp/koko_u/"><img alt="Kozaki Tsuneaki" height="42" src="http://www.gravatar.com/avatar/5b1b558d563288da615a9ea2889afdd5?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kozaki Tsuneaki" width="42"></a>
+<a href="http://d.hatena.ne.jp/koko_u/"><img alt="Kozaki Tsuneaki" height="42" src="https://www.gravatar.com/avatar/5b1b558d563288da615a9ea2889afdd5?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kozaki Tsuneaki" width="42"></a>
 <p class="linkMark">
 <a href="http://d.hatena.ne.jp/koko_u/">Kozaki Tsuneaki</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://twitter.com/adzuki34"><img alt="SUZUKI Miho" height="42" src="http://www.gravatar.com/avatar/f37b9a968b2326062190677906a93080?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="SUZUKI Miho" width="42"></a>
+<a href="http://twitter.com/adzuki34"><img alt="SUZUKI Miho" height="42" src="https://www.gravatar.com/avatar/f37b9a968b2326062190677906a93080?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="SUZUKI Miho" width="42"></a>
 <p class="linkMark">
 <a href="http://twitter.com/adzuki34">SUZUKI Miho</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://twitter.com/lchin"><img alt="Leonard Chin" height="42" src="http://www.gravatar.com/avatar/70762059db0218c6f0ff48042ca0756a?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Leonard Chin" width="42"></a>
+<a href="http://twitter.com/lchin"><img alt="Leonard Chin" height="42" src="https://www.gravatar.com/avatar/70762059db0218c6f0ff48042ca0756a?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Leonard Chin" width="42"></a>
 <p class="linkMark">
 <a href="http://twitter.com/lchin">Leonard Chin</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://d.hatena.ne.jp/suzumura_ss/"><img alt="Toshiyuki Terashita" height="42" src="http://www.gravatar.com/avatar/bb8b58cab667163b6ee53aad0e5f0414?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Toshiyuki Terashita" width="42"></a>
+<a href="http://d.hatena.ne.jp/suzumura_ss/"><img alt="Toshiyuki Terashita" height="42" src="https://www.gravatar.com/avatar/bb8b58cab667163b6ee53aad0e5f0414?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Toshiyuki Terashita" width="42"></a>
 <p class="linkMark">
 <a href="http://d.hatena.ne.jp/suzumura_ss/">Toshiyuki Terashita</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://sites.google.com/site/akihikohashimoto/"><img alt="Akihiko Hashimoto" height="42" src="http://www.gravatar.com/avatar/c8803a4130c3238e34b605d0a0cffe94?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Akihiko Hashimoto" width="42"></a>
+<a href="http://sites.google.com/site/akihikohashimoto/"><img alt="Akihiko Hashimoto" height="42" src="https://www.gravatar.com/avatar/c8803a4130c3238e34b605d0a0cffe94?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Akihiko Hashimoto" width="42"></a>
 <p class="linkMark">
 <a href="http://sites.google.com/site/akihikohashimoto/">Akihiko Hashimoto</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<img alt="OZAWA Sakuro" height="42" src="http://www.gravatar.com/avatar/a1cbed8bf64473e2acdd0c7066cc5b29?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="OZAWA Sakuro" width="42">
+<img alt="OZAWA Sakuro" height="42" src="https://www.gravatar.com/avatar/a1cbed8bf64473e2acdd0c7066cc5b29?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="OZAWA Sakuro" width="42">
 <p>
 OZAWA Sakuro
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://fkmn.exblog.jp/"><img alt="Arinobu FUKUHARA" height="42" src="http://www.gravatar.com/avatar/85319f2b72d7b37ddef5c25a2dd40d30?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Arinobu FUKUHARA" width="42"></a>
+<a href="http://fkmn.exblog.jp/"><img alt="Arinobu FUKUHARA" height="42" src="https://www.gravatar.com/avatar/85319f2b72d7b37ddef5c25a2dd40d30?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Arinobu FUKUHARA" width="42"></a>
 <p class="linkMark">
 <a href="http://fkmn.exblog.jp/">Arinobu FUKUHARA</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://twitter.com/shachi"><img alt="Kazuyuki Koizuka-shachi" height="42" src="http://www.gravatar.com/avatar/f51ee84097a72a8d91bee9bb98736541?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kazuyuki Koizuka-shachi" width="42"></a>
+<a href="http://twitter.com/shachi"><img alt="Kazuyuki Koizuka-shachi" height="42" src="https://www.gravatar.com/avatar/f51ee84097a72a8d91bee9bb98736541?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kazuyuki Koizuka-shachi" width="42"></a>
 <p class="linkMark">
 <a href="http://twitter.com/shachi">Kazuyuki Koizuka-shachi</a>
 </p>
@@ -467,175 +467,175 @@ Anonymous
 </div>
 <hr>
 <div class="avatar">
-<a href="http://atakigu.tumblr.com/"><img alt="atakig" height="42" src="http://www.gravatar.com/avatar/8a949c60e450d226de776072273a1ffc?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="atakig" width="42"></a>
+<a href="http://atakigu.tumblr.com/"><img alt="atakig" height="42" src="https://www.gravatar.com/avatar/8a949c60e450d226de776072273a1ffc?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="atakig" width="42"></a>
 <p class="linkMark">
 <a href="http://atakigu.tumblr.com/">atakig</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<img alt="TSUTSUI Toshinori" height="42" src="http://www.gravatar.com/avatar/ad66fd981c429c12e0f76c436da3337e?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TSUTSUI Toshinori" width="42">
+<img alt="TSUTSUI Toshinori" height="42" src="https://www.gravatar.com/avatar/ad66fd981c429c12e0f76c436da3337e?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TSUTSUI Toshinori" width="42">
 <p>
 TSUTSUI Toshinori
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://yugui.jp"><img alt="Yuki Sonoda (Yugui)" height="42" src="http://www.gravatar.com/avatar/1e7e007723cfe59320d994a7db4ab4cf?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yuki Sonoda (Yugui)" width="42"></a>
+<a href="http://yugui.jp"><img alt="Yuki Sonoda (Yugui)" height="42" src="https://www.gravatar.com/avatar/1e7e007723cfe59320d994a7db4ab4cf?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yuki Sonoda (Yugui)" width="42"></a>
 <p class="linkMark">
 <a href="http://yugui.jp">Yuki Sonoda (Yugui)</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://d.hatena.ne.jp/seiunsky"><img alt="sugamasao" height="42" src="http://www.gravatar.com/avatar/961126d9892ae4df45249529a0721571?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="sugamasao" width="42"></a>
+<a href="http://d.hatena.ne.jp/seiunsky"><img alt="sugamasao" height="42" src="https://www.gravatar.com/avatar/961126d9892ae4df45249529a0721571?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="sugamasao" width="42"></a>
 <p class="linkMark">
 <a href="http://d.hatena.ne.jp/seiunsky">sugamasao</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://d.hatena.ne.jp/mkgin/"><img alt="Makoto Kouno" height="42" src="http://www.gravatar.com/avatar/06e6dcde277cbe5c614baf5d25871025?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Makoto Kouno" width="42"></a>
+<a href="http://d.hatena.ne.jp/mkgin/"><img alt="Makoto Kouno" height="42" src="https://www.gravatar.com/avatar/06e6dcde277cbe5c614baf5d25871025?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Makoto Kouno" width="42"></a>
 <p class="linkMark">
 <a href="http://d.hatena.ne.jp/mkgin/">Makoto Kouno</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://twitter.com/suzuki"><img alt="Norio Suzuki" height="42" src="http://www.gravatar.com/avatar/8e528456ff66ec543952daa815353a01?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Norio Suzuki" width="42"></a>
+<a href="http://twitter.com/suzuki"><img alt="Norio Suzuki" height="42" src="https://www.gravatar.com/avatar/8e528456ff66ec543952daa815353a01?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Norio Suzuki" width="42"></a>
 <p class="linkMark">
 <a href="http://twitter.com/suzuki">Norio Suzuki</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://www.artonx.org"><img alt="Akio Tajima" height="42" src="http://www.gravatar.com/avatar/0441ff038018e53a35bb207e81105a5c?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Akio Tajima" width="42"></a>
+<a href="http://www.artonx.org"><img alt="Akio Tajima" height="42" src="https://www.gravatar.com/avatar/0441ff038018e53a35bb207e81105a5c?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Akio Tajima" width="42"></a>
 <p class="linkMark">
 <a href="http://www.artonx.org">Akio Tajima</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://moonrock.jp/~don/"><img alt="Hiroyuki Iwatsuki" height="42" src="http://www.gravatar.com/avatar/cb1f0f80c3fe2729ba593656772c266d?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hiroyuki Iwatsuki" width="42"></a>
+<a href="http://moonrock.jp/~don/"><img alt="Hiroyuki Iwatsuki" height="42" src="https://www.gravatar.com/avatar/cb1f0f80c3fe2729ba593656772c266d?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hiroyuki Iwatsuki" width="42"></a>
 <p class="linkMark">
 <a href="http://moonrock.jp/~don/">Hiroyuki Iwatsuki</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://d.hatena.ne.jp/monyakata/"><img alt="MUNAKATA Akiko" height="42" src="http://www.gravatar.com/avatar/55a6db4b079c962f72adb014055e9a28?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MUNAKATA Akiko" width="42"></a>
+<a href="http://d.hatena.ne.jp/monyakata/"><img alt="MUNAKATA Akiko" height="42" src="https://www.gravatar.com/avatar/55a6db4b079c962f72adb014055e9a28?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MUNAKATA Akiko" width="42"></a>
 <p class="linkMark">
 <a href="http://d.hatena.ne.jp/monyakata/">MUNAKATA Akiko</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://www.bawdo.com"><img alt="Keith Bawden" height="42" src="http://www.gravatar.com/avatar/a6cc567a6b77ee09f7363d175455593b?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Keith Bawden" width="42"></a>
+<a href="http://www.bawdo.com"><img alt="Keith Bawden" height="42" src="https://www.gravatar.com/avatar/a6cc567a6b77ee09f7363d175455593b?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Keith Bawden" width="42"></a>
 <p class="linkMark">
 <a href="http://www.bawdo.com">Keith Bawden</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<img alt="Norihito Yoshioka" height="42" src="http://www.gravatar.com/avatar/c6033734a5b01f43cca06773ea9ff1fe?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Norihito Yoshioka" width="42">
+<img alt="Norihito Yoshioka" height="42" src="https://www.gravatar.com/avatar/c6033734a5b01f43cca06773ea9ff1fe?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Norihito Yoshioka" width="42">
 <p>
 Norihito Yoshioka
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://d.hatena.ne.jp/vestige/"><img alt="makoto yonezawa" height="42" src="http://www.gravatar.com/avatar/8da7ceb361c63bd6622fe33153a0293b?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="makoto yonezawa" width="42"></a>
+<a href="http://d.hatena.ne.jp/vestige/"><img alt="makoto yonezawa" height="42" src="https://www.gravatar.com/avatar/8da7ceb361c63bd6622fe33153a0293b?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="makoto yonezawa" width="42"></a>
 <p class="linkMark">
 <a href="http://d.hatena.ne.jp/vestige/">makoto yonezawa</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="https://twitter.com/tsuboi"><img alt="Sougo TSUBOI" height="42" src="http://www.gravatar.com/avatar/847bf4e3766b2e17cafef8e83b046db1?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Sougo TSUBOI" width="42"></a>
+<a href="https://twitter.com/tsuboi"><img alt="Sougo TSUBOI" height="42" src="https://www.gravatar.com/avatar/847bf4e3766b2e17cafef8e83b046db1?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Sougo TSUBOI" width="42"></a>
 <p class="linkMark">
 <a href="https://twitter.com/tsuboi">Sougo TSUBOI</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://twitter.com/#!/mojamoja_mixi"><img alt="MojaMoja" height="42" src="http://www.gravatar.com/avatar/7b0d6fc806322376d65cbb95d40bc176?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MojaMoja" width="42"></a>
+<a href="http://twitter.com/#!/mojamoja_mixi"><img alt="MojaMoja" height="42" src="https://www.gravatar.com/avatar/7b0d6fc806322376d65cbb95d40bc176?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MojaMoja" width="42"></a>
 <p class="linkMark">
 <a href="http://twitter.com/#!/mojamoja_mixi">MojaMoja</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://twitter.com/takkanm"><img alt="mitsutaka mimura" height="42" src="http://www.gravatar.com/avatar/8f39a252784d5a99589be6e20c4553fb?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="mitsutaka mimura" width="42"></a>
+<a href="http://twitter.com/takkanm"><img alt="mitsutaka mimura" height="42" src="https://www.gravatar.com/avatar/8f39a252784d5a99589be6e20c4553fb?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="mitsutaka mimura" width="42"></a>
 <p class="linkMark">
 <a href="http://twitter.com/takkanm">mitsutaka mimura</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://twitter.com/dan5ya"><img alt="Dan Yamamoto" height="42" src="http://www.gravatar.com/avatar/ffaa5dad365d5bb5025f4126bb54676c?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Dan Yamamoto" width="42"></a>
+<a href="http://twitter.com/dan5ya"><img alt="Dan Yamamoto" height="42" src="https://www.gravatar.com/avatar/ffaa5dad365d5bb5025f4126bb54676c?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Dan Yamamoto" width="42"></a>
 <p class="linkMark">
 <a href="http://twitter.com/dan5ya">Dan Yamamoto</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://www.hsbt.org/"><img alt="SHIBATA Hiroshi" height="42" src="http://www.gravatar.com/avatar/eabad423977cfc6873b8f5df62b848a6?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="SHIBATA Hiroshi" width="42"></a>
+<a href="http://www.hsbt.org/"><img alt="SHIBATA Hiroshi" height="42" src="https://www.gravatar.com/avatar/eabad423977cfc6873b8f5df62b848a6?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="SHIBATA Hiroshi" width="42"></a>
 <p class="linkMark">
 <a href="http://www.hsbt.org/">SHIBATA Hiroshi</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://d.hatena.ne.jp/moro/"><img alt="MOROHASHI Kyosuke" height="42" src="http://www.gravatar.com/avatar/70e13d9877054026fda46d5a5b53a236?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MOROHASHI Kyosuke" width="42"></a>
+<a href="http://d.hatena.ne.jp/moro/"><img alt="MOROHASHI Kyosuke" height="42" src="https://www.gravatar.com/avatar/70e13d9877054026fda46d5a5b53a236?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="MOROHASHI Kyosuke" width="42"></a>
 <p class="linkMark">
 <a href="http://d.hatena.ne.jp/moro/">MOROHASHI Kyosuke</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://rsss.be/hibariya"><img alt="Hibariya Hi" height="42" src="http://www.gravatar.com/avatar/de0df5acda15a9c7eeb6c28a5e5d4e8e?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hibariya Hi" width="42"></a>
+<a href="http://rsss.be/hibariya"><img alt="Hibariya Hi" height="42" src="https://www.gravatar.com/avatar/de0df5acda15a9c7eeb6c28a5e5d4e8e?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hibariya Hi" width="42"></a>
 <p class="linkMark">
 <a href="http://rsss.be/hibariya">Hibariya Hi</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://twitter.com/kyanny"><img alt="Kensuke Nagae" height="42" src="http://www.gravatar.com/avatar/fffd8bf62b842a46803fb07792029fa4?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kensuke Nagae" width="42"></a>
+<a href="http://twitter.com/kyanny"><img alt="Kensuke Nagae" height="42" src="https://www.gravatar.com/avatar/fffd8bf62b842a46803fb07792029fa4?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kensuke Nagae" width="42"></a>
 <p class="linkMark">
 <a href="http://twitter.com/kyanny">Kensuke Nagae</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<img alt="oku23" height="42" src="http://www.gravatar.com/avatar/3725ec1dce281fb187d798a9b9ddc9d3?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="oku23" width="42">
+<img alt="oku23" height="42" src="https://www.gravatar.com/avatar/3725ec1dce281fb187d798a9b9ddc9d3?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="oku23" width="42">
 <p>
 oku23
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://ko.meadowy.net/~koichiro/diary/"><img alt="Koichiro Ohba" height="42" src="http://www.gravatar.com/avatar/1ce18b10bd8f911566c5577042b6a44c?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Koichiro Ohba" width="42"></a>
+<a href="http://ko.meadowy.net/~koichiro/diary/"><img alt="Koichiro Ohba" height="42" src="https://www.gravatar.com/avatar/1ce18b10bd8f911566c5577042b6a44c?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Koichiro Ohba" width="42"></a>
 <p class="linkMark">
 <a href="http://ko.meadowy.net/~koichiro/diary/">Koichiro Ohba</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://www.flickr.com/photos/t-seto"><img alt="せとん" height="42" src="http://www.gravatar.com/avatar/ac007a5b84f817d8cc80a3c208ea0181?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="せとん" width="42"></a>
+<a href="http://www.flickr.com/photos/t-seto"><img alt="せとん" height="42" src="https://www.gravatar.com/avatar/ac007a5b84f817d8cc80a3c208ea0181?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="せとん" width="42"></a>
 <p class="linkMark">
 <a href="http://www.flickr.com/photos/t-seto">せとん</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://twitter.com/#!/tsuyoshikawa"><img alt="Tsuyoshi Yoshikawa" height="42" src="http://www.gravatar.com/avatar/6969ade78c1eaff0d08c76020fc80e83?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tsuyoshi Yoshikawa" width="42"></a>
+<a href="http://twitter.com/#!/tsuyoshikawa"><img alt="Tsuyoshi Yoshikawa" height="42" src="https://www.gravatar.com/avatar/6969ade78c1eaff0d08c76020fc80e83?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tsuyoshi Yoshikawa" width="42"></a>
 <p class="linkMark">
 <a href="http://twitter.com/#!/tsuyoshikawa">Tsuyoshi Yoshikawa</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://www.water-lily.biz/"><img alt="Water Lily LLC" height="42" src="http://www.gravatar.com/avatar/0734b8ec5eed71892e5db432856f4f40?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Water Lily LLC" width="42"></a>
+<a href="http://www.water-lily.biz/"><img alt="Water Lily LLC" height="42" src="https://www.gravatar.com/avatar/0734b8ec5eed71892e5db432856f4f40?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Water Lily LLC" width="42"></a>
 <p class="linkMark">
 <a href="http://www.water-lily.biz/">Water Lily LLC</a>
 </p>
@@ -649,168 +649,168 @@ oku23
 </div>
 <hr>
 <div class="avatar">
-<a href="http://web-engineer.buyuden.net/blog/kawai/"><img alt="Takeshi Kawai" height="42" src="http://www.gravatar.com/avatar/6b53e472c9200f5ed61d7a6db0a28986?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takeshi Kawai" width="42"></a>
+<a href="http://web-engineer.buyuden.net/blog/kawai/"><img alt="Takeshi Kawai" height="42" src="https://www.gravatar.com/avatar/6b53e472c9200f5ed61d7a6db0a28986?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takeshi Kawai" width="42"></a>
 <p class="linkMark">
 <a href="http://web-engineer.buyuden.net/blog/kawai/">Takeshi Kawai</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://d.hatena.ne.jp/k3c/"><img alt="KANEKO Seiji" height="42" src="http://www.gravatar.com/avatar/63d3818b5c107a6483a1d2e2767be4c5?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="KANEKO Seiji" width="42"></a>
+<a href="http://d.hatena.ne.jp/k3c/"><img alt="KANEKO Seiji" height="42" src="https://www.gravatar.com/avatar/63d3818b5c107a6483a1d2e2767be4c5?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="KANEKO Seiji" width="42"></a>
 <p class="linkMark">
 <a href="http://d.hatena.ne.jp/k3c/">KANEKO Seiji</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://www.famlog.jp/"><img alt="Atsushi Matsuo" height="42" src="http://www.gravatar.com/avatar/0a4da00dbfd37e7f06ef8dceb58ca0c1?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Atsushi Matsuo" width="42"></a>
+<a href="http://www.famlog.jp/"><img alt="Atsushi Matsuo" height="42" src="https://www.gravatar.com/avatar/0a4da00dbfd37e7f06ef8dceb58ca0c1?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Atsushi Matsuo" width="42"></a>
 <p class="linkMark">
 <a href="http://www.famlog.jp/">Atsushi Matsuo</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://m.igrs.jp/"><img alt="Masato Igarashi" height="42" src="http://www.gravatar.com/avatar/6fd2e23d73c26ccbd7df9e3eefacd3ae?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masato Igarashi" width="42"></a>
+<a href="http://m.igrs.jp/"><img alt="Masato Igarashi" height="42" src="https://www.gravatar.com/avatar/6fd2e23d73c26ccbd7df9e3eefacd3ae?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masato Igarashi" width="42"></a>
 <p class="linkMark">
 <a href="http://m.igrs.jp/">Masato Igarashi</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://resume.github.com/?walf443"><img alt="Keiji Yoshimi" height="42" src="http://www.gravatar.com/avatar/dea4fe079aec284744ad02eb3d2594f5?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Keiji Yoshimi" width="42"></a>
+<a href="http://resume.github.com/?walf443"><img alt="Keiji Yoshimi" height="42" src="https://www.gravatar.com/avatar/dea4fe079aec284744ad02eb3d2594f5?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Keiji Yoshimi" width="42"></a>
 <p class="linkMark">
 <a href="http://resume.github.com/?walf443">Keiji Yoshimi</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://gunjisatoshi.appspot.com/"><img alt="GUNJI Satoshi" height="42" src="http://www.gravatar.com/avatar/e6980e09fdff8f481b70f2e1f241231d?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="GUNJI Satoshi" width="42"></a>
+<a href="http://gunjisatoshi.appspot.com/"><img alt="GUNJI Satoshi" height="42" src="https://www.gravatar.com/avatar/e6980e09fdff8f481b70f2e1f241231d?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="GUNJI Satoshi" width="42"></a>
 <p class="linkMark">
 <a href="http://gunjisatoshi.appspot.com/">GUNJI Satoshi</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<img alt="Hisashi Yamaeda" height="42" src="http://www.gravatar.com/avatar/01ca4ebeee47c9b4d6ba9ad58db694a0?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hisashi Yamaeda" width="42">
+<img alt="Hisashi Yamaeda" height="42" src="https://www.gravatar.com/avatar/01ca4ebeee47c9b4d6ba9ad58db694a0?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Hisashi Yamaeda" width="42">
 <p>
 Hisashi Yamaeda
 </p>
 </div>
 <hr>
 <div class="avatar">
-<img alt="gekidanyonin" height="42" src="http://www.gravatar.com/avatar/2b196f1723fdbcbf7bd297b3e7f8cd3c?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="gekidanyonin" width="42">
+<img alt="gekidanyonin" height="42" src="https://www.gravatar.com/avatar/2b196f1723fdbcbf7bd297b3e7f8cd3c?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="gekidanyonin" width="42">
 <p>
 gekidanyonin
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://jp.linkedin.com/in/nakaomitsuteru"><img alt="Mitsuteru Nakao" height="42" src="http://www.gravatar.com/avatar/9090e122cba40b90124ea8eb4859bf8e?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Mitsuteru Nakao" width="42"></a>
+<a href="http://jp.linkedin.com/in/nakaomitsuteru"><img alt="Mitsuteru Nakao" height="42" src="https://www.gravatar.com/avatar/9090e122cba40b90124ea8eb4859bf8e?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Mitsuteru Nakao" width="42"></a>
 <p class="linkMark">
 <a href="http://jp.linkedin.com/in/nakaomitsuteru">Mitsuteru Nakao</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://zaki.asia"><img alt="Dezso Zoltan" height="42" src="http://www.gravatar.com/avatar/a771de8e1e49a9da61e2a602a2af42bc?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Dezso Zoltan" width="42"></a>
+<a href="http://zaki.asia"><img alt="Dezso Zoltan" height="42" src="https://www.gravatar.com/avatar/a771de8e1e49a9da61e2a602a2af42bc?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Dezso Zoltan" width="42"></a>
 <p class="linkMark">
 <a href="http://zaki.asia">Dezso Zoltan</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://www.twitter.com/ope"><img alt="Takanori Nakanowatari" height="42" src="http://www.gravatar.com/avatar/55bcf6eb5de45a70e76f8a2678822ecb?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takanori Nakanowatari" width="42"></a>
+<a href="http://www.twitter.com/ope"><img alt="Takanori Nakanowatari" height="42" src="https://www.gravatar.com/avatar/55bcf6eb5de45a70e76f8a2678822ecb?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Takanori Nakanowatari" width="42"></a>
 <p class="linkMark">
 <a href="http://www.twitter.com/ope">Takanori Nakanowatari</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="https://github.com/zev"><img alt="Zev Blut" height="42" src="http://www.gravatar.com/avatar/1c77ad9f35746369dd1f4dd69b9f8b18?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Zev Blut" width="42"></a>
+<a href="https://github.com/zev"><img alt="Zev Blut" height="42" src="https://www.gravatar.com/avatar/1c77ad9f35746369dd1f4dd69b9f8b18?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Zev Blut" width="42"></a>
 <p class="linkMark">
 <a href="https://github.com/zev">Zev Blut</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://tako3.com/http://rubykaigi.org/rubyists/kei-s"><img alt="kei-s" height="42" src="http://www.gravatar.com/avatar/bf7ce9b68bbb0058721906b4db15b9b5?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="kei-s" width="42"></a>
+<a href="http://tako3.com/http://rubykaigi.org/rubyists/kei-s"><img alt="kei-s" height="42" src="https://www.gravatar.com/avatar/bf7ce9b68bbb0058721906b4db15b9b5?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="kei-s" width="42"></a>
 <p class="linkMark">
 <a href="http://tako3.com/http://rubykaigi.org/rubyists/kei-s">kei-s</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://twitter.com/bobbyjam99"><img alt="Tomokazu IMAI" height="42" src="http://www.gravatar.com/avatar/33814e72445b35ad3b65b1b05e699adc?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomokazu IMAI" width="42"></a>
+<a href="http://twitter.com/bobbyjam99"><img alt="Tomokazu IMAI" height="42" src="https://www.gravatar.com/avatar/33814e72445b35ad3b65b1b05e699adc?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomokazu IMAI" width="42"></a>
 <p class="linkMark">
 <a href="http://twitter.com/bobbyjam99">Tomokazu IMAI</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://twitter.com/hasimo"><img alt="Tohru Hashimoto" height="42" src="http://www.gravatar.com/avatar/6e3d1578114e5d3951a7f90579fff74c?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tohru Hashimoto" width="42"></a>
+<a href="http://twitter.com/hasimo"><img alt="Tohru Hashimoto" height="42" src="https://www.gravatar.com/avatar/6e3d1578114e5d3951a7f90579fff74c?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tohru Hashimoto" width="42"></a>
 <p class="linkMark">
 <a href="http://twitter.com/hasimo">Tohru Hashimoto</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://www.mobalean.com/founders/michael"><img alt="Michael Reinsch" height="42" src="http://www.gravatar.com/avatar/c7915a424cbb28fdd6c1cce270be6b58?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Michael Reinsch" width="42"></a>
+<a href="http://www.mobalean.com/founders/michael"><img alt="Michael Reinsch" height="42" src="https://www.gravatar.com/avatar/c7915a424cbb28fdd6c1cce270be6b58?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Michael Reinsch" width="42"></a>
 <p class="linkMark">
 <a href="http://www.mobalean.com/founders/michael">Michael Reinsch</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://twitter.com/sandinist"><img alt="Tsuyoshi MAEHANA" height="42" src="http://www.gravatar.com/avatar/e8ebe7d4ec09c5dd77ee064706836f23?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tsuyoshi MAEHANA" width="42"></a>
+<a href="http://twitter.com/sandinist"><img alt="Tsuyoshi MAEHANA" height="42" src="https://www.gravatar.com/avatar/e8ebe7d4ec09c5dd77ee064706836f23?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tsuyoshi MAEHANA" width="42"></a>
 <p class="linkMark">
 <a href="http://twitter.com/sandinist">Tsuyoshi MAEHANA</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://sane.jp"><img alt="Murahashi Sanemat Kenichi" height="42" src="http://www.gravatar.com/avatar/5b1d016f87f05ff645ae572ccbbf0448?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Murahashi Sanemat Kenichi" width="42"></a>
+<a href="http://sane.jp"><img alt="Murahashi Sanemat Kenichi" height="42" src="https://www.gravatar.com/avatar/5b1d016f87f05ff645ae572ccbbf0448?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Murahashi Sanemat Kenichi" width="42"></a>
 <p class="linkMark">
 <a href="http://sane.jp">Murahashi Sanemat Kenichi</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://aerial.st"><img alt="Masato Ikeda" height="42" src="http://www.gravatar.com/avatar/03abf5741b7bbd28670af5ec92b6141d?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masato Ikeda" width="42"></a>
+<a href="http://aerial.st"><img alt="Masato Ikeda" height="42" src="https://www.gravatar.com/avatar/03abf5741b7bbd28670af5ec92b6141d?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masato Ikeda" width="42"></a>
 <p class="linkMark">
 <a href="http://aerial.st">Masato Ikeda</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://twitter.com/tex314"><img alt="OKAZAKI Takurou" height="42" src="http://www.gravatar.com/avatar/45c2cc1a731924edf1045d9146ca4a78?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="OKAZAKI Takurou" width="42"></a>
+<a href="http://twitter.com/tex314"><img alt="OKAZAKI Takurou" height="42" src="https://www.gravatar.com/avatar/45c2cc1a731924edf1045d9146ca4a78?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="OKAZAKI Takurou" width="42"></a>
 <p class="linkMark">
 <a href="http://twitter.com/tex314">OKAZAKI Takurou</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="https://twitter.com/toshi3221"><img alt="Toshiharu Takematsu" height="42" src="http://www.gravatar.com/avatar/3ca4621fbbb03278d4550f89e2f723ba?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Toshiharu Takematsu" width="42"></a>
+<a href="https://twitter.com/toshi3221"><img alt="Toshiharu Takematsu" height="42" src="https://www.gravatar.com/avatar/3ca4621fbbb03278d4550f89e2f723ba?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Toshiharu Takematsu" width="42"></a>
 <p class="linkMark">
 <a href="https://twitter.com/toshi3221">Toshiharu Takematsu</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://tdtds.jp"><img alt="TADA Tadashi" height="42" src="http://www.gravatar.com/avatar/846a80b9bf7ea7becb6c4ecd67bedd6f?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TADA Tadashi" width="42"></a>
+<a href="http://tdtds.jp"><img alt="TADA Tadashi" height="42" src="https://www.gravatar.com/avatar/846a80b9bf7ea7becb6c4ecd67bedd6f?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TADA Tadashi" width="42"></a>
 <p class="linkMark">
 <a href="http://tdtds.jp">TADA Tadashi</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://hisano.com"><img alt="HISANO Kozo" height="42" src="http://www.gravatar.com/avatar/b8fa07639c3b720c33ffdcaf89299dda?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="HISANO Kozo" width="42"></a>
+<a href="http://hisano.com"><img alt="HISANO Kozo" height="42" src="https://www.gravatar.com/avatar/b8fa07639c3b720c33ffdcaf89299dda?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="HISANO Kozo" width="42"></a>
 <p class="linkMark">
 <a href="http://hisano.com">HISANO Kozo</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://d.hatena.ne.jp/kouma31/"><img alt="kmuroi" height="42" src="http://www.gravatar.com/avatar/165599097b8533c91af2aad5d7b31449?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="kmuroi" width="42"></a>
+<a href="http://d.hatena.ne.jp/kouma31/"><img alt="kmuroi" height="42" src="https://www.gravatar.com/avatar/165599097b8533c91af2aad5d7b31449?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="kmuroi" width="42"></a>
 <p class="linkMark">
 <a href="http://d.hatena.ne.jp/kouma31/">kmuroi</a>
 </p>
@@ -824,21 +824,21 @@ Anonymous
 </div>
 <hr>
 <div class="avatar">
-<a href="http://twitter.com/h4n"><img alt="Han Kessels" height="42" src="http://www.gravatar.com/avatar/f0bd4ed83708d0af0e0d1374fc7e605b?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Han Kessels" width="42"></a>
+<a href="http://twitter.com/h4n"><img alt="Han Kessels" height="42" src="https://www.gravatar.com/avatar/f0bd4ed83708d0af0e0d1374fc7e605b?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Han Kessels" width="42"></a>
 <p class="linkMark">
 <a href="http://twitter.com/h4n">Han Kessels</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://twitter.com/takagi"><img alt="TAKAGI Masahiro" height="42" src="http://www.gravatar.com/avatar/c3f5a6e729b57f99cb9e7b3ca60152aa?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TAKAGI Masahiro" width="42"></a>
+<a href="http://twitter.com/takagi"><img alt="TAKAGI Masahiro" height="42" src="https://www.gravatar.com/avatar/c3f5a6e729b57f99cb9e7b3ca60152aa?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TAKAGI Masahiro" width="42"></a>
 <p class="linkMark">
 <a href="http://twitter.com/takagi">TAKAGI Masahiro</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://d.hatena.ne.jp/tmtms/"><img alt="TOMITA Masahiro" height="42" src="http://www.gravatar.com/avatar/e4763acee4cf0377437f614fc372a061?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TOMITA Masahiro" width="42"></a>
+<a href="http://d.hatena.ne.jp/tmtms/"><img alt="TOMITA Masahiro" height="42" src="https://www.gravatar.com/avatar/e4763acee4cf0377437f614fc372a061?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TOMITA Masahiro" width="42"></a>
 <p class="linkMark">
 <a href="http://d.hatena.ne.jp/tmtms/">TOMITA Masahiro</a>
 </p>
@@ -852,133 +852,133 @@ Anonymous
 </div>
 <hr>
 <div class="avatar">
-<a href="http://kmuto.jp/"><img alt="Kenshi Muto" height="42" src="http://www.gravatar.com/avatar/43d44fbc12adcf80c9fc24e235f48234?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kenshi Muto" width="42"></a>
+<a href="http://kmuto.jp/"><img alt="Kenshi Muto" height="42" src="https://www.gravatar.com/avatar/43d44fbc12adcf80c9fc24e235f48234?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Kenshi Muto" width="42"></a>
 <p class="linkMark">
 <a href="http://kmuto.jp/">Kenshi Muto</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<img alt="1syo" height="42" src="http://www.gravatar.com/avatar/83899fe2d00874176098a3bb71b043be?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="1syo" width="42">
+<img alt="1syo" height="42" src="https://www.gravatar.com/avatar/83899fe2d00874176098a3bb71b043be?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="1syo" width="42">
 <p>
 1syo
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://fkino.net"><img alt="Fumihiko Kinoshita" height="42" src="http://www.gravatar.com/avatar/f301c0275838d562c72ea9177e7ddc68?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Fumihiko Kinoshita" width="42"></a>
+<a href="http://fkino.net"><img alt="Fumihiko Kinoshita" height="42" src="https://www.gravatar.com/avatar/f301c0275838d562c72ea9177e7ddc68?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Fumihiko Kinoshita" width="42"></a>
 <p class="linkMark">
 <a href="http://fkino.net">Fumihiko Kinoshita</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://blog.masuidrive.jp/"><img alt="Yuichiro MASUI" height="42" src="http://www.gravatar.com/avatar/0ec58a040e1e4e959c8566484b4bba19?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yuichiro MASUI" width="42"></a>
+<a href="http://blog.masuidrive.jp/"><img alt="Yuichiro MASUI" height="42" src="https://www.gravatar.com/avatar/0ec58a040e1e4e959c8566484b4bba19?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Yuichiro MASUI" width="42"></a>
 <p class="linkMark">
 <a href="http://blog.masuidrive.jp/">Yuichiro MASUI</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://d.hatena.ne.jp/t2os/"><img alt="tatsuoSakurai" height="42" src="http://www.gravatar.com/avatar/092404bdf9897eba9ab16e61f56592db?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="tatsuoSakurai" width="42"></a>
+<a href="http://d.hatena.ne.jp/t2os/"><img alt="tatsuoSakurai" height="42" src="https://www.gravatar.com/avatar/092404bdf9897eba9ab16e61f56592db?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="tatsuoSakurai" width="42"></a>
 <p class="linkMark">
 <a href="http://d.hatena.ne.jp/t2os/">tatsuoSakurai</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://ogijun.org"><img alt="Junya Ogino" height="42" src="http://www.gravatar.com/avatar/3a82321f68500d9691a9e190979ac2f0?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Junya Ogino" width="42"></a>
+<a href="http://ogijun.org"><img alt="Junya Ogino" height="42" src="https://www.gravatar.com/avatar/3a82321f68500d9691a9e190979ac2f0?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Junya Ogino" width="42"></a>
 <p class="linkMark">
 <a href="http://ogijun.org">Junya Ogino</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://about.me/mackato"><img alt="Masakuni Kato" height="42" src="http://www.gravatar.com/avatar/28347314c7fc698b4ac0e01113545e25?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masakuni Kato" width="42"></a>
+<a href="http://about.me/mackato"><img alt="Masakuni Kato" height="42" src="https://www.gravatar.com/avatar/28347314c7fc698b4ac0e01113545e25?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masakuni Kato" width="42"></a>
 <p class="linkMark">
 <a href="http://about.me/mackato">Masakuni Kato</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://d.hatena.ne.jp/IWAKIRI"><img alt="IWAKIRI,Akiko" height="42" src="http://www.gravatar.com/avatar/2a02258781c7592d0da1cd5cffa627a8?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="IWAKIRI,Akiko" width="42"></a>
+<a href="http://d.hatena.ne.jp/IWAKIRI"><img alt="IWAKIRI,Akiko" height="42" src="https://www.gravatar.com/avatar/2a02258781c7592d0da1cd5cffa627a8?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="IWAKIRI,Akiko" width="42"></a>
 <p class="linkMark">
 <a href="http://d.hatena.ne.jp/IWAKIRI">IWAKIRI,Akiko</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://june29.jp/"><img alt="june29" height="42" src="http://www.gravatar.com/avatar/6fd9be5cd0196df5ad62a5a5f2be3c55?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="june29" width="42"></a>
+<a href="http://june29.jp/"><img alt="june29" height="42" src="https://www.gravatar.com/avatar/6fd9be5cd0196df5ad62a5a5f2be3c55?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="june29" width="42"></a>
 <p class="linkMark">
 <a href="http://june29.jp/">june29</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://www.socialtoprunners.jp/"><img alt="tomokazuhattanda" height="42" src="http://www.gravatar.com/avatar/19798587cb27b5220a5dcdbaa9a50d57?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="tomokazuhattanda" width="42"></a>
+<a href="http://www.socialtoprunners.jp/"><img alt="tomokazuhattanda" height="42" src="https://www.gravatar.com/avatar/19798587cb27b5220a5dcdbaa9a50d57?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="tomokazuhattanda" width="42"></a>
 <p class="linkMark">
 <a href="http://www.socialtoprunners.jp/">tomokazuhattanda</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://www.jamboree.jp/"><img alt="TOYOSHI, Ryuichiro" height="42" src="http://www.gravatar.com/avatar/203c324392b6c51241da5b42bbf888bd?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TOYOSHI, Ryuichiro" width="42"></a>
+<a href="http://www.jamboree.jp/"><img alt="TOYOSHI, Ryuichiro" height="42" src="https://www.gravatar.com/avatar/203c324392b6c51241da5b42bbf888bd?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="TOYOSHI, Ryuichiro" width="42"></a>
 <p class="linkMark">
 <a href="http://www.jamboree.jp/">TOYOSHI, Ryuichiro</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://twitter.com/takano32"><img alt="たかのみつひろ" height="42" src="http://www.gravatar.com/avatar/eba4a40bdae5edfe1589601c050a2b96?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="たかのみつひろ" width="42"></a>
+<a href="http://twitter.com/takano32"><img alt="たかのみつひろ" height="42" src="https://www.gravatar.com/avatar/eba4a40bdae5edfe1589601c050a2b96?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="たかのみつひろ" width="42"></a>
 <p class="linkMark">
 <a href="http://twitter.com/takano32">たかのみつひろ</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://twitter.com/tyabe"><img alt="tyabe" height="42" src="http://www.gravatar.com/avatar/d21900444f5548d9329861593321b5a6?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="tyabe" width="42"></a>
+<a href="http://twitter.com/tyabe"><img alt="tyabe" height="42" src="https://www.gravatar.com/avatar/d21900444f5548d9329861593321b5a6?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="tyabe" width="42"></a>
 <p class="linkMark">
 <a href="http://twitter.com/tyabe">tyabe</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://twitter.com/#!/maxyz"><img alt="Masafumi Fujiwara" height="42" src="http://www.gravatar.com/avatar/4dd4d13d27559db2fb64ad069f2c49ba?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masafumi Fujiwara" width="42"></a>
+<a href="http://twitter.com/#!/maxyz"><img alt="Masafumi Fujiwara" height="42" src="https://www.gravatar.com/avatar/4dd4d13d27559db2fb64ad069f2c49ba?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masafumi Fujiwara" width="42"></a>
 <p class="linkMark">
 <a href="http://twitter.com/#!/maxyz">Masafumi Fujiwara</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://twitter.com/kdmsnr"><img alt="Masanori Kado" height="42" src="http://www.gravatar.com/avatar/70b07e6b7fe7d921d7ac542d0ccb3b2c?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masanori Kado" width="42"></a>
+<a href="http://twitter.com/kdmsnr"><img alt="Masanori Kado" height="42" src="https://www.gravatar.com/avatar/70b07e6b7fe7d921d7ac542d0ccb3b2c?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Masanori Kado" width="42"></a>
 <p class="linkMark">
 <a href="http://twitter.com/kdmsnr">Masanori Kado</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://www.jitu.org/~tko"><img alt="Tomoyuki Kosimizu" height="42" src="http://www.gravatar.com/avatar/3585181753c22a9531e70a8297771b01?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomoyuki Kosimizu" width="42"></a>
+<a href="http://www.jitu.org/~tko"><img alt="Tomoyuki Kosimizu" height="42" src="https://www.gravatar.com/avatar/3585181753c22a9531e70a8297771b01?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomoyuki Kosimizu" width="42"></a>
 <p class="linkMark">
 <a href="http://www.jitu.org/~tko">Tomoyuki Kosimizu</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://twitter.com/chinmo"><img alt="Tomonori Fukuta" height="42" src="http://www.gravatar.com/avatar/7977a0896e60587b2690550891be2ea7?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomonori Fukuta" width="42"></a>
+<a href="http://twitter.com/chinmo"><img alt="Tomonori Fukuta" height="42" src="https://www.gravatar.com/avatar/7977a0896e60587b2690550891be2ea7?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Tomonori Fukuta" width="42"></a>
 <p class="linkMark">
 <a href="http://twitter.com/chinmo">Tomonori Fukuta</a>
 </p>
 </div>
 <hr>
 <div class="avatar">
-<img alt="YOKOTA Akiko" height="42" src="http://www.gravatar.com/avatar/03e548747e667fc94cc8495868bfd85e?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="YOKOTA Akiko" width="42">
+<img alt="YOKOTA Akiko" height="42" src="https://www.gravatar.com/avatar/03e548747e667fc94cc8495868bfd85e?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="YOKOTA Akiko" width="42">
 <p>
 YOKOTA Akiko
 </p>
 </div>
 <hr>
 <div class="avatar">
-<a href="http://nov.tdiary.net/"><img alt="Nobuhiro IMAI" height="42" src="http://www.gravatar.com/avatar/e49ab9f0774711c473660019728cde95?s=42&amp;d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Nobuhiro IMAI" width="42"></a>
+<a href="http://nov.tdiary.net/"><img alt="Nobuhiro IMAI" height="42" src="https://www.gravatar.com/avatar/e49ab9f0774711c473660019728cde95?s=42&amp;d=https%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png" title="Nobuhiro IMAI" width="42"></a>
 <p class="linkMark">
 <a href="http://nov.tdiary.net/">Nobuhiro IMAI</a>
 </p>

--- a/2011/ja/team/index.html
+++ b/2011/ja/team/index.html
@@ -91,7 +91,7 @@
 <div class="section">
 <h2>実行委員長</h2>
 <div class="avatar">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/21a4b941766d805333e11c5766be43b4?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/21a4b941766d805333e11c5766be43b4?s=32" width="32">
 <p>
 <span class="name">高橋征義</span>
 <span class="affiliation">日本Rubyの会会長, 達人出版会</span>
@@ -101,7 +101,7 @@
 <div class="section">
 <h2>副実行委員長</h2>
 <div class="avatar">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/63a6bff89d692e21de20868202bc8dde?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/63a6bff89d692e21de20868202bc8dde?s=32" width="32">
 <p>
 <span class="name">角谷信太郎</span>
 <span class="affiliation">日本Rubyの会 || (株)永和システムマネジメント</span>
@@ -111,7 +111,7 @@
 <div class="section">
 <h2>運営委員長</h2>
 <div class="avatar">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/941b170e5a115a295cccb5f5cdf0a800?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/941b170e5a115a295cccb5f5cdf0a800?s=32" width="32">
 <p>
 <span class="name">島田浩二</span>
 <span class="affiliation">日本Rubyの会, 株式会社えにしテック</span>
@@ -131,7 +131,7 @@
 <div class="section">
 <h2>スポンサー渉外担当</h2>
 <div class="avatar">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/2e9a2dbe335e0111e4879a9d65dcbae0?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/2e9a2dbe335e0111e4879a9d65dcbae0?s=32" width="32">
 <p>
 <span class="name">相澤歩</span>
 <span class="affiliation">日本Rubyの会, Akasaka.rb</span>
@@ -148,42 +148,42 @@
 <div class="section">
 <h2>実行委員</h2>
 <div class="avatar">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/254df3f07b068f422ef943dc1a2d7e04?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/254df3f07b068f422ef943dc1a2d7e04?s=32" width="32">
 <p>
 <span class="name">あづみしんや</span>
 <span class="affiliation">日本Rubyの会, テクノバン株式会社</span>
 </p>
 </div>
 <div class="avatar">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/f37b9a968b2326062190677906a93080?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/f37b9a968b2326062190677906a93080?s=32" width="32">
 <p>
 <span class="name">すずきみほ</span>
 <span class="affiliation">@adzuki34</span>
 </p>
 </div>
 <div class="avatar">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/70762059db0218c6f0ff48042ca0756a?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/70762059db0218c6f0ff48042ca0756a?s=32" width="32">
 <p>
 <span class="name">レオ</span>
 <span class="affiliation">日本Rubyの会 || 株式会社ドワンゴ</span>
 </p>
 </div>
 <div class="avatar">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/817b7699ccbd3a6664de66eee8c2cbd2?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/817b7699ccbd3a6664de66eee8c2cbd2?s=32" width="32">
 <p>
 <span class="name">しだらようじ</span>
 <span class="affiliation">Ruby札幌, 株式会社えにしテック</span>
 </p>
 </div>
 <div class="avatar">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/6fd9be5cd0196df5ad62a5a5f2be3c55?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/6fd9be5cd0196df5ad62a5a5f2be3c55?s=32" width="32">
 <p>
 <span class="name">大和田純</span>
 <span class="affiliation">Ruby札幌, サイジニア株式会社</span>
 </p>
 </div>
 <div class="avatar">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/046d95b910ab412d0c059caac797ade3?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/046d95b910ab412d0c059caac797ade3?s=32" width="32">
 <p>
 <span class="name">白土慧</span>
 <span class="affiliation">Ruby札幌, サイジニア株式会社</span>
@@ -197,7 +197,7 @@
 </p>
 </div>
 <div class="avatar">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/9d2d4c8b739b1b4d7882ba49dcf1d276?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/9d2d4c8b739b1b4d7882ba49dcf1d276?s=32" width="32">
 <p>
 <span class="name">こしば としあき</span>
 <span class="affiliation">株式会社ECナビ, Shibuya.rb, Chiba.rb</span>
@@ -218,7 +218,7 @@
 </p>
 </div>
 <div class="avatar">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/092404bdf9897eba9ab16e61f56592db?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/092404bdf9897eba9ab16e61f56592db?s=32" width="32">
 <p>
 <span class="name">櫻井達生</span>
 <span class="affiliation">株式会社万葉</span>
@@ -232,7 +232,7 @@
 </p>
 </div>
 <div class="avatar">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/9d2f78236e45a335301ba1195026105d?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/9d2f78236e45a335301ba1195026105d?s=32" width="32">
 <p>
 <span class="name">卜部昌平</span>
 <span class="affiliation">株式会社ネットワーク応用通信研究所</span>
@@ -259,14 +259,14 @@
 <div class="section">
 <h2>デザイナ</h2>
 <div class="avatar">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/00575484b5d4489619bfc52e9775ee3b?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/00575484b5d4489619bfc52e9775ee3b?s=32" width="32">
 <p>
 <span class="name">関谷繭子</span>
 <span class="affiliation">@mayuco / 株式会社えにしテック</span>
 </p>
 </div>
 <div class="avatar">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/465f37a716f559211948394e549a164d?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/465f37a716f559211948394e549a164d?s=32" width="32">
 <p>
 <span class="name">のりお</span>
 <span class="affiliation">ピクシブ株式会社</span>
@@ -276,35 +276,35 @@
 <div class="section">
 <h2>KaigiFreaksレポート班</h2>
 <div class="avatar">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/8f39a252784d5a99589be6e20c4553fb?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/8f39a252784d5a99589be6e20c4553fb?s=32" width="32">
 <p>
 <span class="name">三村益隆</span>
 <span class="affiliation">永和システムマネジメント, asakusa.rb</span>
 </p>
 </div>
 <div class="avatar">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/961126d9892ae4df45249529a0721571?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/961126d9892ae4df45249529a0721571?s=32" width="32">
 <p>
 <span class="name">すがわらまさのり</span>
 <span class="affiliation">@sugamasao</span>
 </p>
 </div>
 <div class="avatar">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/15e2d5cb578d7dc3147fc2be901ecd5f?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/15e2d5cb578d7dc3147fc2be901ecd5f?s=32" width="32">
 <p>
 <span class="name">赤松祐希</span>
 <span class="affiliation">@ukstudio</span>
 </p>
 </div>
 <div class="avatar">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/527e2af04bd5b212b479840016274cdb?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/527e2af04bd5b212b479840016274cdb?s=32" width="32">
 <p>
 <span class="name">菅井祐太朗</span>
 <span class="affiliation">@hokkai7go</span>
 </p>
 </div>
 <div class="avatar">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/a6945e4a032aaa4109e5818465d62b06?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/a6945e4a032aaa4109e5818465d62b06?s=32" width="32">
 <p>
 <span class="name">小松崎典之</span>
 <span class="affiliation">@oshow</span>
@@ -314,7 +314,7 @@
 <div class="section">
 <h2>KaigiFreaksネットワーク班</h2>
 <div class="avatar">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/256838377ddbe600e85d8f446aae224d?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/256838377ddbe600e85d8f446aae224d?s=32" width="32">
 <p>
 <span class="name">小岩秀和</span>
 <span class="affiliation">一般社団法人LOCAL、株式会社エストコスモ、88nite</span>
@@ -331,7 +331,7 @@
 </p>
 </div>
 <div class="avatar">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/8e528456ff66ec543952daa815353a01?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/8e528456ff66ec543952daa815353a01?s=32" width="32">
 <p>
 <span class="name">鈴木則夫</span>
 <span class="affiliation">@suzuki</span>
@@ -355,14 +355,14 @@
 <div class="section">
 <h2>当日スタッフ</h2>
 <div class="avatar">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/dc03a27ae31ba428c560c00c9128cd75?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/dc03a27ae31ba428c560c00c9128cd75?s=32" width="32">
 <p>
 <span class="name">佐藤竜之介</span>
 <span class="affiliation">株式会社えにしテック, Sapporo.js, @tricknotes</span>
 </p>
 </div>
 <div class="avatar">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/f8fbcb02824678dbc843748e8da20d24?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/f8fbcb02824678dbc843748e8da20d24?s=32" width="32">
 <p>
 <span class="name">吉岡ひろき</span>
 <span class="affiliation">irohiroki.com</span>
@@ -390,7 +390,7 @@
 </p>
 </div>
 <div class="avatar">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/de0df5acda15a9c7eeb6c28a5e5d4e8e?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/de0df5acda15a9c7eeb6c28a5e5d4e8e?s=32" width="32">
 <p>
 <span class="name">寺田玄太郎</span>
 <span class="affiliation">永和システムマネジメント, @hibariya</span>
@@ -411,14 +411,14 @@
 </p>
 </div>
 <div class="avatar">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/fbcf9ed09205a5093069f0a2ccccfdf8?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/fbcf9ed09205a5093069f0a2ccccfdf8?s=32" width="32">
 <p>
 <span class="name">沼田 一哉</span>
 <span class="affiliation">株式会社エストコスモ, 一般社団法人LOCAL, @kaznum</span>
 </p>
 </div>
 <div class="avatar">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/164a161443835d8479c19d33241cab2a?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/164a161443835d8479c19d33241cab2a?s=32" width="32">
 <p>
 <span class="name">佐々木　大輔</span>
 <span class="affiliation">一般社団法人LOCAL, 株式会社オープンソース</span>
@@ -439,7 +439,7 @@
 </p>
 </div>
 <div class="avatar">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/8a689b8579d0640762b48ecd0df2271c?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/8a689b8579d0640762b48ecd0df2271c?s=32" width="32">
 <p>
 <span class="name">伊藤元気</span>
 <span class="affiliation">@gnnk</span>
@@ -460,14 +460,14 @@
 </p>
 </div>
 <div class="avatar">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/d6fc8a819afa94f464fe322032a6687f?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/d6fc8a819afa94f464fe322032a6687f?s=32" width="32">
 <p>
 <span class="name">小倉真人</span>
 <span class="affiliation">@Mahito</span>
 </p>
 </div>
 <div class="avatar">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/70405ca68e6f8779be65e75b1a90525b?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/70405ca68e6f8779be65e75b1a90525b?s=32" width="32">
 <p>
 <span class="name">喜多 淳一郎</span>
 <span class="affiliation">@kitaj</span>
@@ -481,7 +481,7 @@
 </p>
 </div>
 <div class="avatar">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/63ed460c175ed37b9427ebb9e397c86b?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/63ed460c175ed37b9427ebb9e397c86b?s=32" width="32">
 <p>
 <span class="name">すずきかい</span>
 <span class="affiliation">@ZoAmichi</span>
@@ -543,14 +543,14 @@
 <div class="section">
 <h2>LT タイマー</h2>
 <div class="avatar">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/ea4f647d2ebc49e087fb84739194b19c?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/ea4f647d2ebc49e087fb84739194b19c?s=32" width="32">
 <p>
 <span class="name">伊藤勝良</span>
 <span class="affiliation">有限会社伊藤ソフトデザイン, Akita.m</span>
 </p>
 </div>
 <div class="avatar">
-<img alt="avatar" height="32" src="http://www.gravatar.com/avatar/5ad0bb268dd2605b09165d464308cb7e?s=32" width="32">
+<img alt="avatar" height="32" src="https://www.gravatar.com/avatar/5ad0bb268dd2605b09165d464308cb7e?s=32" width="32">
 <p>
 <span class="name">五十嵐邦明</span>
 <span class="affiliation">株式会社万葉, 高専カンファレンス, @igaiga555</span>


### PR DESCRIPTION
Fixes "Refused to load the image 'http://www.gravatar.com/avatar/9d2f78236e45a335301ba1195026105d?s=32&d=http%3A%2F%2Frubykaigi.org%2F2011%2Fimages%2Fbow_face.png' because it violates the following Content Security Policy directive: "default-src https: 'self' 'unsafe-inline' 'unsafe-eval'". Note that 'img-src' was not explicitly set, so 'default-src' is used as a fallback."