### PR TITLE
Fetch player.vimeo.com with HTTPS

### DIFF
--- a/2010/en/events/1/index.html
+++ b/2010/en/events/1/index.html
@@ -414,7 +414,7 @@
         <h2>
         Video
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14548019" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14548019" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14548019"></a>
       </p>

--- a/2010/en/events/10/index.html
+++ b/2010/en/events/10/index.html
@@ -374,7 +374,7 @@
         <h2>
         Video
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14549892" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14549892" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14549892"></a>
       </p>

--- a/2010/en/events/11/index.html
+++ b/2010/en/events/11/index.html
@@ -380,7 +380,7 @@
         <h2>
         Video
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14546877" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14546877" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14546877"></a>
       </p>

--- a/2010/en/events/12/index.html
+++ b/2010/en/events/12/index.html
@@ -371,7 +371,7 @@
         <h2>
         Video
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14547164" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14547164" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14547164"></a>
       </p>

--- a/2010/en/events/14/index.html
+++ b/2010/en/events/14/index.html
@@ -375,7 +375,7 @@
         <h2>
         Video
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14547561" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14547561" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14547561"></a>
       </p>

--- a/2010/en/events/15/index.html
+++ b/2010/en/events/15/index.html
@@ -370,7 +370,7 @@
         <h2>
         Video
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14547743" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14547743" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14547743"></a>
       </p>

--- a/2010/en/events/16/index.html
+++ b/2010/en/events/16/index.html
@@ -372,7 +372,7 @@
         <h2>
         Video
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14547648" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14547648" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14547648"></a>
       </p>

--- a/2010/en/events/18/index.html
+++ b/2010/en/events/18/index.html
@@ -373,7 +373,7 @@
         <h2>
         Video
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14547828" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14547828" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14547828"></a>
       </p>

--- a/2010/en/events/19/index.html
+++ b/2010/en/events/19/index.html
@@ -381,7 +381,7 @@
         <h2>
         Video
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14547904" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14547904" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14547904"></a>
       </p>

--- a/2010/en/events/2/index.html
+++ b/2010/en/events/2/index.html
@@ -370,7 +370,7 @@
         <h2>
         Video
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14548338" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14548338" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14548338"></a>
       </p>

--- a/2010/en/events/29/index.html
+++ b/2010/en/events/29/index.html
@@ -371,7 +371,7 @@
         <h2>
         Video
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14550163" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14550163" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14550163"></a>
       </p>

--- a/2010/en/events/3/index.html
+++ b/2010/en/events/3/index.html
@@ -374,7 +374,7 @@
         <h2>
         Video
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14548658" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14548658" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14548658"></a>
       </p>

--- a/2010/en/events/30/index.html
+++ b/2010/en/events/30/index.html
@@ -370,7 +370,7 @@
         <h2>
         Video
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14550223" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14550223" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14550223"></a>
       </p>

--- a/2010/en/events/32/index.html
+++ b/2010/en/events/32/index.html
@@ -375,7 +375,7 @@
         <h2>
         Video
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14817369" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14817369" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14817369"></a>
       </p>

--- a/2010/en/events/33/index.html
+++ b/2010/en/events/33/index.html
@@ -371,7 +371,7 @@
         <h2>
         Video
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14817403" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14817403" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14817403"></a>
       </p>

--- a/2010/en/events/34/index.html
+++ b/2010/en/events/34/index.html
@@ -370,7 +370,7 @@
         <h2>
         Video
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14817471" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14817471" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14817471"></a>
       </p>

--- a/2010/en/events/36/index.html
+++ b/2010/en/events/36/index.html
@@ -377,7 +377,7 @@
         <h2>
         Video
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14817572" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14817572" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14817572"></a>
       </p>

--- a/2010/en/events/39/index.html
+++ b/2010/en/events/39/index.html
@@ -419,7 +419,7 @@
         <h2>
         Video
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14816850" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14816850" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14816850"></a>
       </p>

--- a/2010/en/events/4/index.html
+++ b/2010/en/events/4/index.html
@@ -377,7 +377,7 @@
         <h2>
         Video
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14549468" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14549468" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14549468"></a>
       </p>

--- a/2010/en/events/41/index.html
+++ b/2010/en/events/41/index.html
@@ -417,7 +417,7 @@
         <h2>
         Video
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14816870" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14816870" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14816870"></a>
       </p>

--- a/2010/en/events/42/index.html
+++ b/2010/en/events/42/index.html
@@ -414,7 +414,7 @@
         <h2>
         Video
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14816906" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14816906" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14816906"></a>
       </p>

--- a/2010/en/events/43/index.html
+++ b/2010/en/events/43/index.html
@@ -414,7 +414,7 @@
         <h2>
         Video
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14816932" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14816932" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14816932"></a>
       </p>

--- a/2010/en/events/44/index.html
+++ b/2010/en/events/44/index.html
@@ -414,7 +414,7 @@
         <h2>
         Video
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14816966" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14816966" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14816966"></a>
       </p>

--- a/2010/en/events/45/index.html
+++ b/2010/en/events/45/index.html
@@ -414,7 +414,7 @@
         <h2>
         Video
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14817011" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14817011" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14817011"></a>
       </p>

--- a/2010/en/events/46/index.html
+++ b/2010/en/events/46/index.html
@@ -414,7 +414,7 @@
         <h2>
         Video
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14817287" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14817287" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14817287"></a>
       </p>

--- a/2010/en/events/47/index.html
+++ b/2010/en/events/47/index.html
@@ -416,7 +416,7 @@
         <h2>
         Video
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14817303" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14817303" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14817303"></a>
       </p>

--- a/2010/en/events/48/index.html
+++ b/2010/en/events/48/index.html
@@ -414,7 +414,7 @@
         <h2>
         Video
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14817328" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14817328" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14817328"></a>
       </p>

--- a/2010/en/events/49/index.html
+++ b/2010/en/events/49/index.html
@@ -415,7 +415,7 @@
         <h2>
         Video
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14817604" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14817604" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14817604"></a>
       </p>

--- a/2010/en/events/50/index.html
+++ b/2010/en/events/50/index.html
@@ -371,7 +371,7 @@
         <h2>
         Video
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14550283" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14550283" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14550283"></a>
       </p>

--- a/2010/en/events/51/index.html
+++ b/2010/en/events/51/index.html
@@ -372,7 +372,7 @@
         <h2>
         Video
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14550348" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14550348" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14550348"></a>
       </p>

--- a/2010/en/events/52/index.html
+++ b/2010/en/events/52/index.html
@@ -371,7 +371,7 @@
         <h2>
         Video
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14550424" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14550424" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14550424"></a>
       </p>

--- a/2010/en/events/54/index.html
+++ b/2010/en/events/54/index.html
@@ -377,7 +377,7 @@
         <h2>
         Video
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14550991" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14550991" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14550991"></a>
       </p>

--- a/2010/en/events/55/index.html
+++ b/2010/en/events/55/index.html
@@ -372,7 +372,7 @@
         <h2>
         Video
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14550481" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14550481" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14550481"></a>
       </p>

--- a/2010/en/events/57/index.html
+++ b/2010/en/events/57/index.html
@@ -374,7 +374,7 @@
         <h2>
         Video
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14550567" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14550567" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14550567"></a>
       </p>

--- a/2010/en/events/6/index.html
+++ b/2010/en/events/6/index.html
@@ -375,7 +375,7 @@
         <h2>
         Video
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14549558" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14549558" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14549558"></a>
       </p>

--- a/2010/en/events/7/index.html
+++ b/2010/en/events/7/index.html
@@ -375,7 +375,7 @@
         <h2>
         Video
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14549681" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14549681" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14549681"></a>
       </p>

--- a/2010/en/events/70/index.html
+++ b/2010/en/events/70/index.html
@@ -370,7 +370,7 @@
         <h2>
         Video
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14823540" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14823540" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14823540"></a>
       </p>

--- a/2010/en/events/71/index.html
+++ b/2010/en/events/71/index.html
@@ -381,7 +381,7 @@
         <h2>
         Video
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14823566" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14823566" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14823566"></a>
       </p>

--- a/2010/en/events/72/index.html
+++ b/2010/en/events/72/index.html
@@ -377,7 +377,7 @@
         <h2>
         Video
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14823606" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14823606" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14823606"></a>
       </p>

--- a/2010/en/events/73/index.html
+++ b/2010/en/events/73/index.html
@@ -376,7 +376,7 @@
         <h2>
         Video
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14550670" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14550670" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14550670"></a>
       </p>

--- a/2010/en/events/75/index.html
+++ b/2010/en/events/75/index.html
@@ -372,7 +372,7 @@
         <h2>
         Video
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14550758" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14550758" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14550758"></a>
       </p>

--- a/2010/en/events/77/index.html
+++ b/2010/en/events/77/index.html
@@ -374,7 +374,7 @@
         <h2>
         Video
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14823640" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14823640" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14823640"></a>
       </p>

--- a/2010/en/events/78/index.html
+++ b/2010/en/events/78/index.html
@@ -372,7 +372,7 @@
         <h2>
         Video
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14823175" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14823175" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14823175"></a>
       </p>

--- a/2010/en/events/80/index.html
+++ b/2010/en/events/80/index.html
@@ -369,7 +369,7 @@
         <h2>
         Video
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14571560" width="400"></iframe> 
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14571560" width="400"></iframe> 
       <p> 
         <a href="http://vimeo.com/14571560"></a> 
       </p> 

--- a/2010/en/events/81/index.html
+++ b/2010/en/events/81/index.html
@@ -414,7 +414,7 @@
         <h2>
         Video
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14823657" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14823657" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14823657"></a>
       </p>

--- a/2010/en/events/82/index.html
+++ b/2010/en/events/82/index.html
@@ -376,7 +376,7 @@
         <h2>
         Video
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14823682" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14823682" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14823682"></a>
       </p>

--- a/2010/en/events/83/index.html
+++ b/2010/en/events/83/index.html
@@ -375,7 +375,7 @@
         <h2>
         Video
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14823720" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14823720" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14823720"></a>
       </p>

--- a/2010/en/events/84/index.html
+++ b/2010/en/events/84/index.html
@@ -373,7 +373,7 @@
         <h2>
         Video
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14823744" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14823744" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14823744"></a>
       </p>

--- a/2010/en/events/85/index.html
+++ b/2010/en/events/85/index.html
@@ -375,7 +375,7 @@
         <h2>
         Video
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14823811" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14823811" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14823811"></a>
       </p>

--- a/2010/en/events/86/index.html
+++ b/2010/en/events/86/index.html
@@ -374,7 +374,7 @@
         <h2>
         Video
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14823856" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14823856" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14823856"></a>
       </p>

--- a/2010/en/events/88/index.html
+++ b/2010/en/events/88/index.html
@@ -375,7 +375,7 @@
         <h2>
         Video
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14823899" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14823899" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14823899"></a>
       </p>

--- a/2010/en/events/89/index.html
+++ b/2010/en/events/89/index.html
@@ -370,7 +370,7 @@
         <h2>
         Video
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14550931" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14550931" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14550931"></a>
       </p>

--- a/2010/en/events/9/index.html
+++ b/2010/en/events/9/index.html
@@ -376,7 +376,7 @@
         <h2>
         Video
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14549764" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14549764" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14549764"></a>
       </p>

--- a/2010/en/events/91/index.html
+++ b/2010/en/events/91/index.html
@@ -374,7 +374,7 @@
         <h2>
         Video
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14920187" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14920187" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14920187"></a>
       </p>

--- a/2010/en/events/92/index.html
+++ b/2010/en/events/92/index.html
@@ -373,7 +373,7 @@
         <h2>
         Video
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14823932" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14823932" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14823932"></a>
       </p>

--- a/2010/ja/events/1/index.html
+++ b/2010/ja/events/1/index.html
@@ -417,7 +417,7 @@
         <h2>
         発表動画
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14548019" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14548019" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14548019"></a>
       </p>

--- a/2010/ja/events/10/index.html
+++ b/2010/ja/events/10/index.html
@@ -377,7 +377,7 @@
         <h2>
         発表動画
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14549892" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14549892" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14549892"></a>
       </p>

--- a/2010/ja/events/11/index.html
+++ b/2010/ja/events/11/index.html
@@ -383,7 +383,7 @@
         <h2>
         発表動画
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14546877" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14546877" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14546877"></a>
       </p>

--- a/2010/ja/events/12/index.html
+++ b/2010/ja/events/12/index.html
@@ -374,7 +374,7 @@
         <h2>
         発表動画
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14547164" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14547164" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14547164"></a>
       </p>

--- a/2010/ja/events/14/index.html
+++ b/2010/ja/events/14/index.html
@@ -378,7 +378,7 @@
         <h2>
         発表動画
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14547561" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14547561" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14547561"></a>
       </p>

--- a/2010/ja/events/15/index.html
+++ b/2010/ja/events/15/index.html
@@ -373,7 +373,7 @@
         <h2>
         発表動画
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14547743" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14547743" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14547743"></a>
       </p>

--- a/2010/ja/events/16/index.html
+++ b/2010/ja/events/16/index.html
@@ -375,7 +375,7 @@
         <h2>
         発表動画
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14547648" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14547648" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14547648"></a>
       </p>

--- a/2010/ja/events/18/index.html
+++ b/2010/ja/events/18/index.html
@@ -376,7 +376,7 @@
         <h2>
         発表動画
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14547828" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14547828" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14547828"></a>
       </p>

--- a/2010/ja/events/19/index.html
+++ b/2010/ja/events/19/index.html
@@ -384,7 +384,7 @@
         <h2>
         発表動画
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14547904" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14547904" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14547904"></a>
       </p>

--- a/2010/ja/events/2/index.html
+++ b/2010/ja/events/2/index.html
@@ -373,7 +373,7 @@
         <h2>
         発表動画
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14548338" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14548338" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14548338"></a>
       </p>

--- a/2010/ja/events/29/index.html
+++ b/2010/ja/events/29/index.html
@@ -374,7 +374,7 @@
         <h2>
         発表動画
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14550163" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14550163" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14550163"></a>
       </p>

--- a/2010/ja/events/3/index.html
+++ b/2010/ja/events/3/index.html
@@ -376,7 +376,7 @@
         <h2>
         発表動画
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14548658" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14548658" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14548658"></a>
       </p>

--- a/2010/ja/events/30/index.html
+++ b/2010/ja/events/30/index.html
@@ -373,7 +373,7 @@
         <h2>
         発表動画
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14550223" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14550223" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14550223"></a>
       </p>

--- a/2010/ja/events/32/index.html
+++ b/2010/ja/events/32/index.html
@@ -377,7 +377,7 @@
         <h2>
         発表動画
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14817369" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14817369" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14817369"></a>
       </p>

--- a/2010/ja/events/33/index.html
+++ b/2010/ja/events/33/index.html
@@ -374,7 +374,7 @@
         <h2>
         発表動画
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14817403" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14817403" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14817403"></a>
       </p>

--- a/2010/ja/events/34/index.html
+++ b/2010/ja/events/34/index.html
@@ -373,7 +373,7 @@
         <h2>
         発表動画
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14817471" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14817471" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14817471"></a>
       </p>

--- a/2010/ja/events/36/index.html
+++ b/2010/ja/events/36/index.html
@@ -376,7 +376,7 @@
         <h2>
         発表動画
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14817572" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14817572" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14817572"></a>
       </p>

--- a/2010/ja/events/39/index.html
+++ b/2010/ja/events/39/index.html
@@ -419,7 +419,7 @@
         <h2>
         発表動画
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14816850" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14816850" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14816850"></a>
       </p>

--- a/2010/ja/events/4/index.html
+++ b/2010/ja/events/4/index.html
@@ -380,7 +380,7 @@
         <h2>
         発表動画
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14549468" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14549468" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14549468"></a>
       </p>

--- a/2010/ja/events/41/index.html
+++ b/2010/ja/events/41/index.html
@@ -419,7 +419,7 @@
         <h2>
         発表動画
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14816870" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14816870" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14816870"></a>
       </p>

--- a/2010/ja/events/42/index.html
+++ b/2010/ja/events/42/index.html
@@ -417,7 +417,7 @@
         <h2>
         発表動画
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14816906" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14816906" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14816906"></a>
       </p>

--- a/2010/ja/events/43/index.html
+++ b/2010/ja/events/43/index.html
@@ -417,7 +417,7 @@
         <h2>
         発表動画
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14816932" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14816932" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14816932"></a>
       </p>

--- a/2010/ja/events/44/index.html
+++ b/2010/ja/events/44/index.html
@@ -417,7 +417,7 @@
         <h2>
         発表動画
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14816966" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14816966" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14816966"></a>
       </p>

--- a/2010/ja/events/45/index.html
+++ b/2010/ja/events/45/index.html
@@ -417,7 +417,7 @@
         <h2>
         発表動画
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14817011" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14817011" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14817011"></a>
       </p>

--- a/2010/ja/events/46/index.html
+++ b/2010/ja/events/46/index.html
@@ -417,7 +417,7 @@
         <h2>
         発表動画
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14817287" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14817287" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14817287"></a>
       </p>

--- a/2010/ja/events/47/index.html
+++ b/2010/ja/events/47/index.html
@@ -419,7 +419,7 @@
         <h2>
         発表動画
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14817303" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14817303" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14817303"></a>
       </p>

--- a/2010/ja/events/48/index.html
+++ b/2010/ja/events/48/index.html
@@ -417,7 +417,7 @@
         <h2>
         発表動画
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14817328" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14817328" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14817328"></a>
       </p>

--- a/2010/ja/events/49/index.html
+++ b/2010/ja/events/49/index.html
@@ -418,7 +418,7 @@
         <h2>
         発表動画
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14817604" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14817604" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14817604"></a>
       </p>

--- a/2010/ja/events/50/index.html
+++ b/2010/ja/events/50/index.html
@@ -374,7 +374,7 @@
         <h2>
         発表動画
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14550283" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14550283" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14550283"></a>
       </p>

--- a/2010/ja/events/51/index.html
+++ b/2010/ja/events/51/index.html
@@ -375,7 +375,7 @@
         <h2>
         発表動画
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14550348" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14550348" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14550348"></a>
       </p>

--- a/2010/ja/events/52/index.html
+++ b/2010/ja/events/52/index.html
@@ -374,7 +374,7 @@
         <h2>
         発表動画
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14550424" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14550424" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14550424"></a>
       </p>

--- a/2010/ja/events/54/index.html
+++ b/2010/ja/events/54/index.html
@@ -380,7 +380,7 @@
         <h2>
         発表動画
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14550991" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14550991" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14550991"></a>
       </p>

--- a/2010/ja/events/55/index.html
+++ b/2010/ja/events/55/index.html
@@ -375,7 +375,7 @@
         <h2>
         発表動画
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14550481" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14550481" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14550481"></a>
       </p>

--- a/2010/ja/events/57/index.html
+++ b/2010/ja/events/57/index.html
@@ -377,7 +377,7 @@
         <h2>
         発表動画
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14550567" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14550567" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14550567"></a>
       </p>

--- a/2010/ja/events/6/index.html
+++ b/2010/ja/events/6/index.html
@@ -376,7 +376,7 @@
         <h2>
         発表動画
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14549558" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14549558" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14549558"></a>
       </p>

--- a/2010/ja/events/7/index.html
+++ b/2010/ja/events/7/index.html
@@ -377,7 +377,7 @@
         <h2>
         発表動画
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14549681" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14549681" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14549681"></a>
       </p>

--- a/2010/ja/events/70/index.html
+++ b/2010/ja/events/70/index.html
@@ -373,7 +373,7 @@
         <h2>
         発表動画
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14823540" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14823540" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14823540"></a>
       </p>

--- a/2010/ja/events/71/index.html
+++ b/2010/ja/events/71/index.html
@@ -384,7 +384,7 @@
         <h2>
         発表動画
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14823566" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14823566" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14823566"></a>
       </p>

--- a/2010/ja/events/72/index.html
+++ b/2010/ja/events/72/index.html
@@ -380,7 +380,7 @@
         <h2>
         発表動画
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14823606" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14823606" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14823606"></a>
       </p>

--- a/2010/ja/events/73/index.html
+++ b/2010/ja/events/73/index.html
@@ -379,7 +379,7 @@
         <h2>
         発表動画
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14550670" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14550670" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14550670"></a>
       </p>

--- a/2010/ja/events/75/index.html
+++ b/2010/ja/events/75/index.html
@@ -375,7 +375,7 @@
         <h2>
         発表動画
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14550758" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14550758" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14550758"></a>
       </p>

--- a/2010/ja/events/77/index.html
+++ b/2010/ja/events/77/index.html
@@ -377,7 +377,7 @@
         <h2>
         発表動画
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14823640" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14823640" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14823640"></a>
       </p>

--- a/2010/ja/events/78/index.html
+++ b/2010/ja/events/78/index.html
@@ -375,7 +375,7 @@
         <h2>
         発表動画
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14823175" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14823175" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14823175"></a>
       </p>

--- a/2010/ja/events/80/index.html
+++ b/2010/ja/events/80/index.html
@@ -372,7 +372,7 @@
         <h2>
         発表動画
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14571560" width="400"></iframe> 
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14571560" width="400"></iframe> 
       <p> 
         <a href="http://vimeo.com/14571560"></a> 
       </p> 

--- a/2010/ja/events/81/index.html
+++ b/2010/ja/events/81/index.html
@@ -417,7 +417,7 @@
         <h2>
         発表動画
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14823657" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14823657" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14823657"></a>
       </p>

--- a/2010/ja/events/82/index.html
+++ b/2010/ja/events/82/index.html
@@ -380,7 +380,7 @@
         <h2>
         発表動画
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14823682" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14823682" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14823682"></a>
       </p>

--- a/2010/ja/events/83/index.html
+++ b/2010/ja/events/83/index.html
@@ -377,7 +377,7 @@
         <h2>
         発表動画
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14823720" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14823720" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14823720"></a>
       </p>

--- a/2010/ja/events/84/index.html
+++ b/2010/ja/events/84/index.html
@@ -376,7 +376,7 @@
         <h2>
         発表動画
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14823744" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14823744" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14823744"></a>
       </p>

--- a/2010/ja/events/85/index.html
+++ b/2010/ja/events/85/index.html
@@ -378,7 +378,7 @@
         <h2>
         発表動画
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14823811" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14823811" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14823811"></a>
       </p>

--- a/2010/ja/events/86/index.html
+++ b/2010/ja/events/86/index.html
@@ -377,7 +377,7 @@
         <h2>
         発表動画
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14823856" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14823856" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14823856"></a>
       </p>

--- a/2010/ja/events/88/index.html
+++ b/2010/ja/events/88/index.html
@@ -378,7 +378,7 @@
         <h2>
         発表動画
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14823899" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14823899" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14823899"></a>
       </p>

--- a/2010/ja/events/89/index.html
+++ b/2010/ja/events/89/index.html
@@ -373,7 +373,7 @@
         <h2>
         発表動画
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14550931" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14550931" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14550931"></a>
       </p>

--- a/2010/ja/events/9/index.html
+++ b/2010/ja/events/9/index.html
@@ -378,7 +378,7 @@
         <h2>
         発表動画
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14549764" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14549764" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14549764"></a>
       </p>

--- a/2010/ja/events/91/index.html
+++ b/2010/ja/events/91/index.html
@@ -377,7 +377,7 @@
         <h2>
         発表動画
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14920187" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14920187" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14920187"></a>
       </p>

--- a/2010/ja/events/92/index.html
+++ b/2010/ja/events/92/index.html
@@ -374,7 +374,7 @@
         <h2>
         発表動画
       </h2>
-      <iframe frameborder="0" height="300" src="http://player.vimeo.com/video/14823932" width="400"></iframe>
+      <iframe frameborder="0" height="300" src="https://player.vimeo.com/video/14823932" width="400"></iframe>
       <p>
         <a href="http://vimeo.com/14823932"></a>
       </p>

--- a/2011/en/schedule/details/16M01/index.html
+++ b/2011/en/schedule/details/16M01/index.html
@@ -155,7 +155,7 @@ smooth rock hits of the 70’s and early 80’s.
 <h3 class="cboth">
 Video
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26507951" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26507951" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26507951" target="_blank">
 http://vimeo.com/26507951

--- a/2011/en/schedule/details/16M02/index.html
+++ b/2011/en/schedule/details/16M02/index.html
@@ -146,7 +146,7 @@ CRuby development team
 <h3 class="cboth">
 Video
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26508997" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26508997" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26508997" target="_blank">
 http://vimeo.com/26508997

--- a/2011/en/schedule/details/16M03/index.html
+++ b/2011/en/schedule/details/16M03/index.html
@@ -146,7 +146,7 @@ an initiator of the Shibuya.js. I belong to asakusa.rb. I like Ruby and  instanc
 <h3 class="cboth">
 Video
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26509306" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26509306" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26509306" target="_blank">
 http://vimeo.com/26509306

--- a/2011/en/schedule/details/16M04/index.html
+++ b/2011/en/schedule/details/16M04/index.html
@@ -146,7 +146,7 @@ Hacker at GitHub
 <h3 class="cboth">
 Video
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26509659" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26509659" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26509659" target="_blank">
 http://vimeo.com/26509659

--- a/2011/en/schedule/details/16M05/index.html
+++ b/2011/en/schedule/details/16M05/index.html
@@ -146,7 +146,7 @@ Andy Delcambre started using Ruby while he was a sysadmin in college.  After gra
 <h3 class="cboth">
 Video
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26510145" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26510145" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26510145" target="_blank">
 http://vimeo.com/26510145

--- a/2011/en/schedule/details/16M06/index.html
+++ b/2011/en/schedule/details/16M06/index.html
@@ -156,7 +156,7 @@ Also he is a member of RubyKaigi operation team since 2009 privately.
 <h3 class="cboth">
 Video
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26650083" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26650083" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26650083" target="_blank">
 http://vimeo.com/26650083

--- a/2011/en/schedule/details/16M07/index.html
+++ b/2011/en/schedule/details/16M07/index.html
@@ -149,7 +149,7 @@ a member of "Project Next-L', a voluntary project to develop an open-source libr
 <h3 class="cboth">
 Video
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26519360" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26519360" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26519360" target="_blank">
 http://vimeo.com/26519360

--- a/2011/en/schedule/details/16M08/index.html
+++ b/2011/en/schedule/details/16M08/index.html
@@ -148,7 +148,7 @@ Unit Manager of Development Department, KCS Carrot Corp.
 <h3 class="cboth">
 Video
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26519661" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26519661" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26519661" target="_blank">
 http://vimeo.com/26519661

--- a/2011/en/schedule/details/16MOP/index.html
+++ b/2011/en/schedule/details/16MOP/index.html
@@ -125,14 +125,14 @@ Abstract
 <h3 class="cboth">
 Video
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26507327" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26507327" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26507327" target="_blank">
 http://vimeo.com/26507327
 </a>
 </div>
 
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26507433" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26507433" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26507433" target="_blank">
 http://vimeo.com/26507433

--- a/2011/en/schedule/details/16S01/index.html
+++ b/2011/en/schedule/details/16S01/index.html
@@ -154,7 +154,7 @@ About me: http://sorah.cosmio.net/
 <h3 class="cboth">
 Video
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26505174" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26505174" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26505174" target="_blank">
 http://vimeo.com/26505174

--- a/2011/en/schedule/details/16S02/index.html
+++ b/2011/en/schedule/details/16S02/index.html
@@ -146,7 +146,7 @@ Takahiro Sunaga had studied about Logic and Prolog in undergraduate years.He is 
 <h3 class="cboth">
 Video
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26505273" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26505273" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26505273" target="_blank">
 http://vimeo.com/26505273

--- a/2011/en/schedule/details/16S03/index.html
+++ b/2011/en/schedule/details/16S03/index.html
@@ -149,7 +149,7 @@ April 2011, Yokohama Laboratory, Hitachi Ltd.
 <h3 class="cboth">
 Video
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26505386" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26505386" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26505386" target="_blank">
 http://vimeo.com/26505386

--- a/2011/en/schedule/details/16S04/index.html
+++ b/2011/en/schedule/details/16S04/index.html
@@ -158,7 +158,7 @@ Yukihiro Matsumoto
 <h3 class="cboth">
 Video
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26506938" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26506938" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26506938" target="_blank">
 http://vimeo.com/26506938

--- a/2011/en/schedule/details/16S05/index.html
+++ b/2011/en/schedule/details/16S05/index.html
@@ -153,7 +153,7 @@ My fearful words are "Please revert".
 <h3 class="cboth">
 Video
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26507119" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26507119" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26507119" target="_blank">
 http://vimeo.com/26507119

--- a/2011/en/schedule/details/16S06/index.html
+++ b/2011/en/schedule/details/16S06/index.html
@@ -149,7 +149,7 @@ CRuby Commiter (VM).
 <h3 class="cboth">
 Video
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26507239" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26507239" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26507239" target="_blank">
 http://vimeo.com/26507239

--- a/2011/en/schedule/details/17M01/index.html
+++ b/2011/en/schedule/details/17M01/index.html
@@ -146,7 +146,7 @@ TBD
 <h3 class="cboth">
 Video
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26539927" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26539927" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26539927" target="_blank">
 http://vimeo.com/26539927

--- a/2011/en/schedule/details/17M02/index.html
+++ b/2011/en/schedule/details/17M02/index.html
@@ -146,7 +146,7 @@ Rails Developer, jpmobile contributer. Ph.D. Physics.
 <h3 class="cboth">
 Video
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26540910" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26540910" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26540910" target="_blank">
 http://vimeo.com/26540910

--- a/2011/en/schedule/details/17M03/index.html
+++ b/2011/en/schedule/details/17M03/index.html
@@ -157,7 +157,7 @@ The author of several unique and useful gem/plugins for Rails 3, such as Kaminar
 <h3 class="cboth">
 Video
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26541587" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26541587" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26541587" target="_blank">
 http://vimeo.com/26541587

--- a/2011/en/schedule/details/17M04/index.html
+++ b/2011/en/schedule/details/17M04/index.html
@@ -146,7 +146,7 @@ Rubyist living in Matsue city. Author of the Japanese book "Making Esoteric Lang
 <h3 class="cboth">
 Video
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26550795" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26550795" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26550795" target="_blank">
 http://vimeo.com/26550795

--- a/2011/en/schedule/details/17M05/index.html
+++ b/2011/en/schedule/details/17M05/index.html
@@ -148,7 +148,7 @@ Wen-Tien Chang
 <h3 class="cboth">
 Video
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26551307" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26551307" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26551307" target="_blank">
 http://vimeo.com/26551307

--- a/2011/en/schedule/details/17M06/index.html
+++ b/2011/en/schedule/details/17M06/index.html
@@ -152,7 +152,7 @@ Ruby/Rails Programmer. Love TDD/BDD.
 <h3 class="cboth">
 Video
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26552370" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26552370" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26552370" target="_blank">
 http://vimeo.com/26552370

--- a/2011/en/schedule/details/17M07/index.html
+++ b/2011/en/schedule/details/17M07/index.html
@@ -154,7 +154,7 @@ Check out his stuff on github profile: http://github.com/nu7hatch
 <h3 class="cboth">
 Video
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26552699" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26552699" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26552699" target="_blank">
 http://vimeo.com/26552699

--- a/2011/en/schedule/details/17M08/index.html
+++ b/2011/en/schedule/details/17M08/index.html
@@ -147,7 +147,7 @@ Yehuda Katz is a member of the SproutCore, Ruby on Rails and jQuery Core Teams; 
 <h3 class="cboth">
 Video
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26557190" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26557190" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26557190" target="_blank">
 http://vimeo.com/26557190

--- a/2011/en/schedule/details/17M09/index.html
+++ b/2011/en/schedule/details/17M09/index.html
@@ -146,7 +146,7 @@ Kakutani Shintaro is a just another strong Ruby proponent, chief programmer in E
 <h3 class="cboth">
 Video
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26559212" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26559212" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26559212" target="_blank">
 http://vimeo.com/26559212

--- a/2011/en/schedule/details/17M10/index.html
+++ b/2011/en/schedule/details/17M10/index.html
@@ -323,7 +323,7 @@ Masatoshi SEKI
 <h3 class="cboth">
 Video
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26562213" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26562213" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26562213" target="_blank">
 http://vimeo.com/26562213

--- a/2011/en/schedule/details/17S01/index.html
+++ b/2011/en/schedule/details/17S01/index.html
@@ -149,7 +149,7 @@ She’s a jack of all trades, loves reading, tinkering, food, travel, learning, 
 <h3 class="cboth">
 Video
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26527508" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26527508" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26527508" target="_blank">
 http://vimeo.com/26527508

--- a/2011/en/schedule/details/17S02/index.html
+++ b/2011/en/schedule/details/17S02/index.html
@@ -146,7 +146,7 @@ Programmer. Author of ERB, dRuby and Rinda.
 <h3 class="cboth">
 Video
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26527636" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26527636" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26527636" target="_blank">
 http://vimeo.com/26527636

--- a/2011/en/schedule/details/17S03/index.html
+++ b/2011/en/schedule/details/17S03/index.html
@@ -148,7 +148,7 @@ founder of the Seattle Ruby Brigade.
 <h3 class="cboth">
 Video
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26527737" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26527737" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26527737" target="_blank">
 http://vimeo.com/26527737

--- a/2011/en/schedule/details/17S04/index.html
+++ b/2011/en/schedule/details/17S04/index.html
@@ -146,7 +146,7 @@ Richard Huang (a.k.a flyerhzm) is the senior rails engineer at OpenFeint. He cur
 <h3 class="cboth">
 Video
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26527951" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26527951" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26527951" target="_blank">
 http://vimeo.com/26527951

--- a/2011/en/schedule/details/17S05/index.html
+++ b/2011/en/schedule/details/17S05/index.html
@@ -146,7 +146,7 @@ Hidetoshi NAGAI is a developer of Ruby/Tk. Ruby is a favorite tool for data proc
 <h3 class="cboth">
 Video
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26536996" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26536996" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26536996" target="_blank">
 http://vimeo.com/26536996

--- a/2011/en/schedule/details/17S06/index.html
+++ b/2011/en/schedule/details/17S06/index.html
@@ -146,7 +146,7 @@ a Ruby committer
 <h3 class="cboth">
 Video
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26537238" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26537238" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26537238" target="_blank">
 http://vimeo.com/26537238

--- a/2011/en/schedule/details/17S07/index.html
+++ b/2011/en/schedule/details/17S07/index.html
@@ -167,7 +167,7 @@ He is developing a cloud platform service with JRuby for his company. A member o
 <h3 class="cboth">
 Video
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26537473" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26537473" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26537473" target="_blank">
 http://vimeo.com/26537473

--- a/2011/en/schedule/details/17S08/index.html
+++ b/2011/en/schedule/details/17S08/index.html
@@ -149,7 +149,7 @@ He is maintener of Readline of Ruby.
 <h3 class="cboth">
 Video
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26537809" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26537809" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26537809" target="_blank">
 http://vimeo.com/26537809

--- a/2011/en/schedule/details/17S09/index.html
+++ b/2011/en/schedule/details/17S09/index.html
@@ -153,7 +153,7 @@ Ph.D. student in Dept. of Mathematical and Computing Sciences at Tokyo Institute
 <h3 class="cboth">
 Video
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26538040" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26538040" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26538040" target="_blank">
 http://vimeo.com/26538040

--- a/2011/en/schedule/details/17S10/index.html
+++ b/2011/en/schedule/details/17S10/index.html
@@ -150,7 +150,7 @@ I'm Linux kernel developer and Ruby commiter. I'm interest performance improveme
 <h3 class="cboth">
 Video
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26538260" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26538260" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26538260" target="_blank">
 http://vimeo.com/26538260

--- a/2011/en/schedule/details/18M01/index.html
+++ b/2011/en/schedule/details/18M01/index.html
@@ -170,7 +170,7 @@ Sunao Tanabe
 <h3 class="cboth">
 Video
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26583234" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26583234" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26583234" target="_blank">
 http://vimeo.com/26583234

--- a/2011/en/schedule/details/18M03/index.html
+++ b/2011/en/schedule/details/18M03/index.html
@@ -172,7 +172,7 @@ Kakutani Shintaro is a just another strong Ruby proponent, chief programmer in E
 <h3 class="cboth">
 Video
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26598026" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26598026" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26598026" target="_blank">
 http://vimeo.com/26598026

--- a/2011/en/schedule/details/18M05/index.html
+++ b/2011/en/schedule/details/18M05/index.html
@@ -150,7 +150,7 @@ He is a programmer in Eiwa System Management,Inc. member of Japanese Society for
 <h3 class="cboth">
 Video
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26601980" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26601980" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26601980" target="_blank">
 http://vimeo.com/26601980

--- a/2011/en/schedule/details/18M06/index.html
+++ b/2011/en/schedule/details/18M06/index.html
@@ -146,7 +146,7 @@ He is the president of ClearCode Inc. He is also a developer of RSS Parser, Rabb
 <h3 class="cboth">
 Video
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26602568" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26602568" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26602568" target="_blank">
 http://vimeo.com/26602568

--- a/2011/en/schedule/details/18M07/index.html
+++ b/2011/en/schedule/details/18M07/index.html
@@ -146,7 +146,7 @@ Hiro Asari is a JRuby Support Engineer at Engine Yard. He is also a JRuby commit
 <h3 class="cboth">
 Video
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26698189" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26698189" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26698189" target="_blank">
 http://vimeo.com/26698189

--- a/2011/en/schedule/details/18M08/index.html
+++ b/2011/en/schedule/details/18M08/index.html
@@ -149,7 +149,7 @@ Wrote the book "Ruby逆引きレシピ" (with other authors, published by SHOEIS
 <h3 class="cboth">
 Video
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26627854" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26627854" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26627854" target="_blank">
 http://vimeo.com/26627854

--- a/2011/en/schedule/details/18M09/index.html
+++ b/2011/en/schedule/details/18M09/index.html
@@ -321,7 +321,7 @@ Satoshi GUNJI
 <h3 class="cboth">
 Video
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26631948" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26631948" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26631948" target="_blank">
 http://vimeo.com/26631948

--- a/2011/en/schedule/details/18M10/index.html
+++ b/2011/en/schedule/details/18M10/index.html
@@ -146,7 +146,7 @@ Yukihiro "Matz" Matsumoto
 <h3 class="cboth">
 Video
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26633560" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26633560" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26633560" target="_blank">
 http://vimeo.com/26633560

--- a/2011/en/schedule/details/18MCL/index.html
+++ b/2011/en/schedule/details/18MCL/index.html
@@ -125,7 +125,7 @@ Abstract
 <h3 class="cboth">
 Video
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26647273" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26647273" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26647273" target="_blank">
 http://vimeo.com/26647273

--- a/2011/en/schedule/details/18S01/index.html
+++ b/2011/en/schedule/details/18S01/index.html
@@ -146,7 +146,7 @@ ANDO Yasushi is a perl hater working for a campany mainly using perl.
 <h3 class="cboth">
 Video
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26559563" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26559563" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26559563" target="_blank">
 http://vimeo.com/26559563

--- a/2011/en/schedule/details/18S02/index.html
+++ b/2011/en/schedule/details/18S02/index.html
@@ -155,7 +155,7 @@ things for visual live performances, VJs and music videos.
 <h3 class="cboth">
 Video
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26559991" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26559991" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26559991" target="_blank">
 http://vimeo.com/26559991

--- a/2011/en/schedule/details/18S03/index.html
+++ b/2011/en/schedule/details/18S03/index.html
@@ -150,7 +150,7 @@ Andrew Grimm is a bioinformatician at the University of New South Wales in Sydne
 <h3 class="cboth">
 Video
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26560146" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26560146" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26560146" target="_blank">
 http://vimeo.com/26560146

--- a/2011/en/schedule/details/18S04/index.html
+++ b/2011/en/schedule/details/18S04/index.html
@@ -159,7 +159,7 @@ CEO of Georepublic Japan, a company providing gis-development service using open
 <h3 class="cboth">
 Video
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26560371" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26560371" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26560371" target="_blank">
 http://vimeo.com/26560371

--- a/2011/en/schedule/details/18S05/index.html
+++ b/2011/en/schedule/details/18S05/index.html
@@ -146,7 +146,7 @@ I am a ruby/rails developer working for OptimisCorp in Taiwan.  I haven been inv
 <h3 class="cboth">
 Video
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26583517" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26583517" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26583517" target="_blank">
 http://vimeo.com/26583517

--- a/2011/en/schedule/details/18S06/index.html
+++ b/2011/en/schedule/details/18S06/index.html
@@ -147,7 +147,7 @@ I currently work for Gonow Tecnologia, at São Paulo, Brazil. We are a software 
 <h3 class="cboth">
 Video
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26584318" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26584318" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26584318" target="_blank">
 http://vimeo.com/26584318

--- a/2011/en/schedule/details/18S07/index.html
+++ b/2011/en/schedule/details/18S07/index.html
@@ -147,7 +147,7 @@ Author of Irb
 <h3 class="cboth">
 Video
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26584855" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26584855" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26584855" target="_blank">
 http://vimeo.com/26584855

--- a/2011/en/schedule/details/18S08/index.html
+++ b/2011/en/schedule/details/18S08/index.html
@@ -149,7 +149,7 @@ Programmer.
 <h3 class="cboth">
 Video
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26585481" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26585481" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26585481" target="_blank">
 http://vimeo.com/26585481

--- a/2011/ja/schedule/details/16M01/index.html
+++ b/2011/ja/schedule/details/16M01/index.html
@@ -155,7 +155,7 @@ smooth rock hits of the 70’s and early 80’s.
 <h3 class="cboth">
 発表動画
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26507951" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26507951" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26507951" target="_blank">
 http://vimeo.com/26507951

--- a/2011/ja/schedule/details/16M02/index.html
+++ b/2011/ja/schedule/details/16M02/index.html
@@ -146,7 +146,7 @@ CRuby development team
 <h3 class="cboth">
 発表動画
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26508997" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26508997" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26508997" target="_blank">
 http://vimeo.com/26508997

--- a/2011/ja/schedule/details/16M03/index.html
+++ b/2011/ja/schedule/details/16M03/index.html
@@ -146,7 +146,7 @@ Shibuya.js 発起人。浅草.rb 所属。好きな言語は Ruby。好きなメ
 <h3 class="cboth">
 発表動画
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26509306" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26509306" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26509306" target="_blank">
 http://vimeo.com/26509306

--- a/2011/ja/schedule/details/16M04/index.html
+++ b/2011/ja/schedule/details/16M04/index.html
@@ -146,7 +146,7 @@ Hacker at GitHub
 <h3 class="cboth">
 発表動画
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26509659" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26509659" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26509659" target="_blank">
 http://vimeo.com/26509659

--- a/2011/ja/schedule/details/16M05/index.html
+++ b/2011/ja/schedule/details/16M05/index.html
@@ -146,7 +146,7 @@ Andy Delcambre started using Ruby while he was a sysadmin in college.  After gra
 <h3 class="cboth">
 発表動画
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26510145" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26510145" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26510145" target="_blank">
 http://vimeo.com/26510145

--- a/2011/ja/schedule/details/16M06/index.html
+++ b/2011/ja/schedule/details/16M06/index.html
@@ -155,7 +155,7 @@ SIerがRailsを採用する背景には、高い生産性と業務の変化に�
 <h3 class="cboth">
 発表動画
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26650083" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26650083" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26650083" target="_blank">
 http://vimeo.com/26650083

--- a/2011/ja/schedule/details/16M07/index.html
+++ b/2011/ja/schedule/details/16M07/index.html
@@ -149,7 +149,7 @@ NDL Search: http://iss.ndl.go.jp/
 <h3 class="cboth">
 発表動画
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26519360" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26519360" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26519360" target="_blank">
 http://vimeo.com/26519360

--- a/2011/ja/schedule/details/16M08/index.html
+++ b/2011/ja/schedule/details/16M08/index.html
@@ -150,7 +150,7 @@ Rubyで実装する中で、効果的だと感じた点、
 <h3 class="cboth">
 発表動画
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26519661" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26519661" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26519661" target="_blank">
 http://vimeo.com/26519661

--- a/2011/ja/schedule/details/16MOP/index.html
+++ b/2011/ja/schedule/details/16MOP/index.html
@@ -125,14 +125,14 @@ Opening
 <h3 class="cboth">
 発表動画
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26507327" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26507327" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26507327" target="_blank">
 http://vimeo.com/26507327
 </a>
 </div>
 
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26507433" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26507433" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26507433" target="_blank">
 http://vimeo.com/26507433

--- a/2011/ja/schedule/details/16S01/index.html
+++ b/2011/ja/schedule/details/16S01/index.html
@@ -150,7 +150,7 @@ Shota Fukumori (sora_h)
 <h3 class="cboth">
 発表動画
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26505174" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26505174" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26505174" target="_blank">
 http://vimeo.com/26505174

--- a/2011/ja/schedule/details/16S02/index.html
+++ b/2011/ja/schedule/details/16S02/index.html
@@ -146,7 +146,7 @@ Ruby用のリアルタイム実行時間プロファイラを開発した。本�
 <h3 class="cboth">
 発表動画
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26505273" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26505273" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26505273" target="_blank">
 http://vimeo.com/26505273

--- a/2011/ja/schedule/details/16S03/index.html
+++ b/2011/ja/schedule/details/16S03/index.html
@@ -147,7 +147,7 @@
 <h3 class="cboth">
 発表動画
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26505386" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26505386" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26505386" target="_blank">
 http://vimeo.com/26505386

--- a/2011/ja/schedule/details/16S04/index.html
+++ b/2011/ja/schedule/details/16S04/index.html
@@ -158,7 +158,7 @@
 <h3 class="cboth">
 発表動画
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26506938" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26506938" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26506938" target="_blank">
 http://vimeo.com/26506938

--- a/2011/ja/schedule/details/16S05/index.html
+++ b/2011/ja/schedule/details/16S05/index.html
@@ -152,7 +152,7 @@ RubyKaigi Driven Development(RDD)によるGC開発が得意。
 <h3 class="cboth">
 発表動画
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26507119" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26507119" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26507119" target="_blank">
 http://vimeo.com/26507119

--- a/2011/ja/schedule/details/16S06/index.html
+++ b/2011/ja/schedule/details/16S06/index.html
@@ -146,7 +146,7 @@ CRubyコミッタ（VM関連）．
 <h3 class="cboth">
 発表動画
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26507239" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26507239" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26507239" target="_blank">
 http://vimeo.com/26507239

--- a/2011/ja/schedule/details/17M01/index.html
+++ b/2011/ja/schedule/details/17M01/index.html
@@ -149,7 +149,7 @@ MRIメンテナの一人
 <h3 class="cboth">
 発表動画
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26539927" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26539927" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26539927" target="_blank">
 http://vimeo.com/26539927

--- a/2011/ja/schedule/details/17M02/index.html
+++ b/2011/ja/schedule/details/17M02/index.html
@@ -146,7 +146,7 @@ Railsアプリケーション開発者。jpmobileを開発しています。
 <h3 class="cboth">
 発表動画
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26540910" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26540910" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26540910" target="_blank">
 http://vimeo.com/26540910

--- a/2011/ja/schedule/details/17M03/index.html
+++ b/2011/ja/schedule/details/17M03/index.html
@@ -150,7 +150,7 @@ Rails 3.x用次世代ページネーションライブラリ"Kaminari"、魔法�
 <h3 class="cboth">
 発表動画
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26541587" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26541587" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26541587" target="_blank">
 http://vimeo.com/26541587

--- a/2011/ja/schedule/details/17M04/index.html
+++ b/2011/ja/schedule/details/17M04/index.html
@@ -147,7 +147,7 @@ WEB+DB PRESS連載「Ruby in your hands」(全6回)。
 <h3 class="cboth">
 発表動画
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26550795" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26550795" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26550795" target="_blank">
 http://vimeo.com/26550795

--- a/2011/ja/schedule/details/17M05/index.html
+++ b/2011/ja/schedule/details/17M05/index.html
@@ -148,7 +148,7 @@ Wen-Tien Chang
 <h3 class="cboth">
 発表動画
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26551307" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26551307" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26551307" target="_blank">
 http://vimeo.com/26551307

--- a/2011/ja/schedule/details/17M06/index.html
+++ b/2011/ja/schedule/details/17M06/index.html
@@ -152,7 +152,7 @@ SIerでRuby/Railsプログラマーをやっています。TDD(BDD)が好きで�
 <h3 class="cboth">
 発表動画
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26552370" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26552370" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26552370" target="_blank">
 http://vimeo.com/26552370

--- a/2011/ja/schedule/details/17M07/index.html
+++ b/2011/ja/schedule/details/17M07/index.html
@@ -154,7 +154,7 @@ Check out his stuff on github profile: http://github.com/nu7hatch
 <h3 class="cboth">
 発表動画
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26552699" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26552699" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26552699" target="_blank">
 http://vimeo.com/26552699

--- a/2011/ja/schedule/details/17M08/index.html
+++ b/2011/ja/schedule/details/17M08/index.html
@@ -147,7 +147,7 @@ Yehuda Katz is a member of the SproutCore, Ruby on Rails and jQuery Core Teams; 
 <h3 class="cboth">
 発表動画
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26557190" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26557190" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26557190" target="_blank">
 http://vimeo.com/26557190

--- a/2011/ja/schedule/details/17M09/index.html
+++ b/2011/ja/schedule/details/17M09/index.html
@@ -146,7 +146,7 @@ RubyKaigi2007でDave Thomasは私たち日本のRubyistに「宿題」を出し�
 <h3 class="cboth">
 発表動画
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26559212" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26559212" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26559212" target="_blank">
 http://vimeo.com/26559212

--- a/2011/ja/schedule/details/17M10/index.html
+++ b/2011/ja/schedule/details/17M10/index.html
@@ -323,7 +323,7 @@ Eloy Durán &amp; Vincent Isambart
 <h3 class="cboth">
 発表動画
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26562213" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26562213" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26562213" target="_blank">
 http://vimeo.com/26562213

--- a/2011/ja/schedule/details/17S01/index.html
+++ b/2011/ja/schedule/details/17S01/index.html
@@ -149,7 +149,7 @@ She’s a jack of all trades, loves reading, tinkering, food, travel, learning, 
 <h3 class="cboth">
 発表動画
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26527508" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26527508" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26527508" target="_blank">
 http://vimeo.com/26527508

--- a/2011/ja/schedule/details/17S02/index.html
+++ b/2011/ja/schedule/details/17S02/index.html
@@ -148,7 +148,7 @@ Rinda::TupleSpaceの永続化機能の発表から数年たちました。
 <h3 class="cboth">
 発表動画
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26527636" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26527636" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26527636" target="_blank">
 http://vimeo.com/26527636

--- a/2011/ja/schedule/details/17S03/index.html
+++ b/2011/ja/schedule/details/17S03/index.html
@@ -148,7 +148,7 @@ founder of the Seattle Ruby Brigade.
 <h3 class="cboth">
 発表動画
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26527737" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26527737" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26527737" target="_blank">
 http://vimeo.com/26527737

--- a/2011/ja/schedule/details/17S04/index.html
+++ b/2011/ja/schedule/details/17S04/index.html
@@ -146,7 +146,7 @@ Richard Huang (a.k.a flyerhzm) is the senior rails engineer at OpenFeint. He cur
 <h3 class="cboth">
 発表動画
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26527951" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26527951" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26527951" target="_blank">
 http://vimeo.com/26527951

--- a/2011/ja/schedule/details/17S05/index.html
+++ b/2011/ja/schedule/details/17S05/index.html
@@ -146,7 +146,7 @@ Rubyの組み込みクラスの一つであるThreadGroupは，thread集合を�
 <h3 class="cboth">
 発表動画
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26536996" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26536996" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26536996" target="_blank">
 http://vimeo.com/26536996

--- a/2011/ja/schedule/details/17S06/index.html
+++ b/2011/ja/schedule/details/17S06/index.html
@@ -146,7 +146,7 @@ Rubyコミッタ
 <h3 class="cboth">
 発表動画
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26537238" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26537238" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26537238" target="_blank">
 http://vimeo.com/26537238

--- a/2011/ja/schedule/details/17S07/index.html
+++ b/2011/ja/schedule/details/17S07/index.html
@@ -168,7 +168,7 @@ JRubyを使ってクラウドプラットフォームを開発している。日
 <h3 class="cboth">
 発表動画
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26537473" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26537473" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26537473" target="_blank">
 http://vimeo.com/26537473

--- a/2011/ja/schedule/details/17S08/index.html
+++ b/2011/ja/schedule/details/17S08/index.html
@@ -151,7 +151,7 @@ MRIメンテナの一人。担当はReadlineライブラリです。
 <h3 class="cboth">
 発表動画
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26537809" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26537809" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26537809" target="_blank">
 http://vimeo.com/26537809

--- a/2011/ja/schedule/details/17S09/index.html
+++ b/2011/ja/schedule/details/17S09/index.html
@@ -150,7 +150,7 @@ Method Shelters : Classboxes でも Refinements でもない別のやり方
 <h3 class="cboth">
 発表動画
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26538040" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26538040" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26538040" target="_blank">
 http://vimeo.com/26538040

--- a/2011/ja/schedule/details/17S10/index.html
+++ b/2011/ja/schedule/details/17S10/index.html
@@ -150,7 +150,7 @@ Rubyコミッタ。世界的にもめずらしいLinuxカーネル開発者と�
 <h3 class="cboth">
 発表動画
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26538260" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26538260" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26538260" target="_blank">
 http://vimeo.com/26538260

--- a/2011/ja/schedule/details/18M01/index.html
+++ b/2011/ja/schedule/details/18M01/index.html
@@ -173,7 +173,7 @@ Sunao Tanabe
 <h3 class="cboth">
 発表動画
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26583234" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26583234" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26583234" target="_blank">
 http://vimeo.com/26583234

--- a/2011/ja/schedule/details/18M03/index.html
+++ b/2011/ja/schedule/details/18M03/index.html
@@ -172,7 +172,7 @@ All About RubyKaigi Ecosystem
 <h3 class="cboth">
 発表動画
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26598026" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26598026" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26598026" target="_blank">
 http://vimeo.com/26598026

--- a/2011/ja/schedule/details/18M05/index.html
+++ b/2011/ja/schedule/details/18M05/index.html
@@ -148,7 +148,7 @@ Ruby遺産とレガシーコード修理技術
 <h3 class="cboth">
 発表動画
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26601980" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26601980" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26601980" target="_blank">
 http://vimeo.com/26601980

--- a/2011/ja/schedule/details/18M06/index.html
+++ b/2011/ja/schedule/details/18M06/index.html
@@ -148,7 +148,7 @@
 <h3 class="cboth">
 発表動画
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26602568" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26602568" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26602568" target="_blank">
 http://vimeo.com/26602568

--- a/2011/ja/schedule/details/18M07/index.html
+++ b/2011/ja/schedule/details/18M07/index.html
@@ -146,7 +146,7 @@ Hiro Asari is a JRuby Support Engineer at Engine Yard. He is also a JRuby commit
 <h3 class="cboth">
 発表動画
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26698189" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26698189" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26698189" target="_blank">
 http://vimeo.com/26698189

--- a/2011/ja/schedule/details/18M08/index.html
+++ b/2011/ja/schedule/details/18M08/index.html
@@ -149,7 +149,7 @@ Ruby の教えてくれたこと
 <h3 class="cboth">
 発表動画
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26627854" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26627854" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26627854" target="_blank">
 http://vimeo.com/26627854

--- a/2011/ja/schedule/details/18M09/index.html
+++ b/2011/ja/schedule/details/18M09/index.html
@@ -321,7 +321,7 @@ C、イ㌔。
 <h3 class="cboth">
 発表動画
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26631948" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26631948" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26631948" target="_blank">
 http://vimeo.com/26631948

--- a/2011/ja/schedule/details/18M10/index.html
+++ b/2011/ja/schedule/details/18M10/index.html
@@ -146,7 +146,7 @@ Rubyのパパ。肩書が順調に増加中です。
 <h3 class="cboth">
 発表動画
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26633560" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26633560" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26633560" target="_blank">
 http://vimeo.com/26633560

--- a/2011/ja/schedule/details/18MCL/index.html
+++ b/2011/ja/schedule/details/18MCL/index.html
@@ -125,7 +125,7 @@ Closing
 <h3 class="cboth">
 発表動画
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26647273" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26647273" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26647273" target="_blank">
 http://vimeo.com/26647273

--- a/2011/ja/schedule/details/18S01/index.html
+++ b/2011/ja/schedule/details/18S01/index.html
@@ -146,7 +146,7 @@ Perlの会社でPerlに触れずにどこまで行けるかチキンレース真
 <h3 class="cboth">
 発表動画
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26559563" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26559563" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26559563" target="_blank">
 http://vimeo.com/26559563

--- a/2011/ja/schedule/details/18S02/index.html
+++ b/2011/ja/schedule/details/18S02/index.html
@@ -148,7 +148,7 @@ ucnv
 <h3 class="cboth">
 発表動画
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26559991" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26559991" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26559991" target="_blank">
 http://vimeo.com/26559991

--- a/2011/ja/schedule/details/18S03/index.html
+++ b/2011/ja/schedule/details/18S03/index.html
@@ -150,7 +150,7 @@ So accelerate your Rubies towards the speed of light and see what gets produced.
 <h3 class="cboth">
 発表動画
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26560146" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26560146" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26560146" target="_blank">
 http://vimeo.com/26560146

--- a/2011/ja/schedule/details/18S04/index.html
+++ b/2011/ja/schedule/details/18S04/index.html
@@ -164,7 +164,7 @@ Georepublic Japan CEO. オープンソースソフトウェアを使ったGIS �
 <h3 class="cboth">
 発表動画
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26560371" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26560371" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26560371" target="_blank">
 http://vimeo.com/26560371

--- a/2011/ja/schedule/details/18S05/index.html
+++ b/2011/ja/schedule/details/18S05/index.html
@@ -146,7 +146,7 @@ I am a ruby/rails developer working for OptimisCorp in Taiwan.  I haven been inv
 <h3 class="cboth">
 発表動画
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26583517" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26583517" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26583517" target="_blank">
 http://vimeo.com/26583517

--- a/2011/ja/schedule/details/18S06/index.html
+++ b/2011/ja/schedule/details/18S06/index.html
@@ -147,7 +147,7 @@ I currently work for Gonow Tecnologia, at São Paulo, Brazil. We are a software 
 <h3 class="cboth">
 発表動画
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26584318" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26584318" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26584318" target="_blank">
 http://vimeo.com/26584318

--- a/2011/ja/schedule/details/18S07/index.html
+++ b/2011/ja/schedule/details/18S07/index.html
@@ -147,7 +147,7 @@ Irbの作者。
 <h3 class="cboth">
 発表動画
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26584855" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26584855" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26584855" target="_blank">
 http://vimeo.com/26584855

--- a/2011/ja/schedule/details/18S08/index.html
+++ b/2011/ja/schedule/details/18S08/index.html
@@ -152,7 +152,7 @@ O/R Mapperを使うとRDBMSを扱うのが簡単になると期待されます�
 <h3 class="cboth">
 発表動画
 </h3>
-<iframe frameborder="0" height="300" src="http://player.vimeo.com/video/26585481" width="400"></iframe>
+<iframe frameborder="0" height="300" src="https://player.vimeo.com/video/26585481" width="400"></iframe>
 <div>
 <a href="http://vimeo.com/26585481" target="_blank">
 http://vimeo.com/26585481

--- a/2013/lightning_talks/index.html
+++ b/2013/lightning_talks/index.html
@@ -39,7 +39,7 @@
       <article id='content'>
         <h1>Lightning Talks</h1>
         <h2>Recorded Video</h2>
-        <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='http://player.vimeo.com/video/68850145' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
+        <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='https://player.vimeo.com/video/68850145' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
         <p>
           <a target="_blank" href="http://vimeo.com/68850145">Lightning Talks</a>
           from

--- a/2013/talk/S01/index.html
+++ b/2013/talk/S01/index.html
@@ -53,7 +53,7 @@
             <p>This talk will cover the development of mruby. The current state of the implementation and the reason why you should contribute to it.</p>
           </div>
           <h3>Recorded Video</h3>
-          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='http://player.vimeo.com/video/69748752' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
+          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='https://player.vimeo.com/video/69748752' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
           <p>
             <a target="_blank" href="http://vimeo.com/69748752">Shrink to Grow</a>
             from

--- a/2013/talk/S05/index.html
+++ b/2013/talk/S05/index.html
@@ -53,7 +53,7 @@
             <p>Vagrant and VirtualBox are used to provide a development environment with the same OS you use in production. Chef is used to install the same packages. In fact you use the same chef recipes everywhere.</p>
           </div>
           <h3>Recorded Video</h3>
-          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='http://player.vimeo.com/video/67731302' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
+          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='https://player.vimeo.com/video/67731302' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
           <p>
             <a target="_blank" href="http://vimeo.com/67731302">Identical Production, Staging and Development Environments Using Chef, AWS and Vagrant</a>
             from

--- a/2013/talk/S06/index.html
+++ b/2013/talk/S06/index.html
@@ -49,7 +49,7 @@
             <p>Traditional data structures like stacks and queues are strict - perhaps too strict. In this talk I will showcase some classical data structures and then provide alternative constraints that will allow our algorithms to achieve a greater level of concurrency. Examples will include a mix of Ruby and Postgres.</p>
           </div>
           <h3>Recorded Video</h3>
-          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='http://player.vimeo.com/video/68850147' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
+          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='https://player.vimeo.com/video/68850147' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
           <p>
             <a target="_blank" href="http://vimeo.com/68850147">Fewer Constraints, More Concurrency.</a>
             from

--- a/2013/talk/S07/index.html
+++ b/2013/talk/S07/index.html
@@ -49,7 +49,7 @@
             <p>Webruby uses emscripten to compile mruby, the lightweight Ruby implementation into pure JavaScript. This allows programmers to write Ruby code and run it in the browser. What's more, we also built a JavaScript calling interface from Webruby, and an OpenGL ES 2.0 binding. While naturally suited for building Web-based games, Webruby also provides an alternative for modern single-page applications without using JavaScript.</p>
           </div>
           <h3>Recorded Video</h3>
-          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='http://player.vimeo.com/video/70673036' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
+          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='https://player.vimeo.com/video/70673036' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
           <p>
             <a target="_blank" href="http://vimeo.com/70673036">Webruby: Now you can write your favorite Ruby code for the browser!</a>
             from

--- a/2013/talk/S08/index.html
+++ b/2013/talk/S08/index.html
@@ -50,7 +50,7 @@
             I'll describe and introduce my work between Feb and Jun. and I'll announce some big news in RubyKaigi.</p>
           </div>
           <h3>Recorded Video</h3>
-          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='http://player.vimeo.com/video/67807964' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
+          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='https://player.vimeo.com/video/67807964' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
           <p>
             <a target="_blank" href="http://vimeo.com/67807964">Ruby 'root'</a>
             from

--- a/2013/talk/S09/index.html
+++ b/2013/talk/S09/index.html
@@ -55,7 +55,7 @@
             <p>Zachary Scott has been a Ruby committer since last Fall and will share his experiences with the standard library of MRI.</p>
           </div>
           <h3>Recorded Video</h3>
-          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='http://player.vimeo.com/video/69161545' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
+          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='https://player.vimeo.com/video/69161545' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
           <p>
             <a target="_blank" href="http://vimeo.com/69161545">Contributing to Ruby</a>
             from

--- a/2013/talk/S17/index.html
+++ b/2013/talk/S17/index.html
@@ -49,7 +49,7 @@
             <p>Heroku has deployed over a million web apps. When you've run that many applications, it's hard not to notice when frameworks and developers do things wrong, and when they do them right. We've taken a look at the most common patterns and boiled down the best of our advice in to 12 simple factors that can help you build your next app to be stable, successful, and scalable. After this talk you'll walk away with in depth knowledge of web framework design patterns and practical examples of how to improve your application code.</p>
           </div>
           <h3>Recorded Video</h3>
-          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='http://player.vimeo.com/video/70673039' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
+          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='https://player.vimeo.com/video/70673039' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
           <p>
             <a target="_blank" href="http://vimeo.com/70673039">Millions of Apps Deployed: What We've Learned</a>
             from

--- a/2013/talk/S19/index.html
+++ b/2013/talk/S19/index.html
@@ -54,7 +54,7 @@
             of code generation without the maintenance nightmare</p>
           </div>
           <h3>Recorded Video</h3>
-          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='http://player.vimeo.com/video/69161543' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
+          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='https://player.vimeo.com/video/69161543' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
           <p>
             <a target="_blank" href="http://vimeo.com/69161543">Unfactoring</a>
             from

--- a/2013/talk/S20/index.html
+++ b/2013/talk/S20/index.html
@@ -49,7 +49,7 @@
             <p>It's been 5 years since 1.8.7, 10 years since 1.8.0.  Remember those 1.8 era.</p>
           </div>
           <h3>Recorded Video</h3>
-          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='http://player.vimeo.com/video/71052215' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
+          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='https://player.vimeo.com/video/71052215' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
           <p>
             <a target="_blank" href="http://vimeo.com/71052215">10 years of Ruby 1.8</a>
             from

--- a/2013/talk/S21/index.html
+++ b/2013/talk/S21/index.html
@@ -49,7 +49,7 @@
             <p>As the responsibility of our applications grows, so too does our code. We'll walk through techniques of object-oriented programming that help clarify our intent and put responsibilities right where we need them.</p>
           </div>
           <h3>Recorded Video</h3>
-          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='http://player.vimeo.com/video/68850148' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
+          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='https://player.vimeo.com/video/68850148' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
           <p>
             <a target="_blank" href="http://vimeo.com/68850148">If you do not enter the tiger's cave, you will not catch its cub: Objects, DCI, and Programming</a>
             from

--- a/2013/talk/S22/index.html
+++ b/2013/talk/S22/index.html
@@ -49,7 +49,7 @@
             <p>This talk will describe the internals of RubyMotion, a Ruby toolchain for iOS development. RubyMotion is different from CRuby in many ways and this session will focus on the technical differences and explain what makes RubyMotion unique.</p>
           </div>
           <h3>Recorded Video</h3>
-          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='http://player.vimeo.com/video/67731482' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
+          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='https://player.vimeo.com/video/67731482' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
           <p>
             <a target="_blank" href="http://vimeo.com/67731482">Inside RubyMotion</a>
             from

--- a/2013/talk/S24/index.html
+++ b/2013/talk/S24/index.html
@@ -49,7 +49,7 @@
             <p>Origami and the Ruby programming language have a lot more in common than having Japanese roots. This talk will make parallels between the two with the goal of presenting various techniques at becoming a better artist of code.</p>
           </div>
           <h3>Recorded Video</h3>
-          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='http://player.vimeo.com/video/70184420' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
+          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='https://player.vimeo.com/video/70184420' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
           <p>
             <a target="_blank" href="http://vimeo.com/70184420">The Origamist's Ruby: Folding better code
             </a>

--- a/2013/talk/S26/index.html
+++ b/2013/talk/S26/index.html
@@ -53,7 +53,7 @@
             <p>Why? Because we're curious about it, that's why.</p>
           </div>
           <h3>Recorded Video</h3>
-          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='http://player.vimeo.com/video/70184258' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
+          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='https://player.vimeo.com/video/70184258' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
           <p>
             <a target="_blank" href="http://vimeo.com/70184258">From Rails to the web server to the browser</a>
             from

--- a/2013/talk/S27/index.html
+++ b/2013/talk/S27/index.html
@@ -51,7 +51,7 @@
             <p>This talk will tell you how you can use RubyJS to stay sane when writing JavaScript. I'll show best practices, tips &amp; tricks for daily use and how you can extend RubyJS with more methods and classes.</p>
           </div>
           <h3>Recorded Video</h3>
-          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='http://player.vimeo.com/video/69748750' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
+          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='https://player.vimeo.com/video/69748750' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
           <p>
             <a target="_blank" href="http://vimeo.com/69748750">RubyJS</a>
             from

--- a/2013/talk/S29/index.html
+++ b/2013/talk/S29/index.html
@@ -59,7 +59,7 @@
             <p>Find out how!</p>
           </div>
           <h3>Recorded Video</h3>
-          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='http://player.vimeo.com/video/70184257' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
+          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='https://player.vimeo.com/video/70184257' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
           <p>
             <a target="_blank" href="http://vimeo.com/70184257">krypt. semper pi.</a>
             from

--- a/2013/talk/S30/index.html
+++ b/2013/talk/S30/index.html
@@ -62,7 +62,7 @@
             </ul>
           </div>
           <h3>Recorded Video</h3>
-          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='http://player.vimeo.com/video/68850149' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
+          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='https://player.vimeo.com/video/68850149' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
           <p>
             <a target="_blank" href="http://vimeo.com/68850149">Async programming is all about programming synchronously
             </a>

--- a/2013/talk/S32/index.html
+++ b/2013/talk/S32/index.html
@@ -53,7 +53,7 @@
             <p>This talk will explore patterns to smoothly deal with increasing intrinsic complexity (read: features!) of your application. Transform fat models into a coordinated set of small, encapsulated objects working together in a veritable symphony.</p>
           </div>
           <h3>Recorded Video</h3>
-          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='http://player.vimeo.com/video/68611168' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
+          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='https://player.vimeo.com/video/68611168' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
           <p>
             <a target="_blank" href="http://vimeo.com/68611168">Refactoring Fat Models with Patterns</a>
             from

--- a/2013/talk/S34/index.html
+++ b/2013/talk/S34/index.html
@@ -49,7 +49,7 @@
             <p>Netzke is a library that allows creating full-featured client-server GUI components - such as data grids, forms, windows, trees, etc - which then can be easily used as building blocks for complex enterprise applications. It uses Ruby on Rails at the server-side, and Sencha Ext JS in the browser. The choice of Ext JS provides for consistent look and feel, as well as for painless reusability of third-party Netzke components. Most importantly, Netzke allows for writing clean and highly maintainable code, which almost doesn't grow with the number of data models being used. After a brief introduction to the basics of Netzke design, some cool code will be shown from a fairly complex real-life web application, which will demonstrate a few highly practical aspects of Netzke.</p>
           </div>
           <h3>Recorded Video</h3>
-          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='http://player.vimeo.com/video/69128205' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
+          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='https://player.vimeo.com/video/69128205' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
           <p>
             <a target="_blank" href="http://vimeo.com/69128205">Rapid development of enterprise web apps with Netzke</a>
             from

--- a/2013/talk/S39/index.html
+++ b/2013/talk/S39/index.html
@@ -51,7 +51,7 @@
             <p>This presentation will answer questions like this and give some examples of exciting future projects involving JRuby.  If you want a good insight into where JRuby is going then this talk is for you.</p>
           </div>
           <h3>Recorded Video</h3>
-          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='http://player.vimeo.com/video/68301517' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
+          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='https://player.vimeo.com/video/68301517' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
           <p>
             <a target="_blank" href="http://vimeo.com/68301517">The Future of JRuby?</a>
             from

--- a/2013/talk/S41/index.html
+++ b/2013/talk/S41/index.html
@@ -49,7 +49,7 @@
             <p>Learn more about Ruby internal by reading Ruby source code, which may or may not be revealed on textbook.</p>
           </div>
           <h3>Recorded Video</h3>
-          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='http://player.vimeo.com/video/69748751' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
+          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='https://player.vimeo.com/video/69748751' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
           <p>
             <a target="_blank" href="http://vimeo.com/69748751">Code Reading - Learning More about Ruby by Reading Ruby Source Code</a>
             from

--- a/2013/talk/S42/index.html
+++ b/2013/talk/S42/index.html
@@ -49,7 +49,7 @@
             <p>We all want to keep our code clean. But it's not very easy when features to implement come in waves. How can we keep code clean? How does the metric help or do no good? Let's seek with some data in the wild.</p>
           </div>
           <h3>Recorded Video</h3>
-          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='http://player.vimeo.com/video/70670186' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
+          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='https://player.vimeo.com/video/70670186' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
           <p>
             <a target="_blank" href="http://vimeo.com/70670186">The Metric Talks or Not</a>
             from

--- a/2013/talk/S43/index.html
+++ b/2013/talk/S43/index.html
@@ -49,7 +49,7 @@
             <p>The last few months have been pretty brutal for anyone who depends on Ruby libraries in production. Ruby is really popular now, and that’s exciting! But it also means that we are now square in the crosshairs of security researchers, whether whitehat, blackhat, or some other hat. Only the Ruby and Rails core teams have meaningful experience with vulnerabilites so far. It won’t last. Vulnerabilities are everywhere, and handling security issues responsibly is critical if we want Ruby (and Rubyists) to stay in high demand. Using Bundler’s first CVE as a case study, I’ll explain responsible disclosure for bugs you find, and repsonsible ownership of your own code. Don’t let your site get hacked, or worse yet, let your project allow someone else’s site to get hacked! Learn from the hard-won wisdom of the security community so that we won’t repeat the mistakes of others.</p>
           </div>
           <h3>Recorded Video</h3>
-          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='http://player.vimeo.com/video/68464116' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
+          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='https://player.vimeo.com/video/68464116' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
           <p>
             <a target="_blank" href="http://vimeo.com/68464116">Security is hard, but we can’t go shopping</a>
             from

--- a/2013/talk/S48/index.html
+++ b/2013/talk/S48/index.html
@@ -51,7 +51,7 @@
             So we are developing open source CEP tool with Fluentd, that have great features for event data collection and delivery. I want to tell you implementation details and practical usages.</p>
           </div>
           <h3>Recorded Video</h3>
-          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='http://player.vimeo.com/video/69161544' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
+          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='https://player.vimeo.com/video/69161544' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
           <p>
             <a target="_blank" href="http://vimeo.com/69161544">Complex Event Processing on Ruby and Fluentd</a>
             from

--- a/2013/talk/S49/index.html
+++ b/2013/talk/S49/index.html
@@ -50,7 +50,7 @@
             For instance, I will introduce about implementations of Bitmap Marking GC and so on, and show results of benchmarks after these are implemented.</p>
           </div>
           <h3>Recorded Video</h3>
-          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='http://player.vimeo.com/video/68611167' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
+          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='https://player.vimeo.com/video/68611167' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
           <p>
             <a target="_blank" href="http://vimeo.com/68611167">Ruby's GC 2.0</a>
             from

--- a/2013/talk/S50/index.html
+++ b/2013/talk/S50/index.html
@@ -57,7 +57,7 @@
             evaluation?</p>
           </div>
           <h3>Recorded Video</h3>
-          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='http://player.vimeo.com/video/69128201' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
+          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='https://player.vimeo.com/video/69128201' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
           <p>
             <a target="_blank" href="http://vimeo.com/69128201">Beyond Ruby</a>
             from

--- a/2013/talk/S52/index.html
+++ b/2013/talk/S52/index.html
@@ -49,7 +49,7 @@
             <p>There are two legal bodies who support Rubyists in Japan; Ruby Association and Ruby-no-Kai.  What are their activities?  What is the difference between them?  It's time to unveil them.</p>
           </div>
           <h3>Recorded Video</h3>
-          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='http://player.vimeo.com/video/70184263' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
+          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='https://player.vimeo.com/video/70184263' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
           <p>
             <a target="_blank" href="http://vimeo.com/70184263">Two Legal Bodies about Ruby and its projects</a>
             from

--- a/2013/talk/S53/index.html
+++ b/2013/talk/S53/index.html
@@ -55,7 +55,7 @@
             <p>See more information: <a href="https://sites.google.com/site/trickcontest2013/">https://sites.google.com/site/trickcontest2013/</a></p>
           </div>
           <h3>Recorded Video</h3>
-          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='http://player.vimeo.com/video/70670188' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
+          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='https://player.vimeo.com/video/70670188' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
           <p>
             <a target="_blank" href="http://vimeo.com/70670188">TRICK (Transcendental Ruby Imbroglio Contest for rubyKaigi)</a>
             from

--- a/2013/talk/S54/index.html
+++ b/2013/talk/S54/index.html
@@ -55,7 +55,7 @@
             <p>We've prototyped a replay service, to replay production traffic to different Heroku apps. With this and our instrumentation we were able to compare performance impact of different changes. We've used this data to guide our decision to change web servers from thin to unicorn. We're also keeping tabs on various setups including MRI 2 and JRuby under real production code and load. We'll go over how we've set this up and how it works on Heroku.</p>
           </div>
           <h3>Recorded Video</h3>
-          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='http://player.vimeo.com/video/67807956' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
+          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='https://player.vimeo.com/video/67807956' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
           <p>
             <a target="_blank" href="http://vimeo.com/67807956">`bundle install` Y U SO SLOW: Server Edition</a>
             from

--- a/2013/talk/S55/index.html
+++ b/2013/talk/S55/index.html
@@ -53,7 +53,7 @@
             <p>Having a great idea, creating useful products, and writing stellar code can be done by smart people. The difficult part is figuring out how to get tons of smart people to work well together. The social aspect is hard, but when you build a culture based off of values that are important to a family you'll see the amazing things that can be done.</p>
           </div>
           <h3>Recorded Video</h3>
-          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='http://player.vimeo.com/video/69688044' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
+          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='https://player.vimeo.com/video/69688044' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
           <p>
             <a target="_blank" href="http://vimeo.com/69688044">We Are Family</a>
             from

--- a/2013/talk/S57/index.html
+++ b/2013/talk/S57/index.html
@@ -49,7 +49,7 @@
             <p>The first session in RubyKaigi 2006, the first RubyKaigi, is "The History of Ruby."  As re-booting of RubyKaigi, we'd like to take a look back over the history of Ruby and us again.</p>
           </div>
           <h3>Recorded Video</h3>
-          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='http://player.vimeo.com/video/67731254' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
+          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='https://player.vimeo.com/video/67731254' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
           <p>
             <a target="_blank" href="http://vimeo.com/67731254">The History of Ruby;20th Anniversary Ed.</a>
             from

--- a/2013/talk/S58/index.html
+++ b/2013/talk/S58/index.html
@@ -49,7 +49,7 @@
             <p>Refinements have been introduced in Ruby 2.0.  However, they are experimental, and some of the features have been removed from Ruby 2.0.0.  This talk explains the current features of Refinements, their limits, and how to refine Refinements themselves in Ruby 2.1.</p>
           </div>
           <h3>Recorded Video</h3>
-          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='http://player.vimeo.com/video/71052100' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
+          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='https://player.vimeo.com/video/71052100' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
           <p>
             <a target="_blank" href="http://vimeo.com/71052100">Refining refinements</a>
             from

--- a/2013/talk/S59/index.html
+++ b/2013/talk/S59/index.html
@@ -49,7 +49,7 @@
             <p>So, it seems like you've finished writing your awesome gem. However, are you sure that your gem is working perfectly against multiple versions of its dependency? Are you sure that you didn't break any backward compatibility? In this talk, I'm going to show you the approach we have been taken to test our gems against multiple versions of dependencies, such as testing against Rails 3.2 and Rails 3.1. I'm also going to introduce you to our gem called "Appraisal" which helps you generating Gemfiles to be used with Bundler, and also guide it to running your test suite against those multiple Gemfiles. Lastly, I'm going to show you how you can config Travis CI to test your gem against those multiple versions of dependencies.</p>
           </div>
           <h3>Recorded Video</h3>
-          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='http://player.vimeo.com/video/69748748' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
+          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='https://player.vimeo.com/video/69748748' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
           <p>
             <a target="_blank" href="http://vimeo.com/69748748">You have to test multiple versions of your gem's dependencies. You used Appraisal. It's super affective!</a>
             from

--- a/2013/talk/S61/index.html
+++ b/2013/talk/S61/index.html
@@ -53,7 +53,7 @@
             <p>Starting with Rails 3, I have applied this technique to a number of practical applications. In the process, I have struggled and learned many lessons about how to extract code into concerns, how to test such concerns, and what level of metaprogramming to use. In this talk I'd like to share some of these lessons with you.                                       </p>
           </div>
           <h3>Recorded Video</h3>
-          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='http://player.vimeo.com/video/68611166' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
+          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='https://player.vimeo.com/video/68611166' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
           <p>
             <a target="_blank" href="http://vimeo.com/68611166">Concerning `Applications'</a>
             from

--- a/2013/talk/S62/index.html
+++ b/2013/talk/S62/index.html
@@ -70,7 +70,7 @@
             </ul>
           </div>
           <h3>Recorded Video</h3>
-          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='http://player.vimeo.com/video/71052214' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
+          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='https://player.vimeo.com/video/71052214' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
           <p>
             <a target="_blank" href="http://vimeo.com/71052214">Ruby Kaja 2013 / Community Appeal</a>
             from

--- a/2013/talk/S64/index.html
+++ b/2013/talk/S64/index.html
@@ -63,7 +63,7 @@
             <p>The time has come for Ruby-based robotics, and Artoo can help lead the way!</p>
           </div>
           <h3>Recorded Video</h3>
-          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='http://player.vimeo.com/video/69688042' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
+          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='https://player.vimeo.com/video/69688042' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
           <p>
             <a target="_blank" href="http://vimeo.com/69688042">Ruby On Robots Using Artoo: A New Platform For Robotics, Physical Computing, and the Real World Web</a>
             from

--- a/2013/talk/S66/index.html
+++ b/2013/talk/S66/index.html
@@ -49,7 +49,7 @@
             <p>Introducing the efforts to the present and future directivity about Windows support of Ruby, and also introducing the truth of how Ruby can actually be used on Windows now.</p>
           </div>
           <h3>Recorded Video</h3>
-          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='http://player.vimeo.com/video/70673037' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
+          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='https://player.vimeo.com/video/70673037' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
           <p>
             <a target="_blank" href="http://vimeo.com/70673037">Ruby on Windows -- the past, the present, and the future</a>
             from

--- a/2013/talk/S67/index.html
+++ b/2013/talk/S67/index.html
@@ -56,7 +56,7 @@
             </ul>
           </div>
           <h3>Recorded Video</h3>
-          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='http://player.vimeo.com/video/70673038' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
+          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='https://player.vimeo.com/video/70673038' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
           <p>
             <a target="_blank" href="http://vimeo.com/70673038">How NougakuDo connect Windows Azure and Rails Application</a>
             from

--- a/2013/talk/S68/index.html
+++ b/2013/talk/S68/index.html
@@ -49,7 +49,7 @@
             <p>Pair programming shares a similar philosophy with Ruby- the focus is on  people solving problems for other people, not the machine. I want to share my experiences with pair programming and how it helped me become a better engineer, enjoy coding more, and maybe even grow as a person.</p>
           </div>
           <h3>Recorded Video</h3>
-          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='http://player.vimeo.com/video/71052101' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
+          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='https://player.vimeo.com/video/71052101' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
           <p>
             <a target="_blank" href="http://vimeo.com/71052101">Paired ruby</a>
             from

--- a/2013/talk/S69/index.html
+++ b/2013/talk/S69/index.html
@@ -51,7 +51,7 @@
             I'll also talk about where we'd like to go in the future with the project.</p>
           </div>
           <h3>Recorded Video</h3>
-          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='http://player.vimeo.com/video/69688043' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
+          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='https://player.vimeo.com/video/69688043' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
           <p>
             <a target="_blank" href="http://vimeo.com/69688043">Ruby2.0 reference manual for Japanese</a>
             from

--- a/2013/talk/S70/index.html
+++ b/2013/talk/S70/index.html
@@ -54,7 +54,7 @@
             Useful logging patters and query tools in Ruby-ish way will also be introduced.</p>
           </div>
           <h3>Recorded Video</h3>
-          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='http://player.vimeo.com/video/69128202' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
+          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='https://player.vimeo.com/video/69128202' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
           <p>
             <a target="_blank" href="http://vimeo.com/69128202">Casual Log Collection and Querying with fluent-plugin-riak</a>
             from

--- a/2013/talk/S72/index.html
+++ b/2013/talk/S72/index.html
@@ -69,7 +69,7 @@
             In this talk, I will talk about how I solved this problem, and compare this method to the similar ways.</p>
           </div>
           <h3>Recorded Video</h3>
-          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='http://player.vimeo.com/video/68300423' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
+          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='https://player.vimeo.com/video/68300423' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
           <p>
             <a target="_blank" href="http://vimeo.com/68300423">Continuous gem dependency updating with Jenkins and Pull Request</a>
             from

--- a/2013/talk/S73/index.html
+++ b/2013/talk/S73/index.html
@@ -53,7 +53,7 @@
             work in progress.</p>
           </div>
           <h3>Recorded Video</h3>
-          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='http://player.vimeo.com/video/67807718' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
+          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='https://player.vimeo.com/video/67807718' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
           <p>
             <a target="_blank" href="http://vimeo.com/67807718">Toward efficient Ruby 2.1</a>
             from

--- a/2013/talk/S76/index.html
+++ b/2013/talk/S76/index.html
@@ -57,7 +57,7 @@
             And I'll talk about how engineers who are responsible for site's performance should work in their company.</p>
           </div>
           <h3>Recorded Video</h3>
-          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='http://player.vimeo.com/video/68301518' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
+          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='https://player.vimeo.com/video/68301518' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
           <p>
             <a target="_blank" href="http://vimeo.com/68301518">High Performance Rails</a>
             from

--- a/2013/talk/S78/index.html
+++ b/2013/talk/S78/index.html
@@ -53,7 +53,7 @@
             <p>In this talk I will look at useful practical patterns adopted in such gems, and also introduce a gem currently under development which has the potential to play the role of a key missing piece.</p>
           </div>
           <h3>Recorded Video</h3>
-          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='http://player.vimeo.com/video/70184260' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
+          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='https://player.vimeo.com/video/70184260' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
           <p>
             <a target="_blank" href="http://vimeo.com/70184260">Rails Gems realize RESTful modeling patterns</a>
             from

--- a/2013/talk/S79/index.html
+++ b/2013/talk/S79/index.html
@@ -50,7 +50,7 @@
             In this talk, I will introduce the backyard of CRuby development.</p>
           </div>
           <h3>Recorded Video</h3>
-          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='http://player.vimeo.com/video/68611165' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
+          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='https://player.vimeo.com/video/68611165' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
           <p>
             <a target="_blank" href="http://vimeo.com/68611165">CRuby Committers Who's Who in 2013</a>
             from

--- a/2013/talk/S80/index.html
+++ b/2013/talk/S80/index.html
@@ -49,7 +49,7 @@
             <p>Concurrency has been a popular topic in the programming community in the last decade and has received special attention in the Ruby community in recent years. José Valim will start his talk by explaining why concurrency has become so important and why it is particularly hard to write safe concurrent software in Ruby, based on his experience from working on Ruby on Rails. The goal of this talk is to highlight the current limitations and start the search for possible solutions, looking at how other languages are tackling this issue today.</p>
           </div>
           <h3>Recorded Video</h3>
-          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='http://player.vimeo.com/video/68259585' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
+          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='https://player.vimeo.com/video/68259585' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
           <p>
             <a target="_blank" href="http://vimeo.com/68259585">Concurrency in Ruby: In search of inspiration</a>
             from

--- a/2013/talk/S81/index.html
+++ b/2013/talk/S81/index.html
@@ -49,7 +49,7 @@
             <p>Keynote given by Matz.</p>
           </div>
           <h3>Recorded Video</h3>
-          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='http://player.vimeo.com/video/67807958' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
+          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='https://player.vimeo.com/video/67807958' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
           <p>
             <a target="_blank" href="http://vimeo.com/67807958">How to create Ruby</a>
             from

--- a/2013/talk/S82/index.html
+++ b/2013/talk/S82/index.html
@@ -53,7 +53,7 @@
             I'll talk about such nightmare in my experience.</p>
           </div>
           <h3>Recorded Video</h3>
-          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='http://player.vimeo.com/video/68259586' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
+          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='https://player.vimeo.com/video/68259586' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
           <p>
             <a target="_blank" href="http://vimeo.com/68259586">Fight with Diversity</a>
             from

--- a/2013/talk/S84/index.html
+++ b/2013/talk/S84/index.html
@@ -49,7 +49,7 @@
             <p>My Rails are not like yours. I'm gonna tell you why and how.</p>
           </div>
           <h3>Recorded Video</h3>
-          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='http://player.vimeo.com/video/68464117' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
+          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='https://player.vimeo.com/video/68464117' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
           <p>
             <a target="_blank" href="http://vimeo.com/68464117">Ruby on Your Rails</a>
             from

--- a/2013/talk/S85/index.html
+++ b/2013/talk/S85/index.html
@@ -49,7 +49,7 @@
             <p>For building today's web applications, our job is less about doing it all ourself, and often more about integrating the right services. This is how engineers build on Heroku, using any of the broad range of add-ons available to them. It's easy to build add-ons for this marketplace and provide the components for applications of the future. I'll show you how!</p>
           </div>
           <h3>Recorded Video</h3>
-          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='http://player.vimeo.com/video/70673040' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
+          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='https://player.vimeo.com/video/70673040' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
           <p>
             <a target="_blank" href="http://vimeo.com/70673040">Heroku Add-ons For Fun and Profit</a>
             from

--- a/2013/talk/S91/index.html
+++ b/2013/talk/S91/index.html
@@ -59,7 +59,7 @@
             <p>Please allow me to enliven the debates.</p>
           </div>
           <h3>Recorded Video</h3>
-          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='http://player.vimeo.com/video/70670187' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
+          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='https://player.vimeo.com/video/70670187' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
           <p>
             <a target="_blank" href="http://vimeo.com/70670187">How to fail at Background Jobs</a>
             from

--- a/2013/talk/S93/index.html
+++ b/2013/talk/S93/index.html
@@ -49,7 +49,7 @@
             <p>I will unearth the early history of Ruby, from the night before it was born to day it was released to the world.</p>
           </div>
           <h3>Recorded Video</h3>
-          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='http://player.vimeo.com/video/69688041' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
+          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='https://player.vimeo.com/video/69688041' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
           <p>
             <a target="_blank" href="http://vimeo.com/69688041">Ruby Archaeology</a>
             from

--- a/2013/talk/S94/index.html
+++ b/2013/talk/S94/index.html
@@ -65,7 +65,7 @@
             developers".</p>
           </div>
           <h3>Recorded Video</h3>
-          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='http://player.vimeo.com/video/69128203' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
+          <iframe allowFullScreen='allowFullScreen' frameborder='0' height='281' mozallowfullscreen='mozallowfullscreen' src='https://player.vimeo.com/video/69128203' webkitAllowFullScreen='webkitAllowFullScreen' width='500'></iframe>
           <p>
             <a target="_blank" href="http://vimeo.com/69128203">Be a library developer!</a>
             from


### PR DESCRIPTION
iframeで埋めてるVimeoのプレーヤーがHTTPになってて、ページをHTTPSで開くと表示されなくなってしまってました。
2013年ぶんのソースの修正はこちら https://github.com/ruby-no-kai/rubykaigi2013/commit/d1a962d719ebe03f463ed7307dae12cd50f1ebd3