### PR TITLE
2006: Put hiki_base.css within 2006 site

### DIFF
--- a/2006/about.html
+++ b/2006/about.html
@@ -9,7 +9,7 @@
   <meta http-equiv="Content-Style-Type" content="text/css">
   <meta name="generator" content="Hiki 0.9dev">
   <title>日本Rubyカンファレンス2006 - カンファレンス概要</title>
-  <link rel="stylesheet" type="text/css" href="../hiki_base.css" media="all">
+  <link rel="stylesheet" type="text/css" href="/2006/hiki_base.css" media="all">
   <link rel="stylesheet" type="text/css" href="ruby_kaigi.css" media="all">
   <link rel="alternate" type="application/rss+xml" title="RSS" href="index.html?c=rss">  <link rel="icon" type="image/png" href="/2007/favicon.png">
   <link rel="shortcut icon" type="image/x-icon" href="../favicon.ico">

--- a/2006/application.html
+++ b/2006/application.html
@@ -9,7 +9,7 @@
   <meta http-equiv="Content-Style-Type" content="text/css">
   <meta name="generator" content="Hiki 0.9dev">
   <title>日本Rubyカンファレンス2006 - 参加申し込み</title>
-  <link rel="stylesheet" type="text/css" href="../hiki_base.css" media="all">
+  <link rel="stylesheet" type="text/css" href="/2006/hiki_base.css" media="all">
   <link rel="stylesheet" type="text/css" href="ruby_kaigi.css" media="all">
   <link rel="alternate" type="application/rss+xml" title="RSS" href="index.html?c=rss">  <link rel="icon" type="image/png" href="/2007/favicon.png">
   <link rel="shortcut icon" type="image/x-icon" href="../favicon.ico">

--- a/2006/cfp_lt.html
+++ b/2006/cfp_lt.html
@@ -9,7 +9,7 @@
   <meta http-equiv="Content-Style-Type" content="text/css">
   <meta name="generator" content="Hiki 0.9dev">
   <title>日本Rubyカンファレンス2006 - LT 発表者募集</title>
-  <link rel="stylesheet" type="text/css" href="../hiki_base.css" media="all">
+  <link rel="stylesheet" type="text/css" href="/2006/hiki_base.css" media="all">
   <link rel="stylesheet" type="text/css" href="ruby_kaigi.css" media="all">
   <link rel="alternate" type="application/rss+xml" title="RSS" href="index.html?c=rss">  <link rel="icon" type="image/png" href="/2007/favicon.png">
   <link rel="shortcut icon" type="image/x-icon" href="../favicon.ico">

--- a/2006/enquete.html
+++ b/2006/enquete.html
@@ -9,7 +9,7 @@
   <meta http-equiv="Content-Style-Type" content="text/css">
   <meta name="generator" content="Hiki 0.9dev">
   <title>日本Rubyカンファレンス2006 - アンケート</title>
-  <link rel="stylesheet" type="text/css" href="../hiki_base.css" media="all">
+  <link rel="stylesheet" type="text/css" href="/2006/hiki_base.css" media="all">
   <link rel="stylesheet" type="text/css" href="ruby_kaigi.css" media="all">
   <link rel="alternate" type="application/rss+xml" title="RSS" href="index.html?c=rss">  <link rel="icon" type="image/png" href="/2007/favicon.png">
   <link rel="shortcut icon" type="image/x-icon" href="../favicon.ico">

--- a/2006/hiki_base.css
+++ b/2006/hiki_base.css
@@ -1,0 +1,35 @@
+ins.added {
+	font-weight: bold;
+}
+
+del.deleted {
+	text-decoration: line-through;
+}
+
+form.update textarea.keyword {
+        width: 15em;
+        height: 3em;
+}
+
+/* 02help */
+div.helptlbr {
+	font-size: small;
+	padding: 1px;
+}
+
+span.helpbttn {
+	border-style: solid;
+	border-width: 0px 0px 1px 0px;
+}
+
+@media print{
+  div.adminmenu{
+    display: none;
+  }
+  div.main{
+    margin-left: 0;
+  }
+  div.sidebar{
+    display: none;
+  }
+}

--- a/2006/index.html
+++ b/2006/index.html
@@ -9,7 +9,7 @@
   <meta http-equiv="Content-Style-Type" content="text/css">
   <meta name="generator" content="Hiki 0.9dev">
   <title>日本Rubyカンファレンス2006 - トップページ</title>
-  <link rel="stylesheet" type="text/css" href="../hiki_base.css" media="all">
+  <link rel="stylesheet" type="text/css" href="/2006/hiki_base.css" media="all">
   <link rel="stylesheet" type="text/css" href="ruby_kaigi.css" media="all">
   <link rel="alternate" type="application/rss+xml" title="RSS" href="index.html?c=rss">  <link rel="icon" type="image/png" href="/2007/favicon.png">
   <link rel="shortcut icon" type="image/x-icon" href="../favicon.ico">

--- a/2006/news.html
+++ b/2006/news.html
@@ -9,7 +9,7 @@
   <meta http-equiv="Content-Style-Type" content="text/css">
   <meta name="generator" content="Hiki 0.9dev">
   <title>日本Rubyカンファレンス2006 - 新着情報</title>
-  <link rel="stylesheet" type="text/css" href="../hiki_base.css" media="all">
+  <link rel="stylesheet" type="text/css" href="/2006/hiki_base.css" media="all">
   <link rel="stylesheet" type="text/css" href="ruby_kaigi.css" media="all">
   <link rel="alternate" type="application/rss+xml" title="RSS" href="index.html?c=rss">  <link rel="icon" type="image/png" href="/2007/favicon.png">
   <link rel="shortcut icon" type="image/x-icon" href="../favicon.ico">

--- a/2006/party.html
+++ b/2006/party.html
@@ -9,7 +9,7 @@
   <meta http-equiv="Content-Style-Type" content="text/css">
   <meta name="generator" content="Hiki 0.9dev">
   <title>日本Rubyカンファレンス2006 - 懇親会について</title>
-  <link rel="stylesheet" type="text/css" href="../hiki_base.css" media="all">
+  <link rel="stylesheet" type="text/css" href="/2006/hiki_base.css" media="all">
   <link rel="stylesheet" type="text/css" href="ruby_kaigi.css" media="all">
   <link rel="alternate" type="application/rss+xml" title="RSS" href="index.html?c=rss">  <link rel="icon" type="image/png" href="/2007/favicon.png">
   <link rel="shortcut icon" type="image/x-icon" href="../favicon.ico">

--- a/2006/program.html
+++ b/2006/program.html
@@ -9,7 +9,7 @@
   <meta http-equiv="Content-Style-Type" content="text/css">
   <meta name="generator" content="Hiki 0.9dev">
   <title>日本Rubyカンファレンス2006 - プログラム</title>
-  <link rel="stylesheet" type="text/css" href="../hiki_base.css" media="all">
+  <link rel="stylesheet" type="text/css" href="/2006/hiki_base.css" media="all">
   <link rel="stylesheet" type="text/css" href="ruby_kaigi.css" media="all">
   <link rel="alternate" type="application/rss+xml" title="RSS" href="index.html?c=rss">  <link rel="icon" type="image/png" href="/2007/favicon.png">
   <link rel="shortcut icon" type="image/x-icon" href="../favicon.ico">

--- a/2006/program0610.html
+++ b/2006/program0610.html
@@ -9,7 +9,7 @@
   <meta http-equiv="Content-Style-Type" content="text/css">
   <meta name="generator" content="Hiki 0.9dev">
   <title>日本Rubyカンファレンス2006 - プログラム（6月10日）</title>
-  <link rel="stylesheet" type="text/css" href="../hiki_base.css" media="all">
+  <link rel="stylesheet" type="text/css" href="/2006/hiki_base.css" media="all">
   <link rel="stylesheet" type="text/css" href="ruby_kaigi.css" media="all">
   <link rel="alternate" type="application/rss+xml" title="RSS" href="index.html?c=rss">  <link rel="icon" type="image/png" href="/2007/favicon.png">
   <link rel="shortcut icon" type="image/x-icon" href="../favicon.ico">

--- a/2006/program0611.html
+++ b/2006/program0611.html
@@ -9,7 +9,7 @@
   <meta http-equiv="Content-Style-Type" content="text/css">
   <meta name="generator" content="Hiki 0.9dev">
   <title>日本Rubyカンファレンス2006 - プログラム（6月11日）</title>
-  <link rel="stylesheet" type="text/css" href="../hiki_base.css" media="all">
+  <link rel="stylesheet" type="text/css" href="/2006/hiki_base.css" media="all">
   <link rel="stylesheet" type="text/css" href="ruby_kaigi.css" media="all">
   <link rel="alternate" type="application/rss+xml" title="RSS" href="index.html?c=rss">  <link rel="icon" type="image/png" href="/2007/favicon.png">
   <link rel="shortcut icon" type="image/x-icon" href="../favicon.ico">

--- a/2006/tb20060610.html
+++ b/2006/tb20060610.html
@@ -9,7 +9,7 @@
   <meta http-equiv="Content-Style-Type" content="text/css">
   <meta name="generator" content="Hiki 0.9dev">
   <title>日本Rubyカンファレンス2006 - トラックバック：一日目</title>
-  <link rel="stylesheet" type="text/css" href="../hiki_base.css" media="all">
+  <link rel="stylesheet" type="text/css" href="/2006/hiki_base.css" media="all">
   <link rel="stylesheet" type="text/css" href="ruby_kaigi.css" media="all">
   <link rel="alternate" type="application/rss+xml" title="RSS" href="index.html?c=rss">  <link rel="icon" type="image/png" href="/2007/favicon.png">
   <link rel="shortcut icon" type="image/x-icon" href="../favicon.ico">

--- a/2006/tb20060611.html
+++ b/2006/tb20060611.html
@@ -9,7 +9,7 @@
   <meta http-equiv="Content-Style-Type" content="text/css">
   <meta name="generator" content="Hiki 0.9dev">
   <title>日本Rubyカンファレンス2006 - トラックバック：二日目</title>
-  <link rel="stylesheet" type="text/css" href="../hiki_base.css" media="all">
+  <link rel="stylesheet" type="text/css" href="/2006/hiki_base.css" media="all">
   <link rel="stylesheet" type="text/css" href="ruby_kaigi.css" media="all">
   <link rel="alternate" type="application/rss+xml" title="RSS" href="index.html?c=rss">  <link rel="icon" type="image/png" href="/2007/favicon.png">
   <link rel="shortcut icon" type="image/x-icon" href="../favicon.ico">

--- a/2006/videos.html
+++ b/2006/videos.html
@@ -9,7 +9,7 @@
   <meta http-equiv="Content-Style-Type" content="text/css">
   <meta name="generator" content="Hiki 0.9dev">
   <title>日本Rubyカンファレンス2006 - 動画一覧</title>
-  <link rel="stylesheet" type="text/css" href="../hiki_base.css" media="all">
+  <link rel="stylesheet" type="text/css" href="/2006/hiki_base.css" media="all">
   <link rel="stylesheet" type="text/css" href="ruby_kaigi.css" media="all">
   <link rel="alternate" type="application/rss+xml" title="RSS" href="index.html?c=rss">  <link rel="icon" type="image/png" href="/2007/favicon.png">
   <link rel="shortcut icon" type="image/x-icon" href="../favicon.ico">

--- a/2006/volunteer_staff.html
+++ b/2006/volunteer_staff.html
@@ -9,7 +9,7 @@
   <meta http-equiv="Content-Style-Type" content="text/css">
   <meta name="generator" content="Hiki 0.9dev">
   <title>日本Rubyカンファレンス2006 - 運営スタッフ募集</title>
-  <link rel="stylesheet" type="text/css" href="../hiki_base.css" media="all">
+  <link rel="stylesheet" type="text/css" href="/2006/hiki_base.css" media="all">
   <link rel="stylesheet" type="text/css" href="ruby_kaigi.css" media="all">
   <link rel="alternate" type="application/rss+xml" title="RSS" href="index.html?c=rss">  <link rel="icon" type="image/png" href="/2007/favicon.png">
   <link rel="shortcut icon" type="image/x-icon" href="../favicon.ico">


### PR DESCRIPTION
現在2006のサイトで404になっているhiki_base.cssというファイルを、2006配下に持ってきて参照するように修正しています。
hiki_base.css自体は2007の下にあったものをコピーして持ってきています。