### PR TITLE
2011: Restore missing widget.js from web.archive.org

### DIFF
--- a/2011/en/index.html
+++ b/2011/en/index.html
@@ -253,7 +253,7 @@ Keep in shape (Beware of its being hot here in Tokyo).
 <img alt="" height="35" src="/2011/images/indexTwitterHeader.png" width="250">
 </h2>
 <article>
-<script src="http://widgets.twimg.com/j/2/widget.js"></script>
+<script src="/2011/javascripts/widget.js"></script>
 <script type="text/javascript">
   //<![CDATA[
     new TWTR.Widget({

--- a/2011/index.html
+++ b/2011/index.html
@@ -253,7 +253,7 @@ Keep in shape (Beware of its being hot here in Tokyo).
 <img alt="" height="35" src="/2011/images/indexTwitterHeader.png" width="250">
 </h2>
 <article>
-<script src="http://widgets.twimg.com/j/2/widget.js"></script>
+<script src="/2011/javascripts/widget.js"></script>
 <script type="text/javascript">
   //<![CDATA[
     new TWTR.Widget({

--- a/2011/ja/index.html
+++ b/2011/ja/index.html
@@ -255,7 +255,7 @@
 <img alt="" height="35" src="/2011/images/indexTwitterHeader.png" width="250">
 </h2>
 <article>
-<script src="http://widgets.twimg.com/j/2/widget.js"></script>
+<script src="/2011/javascripts/widget.js"></script>
 <script type="text/javascript">
   //<![CDATA[
     new TWTR.Widget({


### PR DESCRIPTION
2011のサイトで使われてるwidget.jsってやつが読み込めなくなっているので、webarchiveからダウンロードしてみました。URL的にはこのへんから。
http://web.archive.org/web/20111204155657js_/http://widgets.twimg.com/j/2/widget.js
2010のディレクトリに入ってるものでもよかったような気もするけどよくわからずとりあえず。