### PR TITLE
2013: Fetch maps JS via HTTPS

### DIFF
--- a/2013/for_attendees/index.html
+++ b/2013/for_attendees/index.html
@@ -126,7 +126,7 @@
           </ul>
         </div>
       </article>
-      <script src="http://maps.google.com/maps/api/js?sensor=false&language=en" type="text/javascript"></script>
+      <script src="https://maps.google.com/maps/api/js?sensor=false&language=en" type="text/javascript"></script>
       <script>
         (function() {
           var rubykaigi2013 = new google.maps.LatLng(35.620322756056446, 139.77647379040718);


### PR DESCRIPTION
Fixes `Mixed Content: The page at 'https://rubykaigi.org/2013/for_attendees/' was loaded over HTTPS, but requested an insecure script 'http://maps.google.com/maps/api/js?sensor=false&language=en'. This request has been blocked; the content must be served over HTTPS.`