### PR TITLE
Fetch Creative Commons 3.0 image via HTTPS

### DIFF
--- a/2007/Log0610-S5-En.html
+++ b/2007/Log0610-S5-En.html
@@ -330,7 +330,7 @@ I felt very welcomed.</p>
 <p><img alt="IMG_9240.JPG" width="256" height="192" src="IMG_9240.JPG">
 <img alt="IMG_9241.JPG" width="256" height="192" src="IMG_9241.JPG"></p>
 <h3><a name="l15"><span class="sanchor"> </span></a>License</h3>
-<p><img src="http://i.creativecommons.org/l/by/3.0/88x31.png" alt="Creative Commons License">
+<p><img src="https://i.creativecommons.org/l/by/3.0/88x31.png" alt="Creative Commons License">
 This English version of a log of the presentation
 `The Island of Ruby' by <a href="http://pragdave.pragprog.com" class="external">Dave Thomas</a>
 on June 10th, 2007 in

--- a/2007/Log0610-S5.html
+++ b/2007/Log0610-S5.html
@@ -326,7 +326,7 @@ Apple、Mircosoft、Sun、そしてThoughtworksから。</p>
 <p><img alt="IMG_9240.JPG" width="256" height="192" src="IMG_9240.JPG">
 <img alt="IMG_9241.JPG" width="256" height="192" src="IMG_9241.JPG"></p>
 <h3><a name="l15"><span class="sanchor"> </span></a>License</h3>
-<p><img src="http://i.creativecommons.org/l/by/2.1/jp/88x31.png" alt="Creative Commons License">
+<p><img src="https://i.creativecommons.org/l/by/2.1/jp/88x31.png" alt="Creative Commons License">
 This Japanese version of a log of the presentation
 `The Island of Ruby' by <a href="http://pragdave.pragprog.com" class="external">Dave Thomas</a>
 on June 10th, 2007 in

--- a/2007/index.rss
+++ b/2007/index.rss
@@ -1268,7 +1268,7 @@ I felt very welcomed.</p>
 <p><span class="plugin">{{attach_view(IMG_9240.JPG)}}</span>
 <span class="plugin">{{attach_view(IMG_9241.JPG)}}</span></p>
 <h3><a name="l15"><span class="sanchor"> </span></a>License</h3>
-<p><img src="http://i.creativecommons.org/l/by/3.0/88x31.png" alt="Creative Commons License">
+<p><img src="https://i.creativecommons.org/l/by/3.0/88x31.png" alt="Creative Commons License">
 This English version of a log of the presentation
 `The Island of Ruby' by <a href="http://pragdave.pragprog.com" class="external">Dave Thomas</a>
 on June 10th, 2007 in
@@ -1562,7 +1562,7 @@ Apple、Mircosoft、Sun、そしてThoughtworksから。</p>
 <p><span class="plugin">{{attach_view(IMG_9240.JPG)}}</span>
 <span class="plugin">{{attach_view(IMG_9241.JPG)}}</span></p>
 <h3><a name="l15"><span class="sanchor"> </span></a>License</h3>
-<p><img src="http://i.creativecommons.org/l/by/2.1/jp/88x31.png" alt="Creative Commons License">
+<p><img src="https://i.creativecommons.org/l/by/2.1/jp/88x31.png" alt="Creative Commons License">
 This Japanese version of a log of the presentation
 `The Island of Ruby' by <a href="http://pragdave.pragprog.com" class="external">Dave Thomas</a>
 on June 10th, 2007 in

--- a/2008/0thDay.html
+++ b/2008/0thDay.html
@@ -197,7 +197,7 @@
                 <h2><span class="date"><a name="l16"> </a></span><span class="title">動画ファイルのライセンス</span></h2>
                 <div class="body">
                     <div class="section">
-                        <p><img src="http://i.creativecommons.org/l/by/2.1/jp/88x31.png" alt="クローバー">
+                        <p><img src="https://i.creativecommons.org/l/by/2.1/jp/88x31.png" alt="クローバー">
                             <a href="http://creativecommons.org/licenses/by/2.1/jp/" class="external">http://creativecommons.org/licenses/by/2.1/jp/</a> です。</p>
                     </div>
                 </div>

--- a/2008/Goodies.html
+++ b/2008/Goodies.html
@@ -204,7 +204,7 @@
                 <h2><span class="date"><a name="l13"> </a></span><span class="title">ライセンス (License)</span></h2>
                 <div class="body">
                     <div class="section">
-                        <p><img src="http://i.creativecommons.org/l/by/2.1/jp/88x31.png" alt="クローバー"><a href="http://creativecommons.org/licenses/by/2.1/jp/" class="external">http://creativecommons.org/licenses/by/2.1/jp/</a></p>
+                        <p><img src="https://i.creativecommons.org/l/by/2.1/jp/88x31.png" alt="クローバー"><a href="http://creativecommons.org/licenses/by/2.1/jp/" class="external">http://creativecommons.org/licenses/by/2.1/jp/</a></p>
                     </div>
                 </div>
             </div>

--- a/2008/LT.html
+++ b/2008/LT.html
@@ -180,7 +180,7 @@
                 <h2><span class="date"><a name="l13"> </a></span><span class="title">動画ファイルのライセンス</span></h2>
                 <div class="body">
                     <div class="section">
-                        <p><img src="http://i.creativecommons.org/l/by/2.1/jp/88x31.png" alt="クローバー"><a href="http://creativecommons.org/licenses/by/2.1/jp/" class="external">http://creativecommons.org/licenses/by/2.1/jp/</a> です。</p>
+                        <p><img src="https://i.creativecommons.org/l/by/2.1/jp/88x31.png" alt="クローバー"><a href="http://creativecommons.org/licenses/by/2.1/jp/" class="external">http://creativecommons.org/licenses/by/2.1/jp/</a> です。</p>
                     </div>
                 </div>
             </div>

--- a/2008/MainSession.html
+++ b/2008/MainSession.html
@@ -404,7 +404,7 @@
                 <h2><span class="date"><a name="l39"> </a></span><span class="title">動画ファイルのライセンス</span></h2>
                 <div class="body">
                     <div class="section">
-                        <p><img src="http://i.creativecommons.org/l/by/2.1/jp/88x31.png" alt="クローバー"><a href="http://creativecommons.org/licenses/by/2.1/jp/" class="external">http://creativecommons.org/licenses/by/2.1/jp/</a> です。</p>
+                        <p><img src="https://i.creativecommons.org/l/by/2.1/jp/88x31.png" alt="クローバー"><a href="http://creativecommons.org/licenses/by/2.1/jp/" class="external">http://creativecommons.org/licenses/by/2.1/jp/</a> です。</p>
                     </div>
                 </div>
             </div>

--- a/2008/SubSession.html
+++ b/2008/SubSession.html
@@ -273,7 +273,7 @@
                 <h2><span class="date"><a name="l34"> </a></span><span class="title">動画ファイルのライセンス</span></h2>
                 <div class="body">
                     <div class="section">
-                        <p><img src="http://i.creativecommons.org/l/by/2.1/jp/88x31.png" alt="クローバー"><a href="http://creativecommons.org/licenses/by/2.1/jp/" class="external">http://creativecommons.org/licenses/by/2.1/jp/</a> です。</p>
+                        <p><img src="https://i.creativecommons.org/l/by/2.1/jp/88x31.png" alt="クローバー"><a href="http://creativecommons.org/licenses/by/2.1/jp/" class="external">http://creativecommons.org/licenses/by/2.1/jp/</a> です。</p>
                     </div>
                 </div>
             </div>

--- a/2008/rss.xml
+++ b/2008/rss.xml
@@ -396,7 +396,7 @@ From the launch, on October 1 2007, to now we have seen steady to explosive grow
 <li>資料(作業中)</li>
 </ul>
 <h2><span class="date"><a name="l39"> </a></span><span class="title">動画ファイルのライセンス</span></h2>
-<p><img src="http://i.creativecommons.org/l/by/2.1/jp/88x31.png" alt="クローバー"><a href="http://creativecommons.org/licenses/by/2.1/jp/" class="external">http://creativecommons.org/licenses/by/2.1/jp/</a> です。</p>
+<p><img src="https://i.creativecommons.org/l/by/2.1/jp/88x31.png" alt="クローバー"><a href="http://creativecommons.org/licenses/by/2.1/jp/" class="external">http://creativecommons.org/licenses/by/2.1/jp/</a> です。</p>
 </div>]]></content:encoded>  </item>  <item rdf:about="/2008/0thDay.html">
     <title>0th dayプログラム</title>
     <link>/2008/0thDay.html</link>
@@ -532,7 +532,7 @@ From the launch, on October 1 2007, to now we have seen steady to explosive grow
 <p>会場はそのままに、飲食物各自持ち込み方式の前夜祭に突入します。開始までに30分程度の空き時間があるので、食料品の買出しに行けます。
 前夜祭に関する詳細はRubyKaigi日記の「<a href="http://rubykaigi.tdiary.net/20080612.html#p01" class="external">6月20日に「前夜祭」を行います</a>」をご覧ください。</p>
 <h2><span class="date"><a name="l16"> </a></span><span class="title">動画ファイルのライセンス</span></h2>
-<p><img src="http://i.creativecommons.org/l/by/2.1/jp/88x31.png" alt="クローバー">
+<p><img src="https://i.creativecommons.org/l/by/2.1/jp/88x31.png" alt="クローバー">
 <a href="http://creativecommons.org/licenses/by/2.1/jp/" class="external">http://creativecommons.org/licenses/by/2.1/jp/</a> です。</p>
 </div>]]></content:encoded>  </item>  <item rdf:about="/2008/SubSession.html">
     <title>サブセッション・プログラム</title>
@@ -710,7 +710,7 @@ Star Ruby はスーファミ風 2D ゲームを作ることを目的としたラ
 <li><a href="http://www.sw.it.aoyama.ac.jp/SVuGy/RubyKaigi2008Presentation.html" class="external">資料</a> (Link)</li>
 </ul>
 <h2><span class="date"><a name="l34"> </a></span><span class="title">動画ファイルのライセンス</span></h2>
-<p><img src="http://i.creativecommons.org/l/by/2.1/jp/88x31.png" alt="クローバー"><a href="http://creativecommons.org/licenses/by/2.1/jp/" class="external">http://creativecommons.org/licenses/by/2.1/jp/</a> です。</p>
+<p><img src="https://i.creativecommons.org/l/by/2.1/jp/88x31.png" alt="クローバー"><a href="http://creativecommons.org/licenses/by/2.1/jp/" class="external">http://creativecommons.org/licenses/by/2.1/jp/</a> です。</p>
 </div>]]></content:encoded>  </item>  <item rdf:about="/2008/LT.html">
     <title>ライトニング・トークス</title>
     <link>/2008/LT.html</link>
@@ -818,7 +818,7 @@ Star Ruby はスーファミ風 2D ゲームを作ることを目的としたラ
 <li>資料は皆さんの心のなかにあります</li>
 </ul>
 <h2><span class="date"><a name="l13"> </a></span><span class="title">動画ファイルのライセンス</span></h2>
-<p><img src="http://i.creativecommons.org/l/by/2.1/jp/88x31.png" alt="クローバー"><a href="http://creativecommons.org/licenses/by/2.1/jp/" class="external">http://creativecommons.org/licenses/by/2.1/jp/</a> です。</p>
+<p><img src="https://i.creativecommons.org/l/by/2.1/jp/88x31.png" alt="クローバー"><a href="http://creativecommons.org/licenses/by/2.1/jp/" class="external">http://creativecommons.org/licenses/by/2.1/jp/</a> です。</p>
 </div>]]></content:encoded>  </item>  <item rdf:about="/2008/ExecutiveCommittee.html">
     <title>日本Ruby会議2008実行委員会</title>
     <link>/2008/ExecutiveCommittee.html</link>
@@ -996,7 +996,7 @@ Star Ruby はスーファミ風 2D ゲームを作ることを目的としたラ
 <li>白紙: <span class="plugin">{{attach_anchor(tumbler-blank.pdf)}}</span> </li>
 </ul>
 <h2><span class="date"><a name="l13"> </a></span><span class="title">ライセンス (License)</span></h2>
-<p><img src="http://i.creativecommons.org/l/by/2.1/jp/88x31.png" alt="クローバー"><a href="http://creativecommons.org/licenses/by/2.1/jp/" class="external">http://creativecommons.org/licenses/by/2.1/jp/</a></p>
+<p><img src="https://i.creativecommons.org/l/by/2.1/jp/88x31.png" alt="クローバー"><a href="http://creativecommons.org/licenses/by/2.1/jp/" class="external">http://creativecommons.org/licenses/by/2.1/jp/</a></p>
 </div>]]></content:encoded>  </item>  <item rdf:about="/2008/thanks.html">
     <title>アンケート送信完了</title>
     <link>/2008/thanks.html</link>

--- a/2009/en/goodies/index.html
+++ b/2009/en/goodies/index.html
@@ -71,7 +71,7 @@
 
   <h3>License</h3>
   <p>
-  <a href="http://creativecommons.org/licenses/by/2.1/jp/"><img alt="88x31" height="31" src="http://i.creativecommons.org/l/by/2.1/jp/88x31.png" width="88"></a><br>
+  <a href="http://creativecommons.org/licenses/by/2.1/jp/"><img alt="88x31" height="31" src="https://i.creativecommons.org/l/by/2.1/jp/88x31.png" width="88"></a><br>
   <a href="http://creativecommons.org/licenses/by/2.1/jp/">http://creativecommons.org/licenses/by/2.1/jp/</a>
   </p>
 

--- a/2009/ja/goodies/index.html
+++ b/2009/ja/goodies/index.html
@@ -76,7 +76,7 @@
 
   <h3>ライセンス</h3>
   <p>
-  <a href="http://creativecommons.org/licenses/by/2.1/jp/"><img alt="88x31" height="31" src="http://i.creativecommons.org/l/by/2.1/jp/88x31.png" width="88"></a><br>
+  <a href="http://creativecommons.org/licenses/by/2.1/jp/"><img alt="88x31" height="31" src="https://i.creativecommons.org/l/by/2.1/jp/88x31.png" width="88"></a><br>
   <a href="http://creativecommons.org/licenses/by/2.1/jp/">http://creativecommons.org/licenses/by/2.1/jp/</a>
   </p>
 


### PR DESCRIPTION
2007-2009の http://i.creativecommons.org への画像のリクエストをHTTPSにするやつです。
ソースは僕が触れる範囲内には見当たらないので、staticの中身を直接 git gsub しています。