### PR TITLE
2006-2008の動画をYouTubeにリンク

### DIFF
--- a/2006/videos.html
+++ b/2006/videos.html
@@ -34,21 +34,21 @@
     <div class="section">
       <p>総合司会：かずひこ</p>
 <h3><a name="l1"><span class="sanchor"> </span></a>9:45-10:00</h3>
-<p>開会：高橋征義⇒<a href="http://video.google.com/videoplay?docid=-5194800282170491626" class="external">【Google Video】</a></p>
+<p>開会：高橋征義⇒<a href="https://www.youtube.com/watch?v=Xde55uXfBSo" class="external">【YouTube】</a></p>
 <h3><a name="l2"><span class="sanchor"> </span></a>10:00-12:00</h3>
 <dl>
 <dt> 高橋征義</dt>
-<dd> 「Ruby の歴史」⇒<a href="http://video.google.com/videoplay?docid=4449480303876512955&amp;hl=en" class="external">【Google Video】</a>
+<dd> 「Ruby の歴史」⇒<a href="https://www.youtube.com/watch?v=TOJZElf0aBM" class="external">【YouTube】</a>
 </dd>
 <dt> 井上　浩</dt>
-<dd> 「NaCl のオープンソース戦略〜そして今後の Ruby 戦略に関して〜」⇒<a href="http://video.google.com/videoplay?docid=8517291872595245630&amp;hl=en" class="external">【Google Video】</a>
+<dd> 「NaCl のオープンソース戦略〜そして今後の Ruby 戦略に関して〜」⇒<a href="https://www.youtube.com/watch?v=8maUiS-9a3Q" class="external">【YouTube】</a>
 </dd>
 <dt> 基調講演：まつもとゆきひろ</dt>
-<dd> 「State of the Dominion」⇒<a href="http://video.google.com/videoplay?docid=-8932726130774605520&amp;hl=en" class="external">【Google Video】</a>
+<dd> 「State of the Dominion」⇒<a href="https://www.youtube.com/watch?v=c6nDzYmxk_o" class="external">【YouTube】</a>
 </dd>
 </dl>
 <h3><a name="l3"><span class="sanchor"> </span></a>13:15-14:15</h3>
-<p>パネル企画「Ruby 2.0」⇒<a href="http://video.google.com/videoplay?docid=2952820706377659777&amp;hl=en" class="external">【Google Video】</a></p>
+<p>パネル企画「Ruby 2.0」⇒<a href="https://www.youtube.com/watch?v=AOpi96eMGfU" class="external">【YouTube】</a></p>
 <table border="1">
 <tr><td> パネリスト	</td><td> まつもとゆきひろ／ささだこういち／小迫清美／卜部昌平
 </td></tr>
@@ -60,25 +60,25 @@
 <h3><a name="l4"><span class="sanchor"> </span></a>14:25-15:55</h3>
 <dl>
 <dt> arton</dt>
-<dd>  「Rubyize による言語境界の越え方」⇒<a href="http://video.google.com/videoplay?docid=-7291180397703324486&amp;hl=en" class="external">【Google Video】</a>
+<dd>  「Rubyize による言語境界の越え方」⇒<a href="https://www.youtube.com/watch?v=xhTafSkS2Vw" class="external">【YouTube】</a>
 </dd>
 <dt> 田中 哲</dt>
-<dd>  「使いやすいライブラリ API デザイン」⇒<a href="video/1-06-akr-high.ogg" class="external">【Ogg File Download】</a>｜<a href="http://video.google.com/videoplay?docid=-7833644236492870974&amp;hl=en" class="external">【Google Video】</a>
+<dd>  「使いやすいライブラリ API デザイン」⇒<a href="video/1-06-akr-high.ogg" class="external">【Ogg File Download】</a>｜<a href="https://www.youtube.com/watch?v=enuE_exC3MA" class="external">【YouTube】</a>
 </dd>
 <dt> 石塚圭樹</dt>
-<dd> 「Ruby プログラミング + モデリングでより楽しくなろう - その1」⇒<a href="http://video.google.com/videoplay?docid=8796560015326633364&amp;hl=en" class="external">【Google Video】</a>
+<dd> 「Ruby プログラミング + モデリングでより楽しくなろう - その1」⇒<a href="https://www.youtube.com/watch?v=TWfG6BeuFuI" class="external">【YouTube】</a>
 </dd>
 </dl>
 <h3><a name="l5"><span class="sanchor"> </span></a>16:05-17:35</h3>
 <dl>
 <dt> なひ</dt>
-<dd> 「セキュアアプリケーションプログラミング」⇒<a href="http://video.google.com/videoplay?docid=-3199657013913562839&amp;hl=en" class="external">【Google Video】</a>
+<dd> 「セキュアアプリケーションプログラミング」⇒<a href="https://www.youtube.com/watch?v=QHIy9ASe2yg" class="external">【YouTube】</a>
 </dd>
 <dt> 後藤謙太郎</dt>
-<dd> 「仕事で使うRuby」⇒<a href="http://video.google.com/videoplay?docid=-4254699290252847132&amp;hl=en" class="external">【Google Video】</a>
+<dd> 「仕事で使うRuby」⇒<a href="https://www.youtube.com/watch?v=9xsBLmCJysE" class="external">【YouTube】</a>
 </dd>
 <dt> 前田修吾</dt>
-<dd> 「Railsによるメタプログラミング入門」⇒<a href="http://video.google.com/videoplay?docid=-665307649987089422&amp;hl=en" class="external">【Google Video】</a>
+<dd> 「Railsによるメタプログラミング入門」⇒<a href="https://www.youtube.com/watch?v=THlvB-IcvUc" class="external">【YouTube】</a>
 </dd>
 </dl>
     </div>
@@ -92,20 +92,20 @@
 <h3><a name="l7"><span class="sanchor"> </span></a>10:00-12:00</h3>
 <dl>
 <dt> ただただし</dt>
-<dd> 「Ruby anywhere 〜Ruby普及のためにアプリケーションができること」⇒<a href="http://video.google.com/videoplay?docid=273946274126713601&amp;hl=en" class="external">【Google Video】</a>
+<dd> 「Ruby anywhere 〜Ruby普及のためにアプリケーションができること」⇒<a href="https://www.youtube.com/watch?v=VLshE6o7kMo" class="external">【YouTube】</a>
 </dd>
 <dt> 関将俊</dt>
-<dd> 「dRubyをもう一度」⇒<a href="http://video.google.com/videoplay?docid=-3981589646817959992&amp;hl=en" class="external">【Google Video】</a>
+<dd> 「dRubyをもう一度」⇒<a href="https://www.youtube.com/watch?v=0uFjbQ3Ux1s" class="external">【YouTube】</a>
 </dd>
 <dt> 中島 拓</dt>
-<dd> 「Amrita2 の紹介」⇒<a href="http://video.google.com/videoplay?docid=-7898443587008216613&amp;hl=en" class="external">【Google Video】</a>
+<dd> 「Amrita2 の紹介」⇒<a href="https://www.youtube.com/watch?v=UM1Wj3qTAmI" class="external">【YouTube】</a>
 </dd>
 <dt> secondlife（舘野祐一）</dt>
-<dd> 「Perl の会社で使われる Ruby の利用法とは!?」⇒<a href="http://video.google.com/videoplay?docid=8433801350256430539&amp;hl=en" class="external">【Google Video】</a>
+<dd> 「Perl の会社で使われる Ruby の利用法とは!?」⇒<a href="https://www.youtube.com/watch?v=TMIhvjfja1Q" class="external">【YouTube】</a>
 </dd>
 </dl>
 <h3><a name="l8"><span class="sanchor"> </span></a>13:15-14:15</h3>
-<p>パネル企画 「Rails in Production」⇒<a href="http://video.google.com/videoplay?docid=653706193181073615&amp;hl=en" class="external">【Google Video】</a></p>
+<p>パネル企画 「Rails in Production」⇒<a href="https://www.youtube.com/watch?v=WOPhM4BwaBQ" class="external">【YouTube】</a></p>
 <table border="1">
 <tr><td> パネリスト	</td><td> 大前 潤／ストヤン・ジェコフ(Stoyan Zhekov)／瀧内 元気／高木宏(Gollum)
 </td></tr>
@@ -117,17 +117,17 @@
 <h3><a name="l9"><span class="sanchor"> </span></a>14:25-16:25</h3>
 <dl>
 <dt> moriq (吉田和弘)</dt>
-<dd> 「Rails による Web アプリケーション開発・保守事例の紹介」⇒<a href="http://video.google.com/videoplay?docid=7859850141855957412&amp;hl=en" class="external">【Google Video】</a>
+<dd> 「Rails による Web アプリケーション開発・保守事例の紹介」⇒<a href="https://www.youtube.com/watch?v=aPdy2EYMkjQ" class="external">【YouTube】</a>
 </dd>
 <dt> 西 和則</dt>
-<dd> 「ActiveRecord を詳しく」⇒<a href="http://video.google.com/videoplay?docid=5998228664309799916&amp;hl=en" class="external">【Google Video】</a>
+<dd> 「ActiveRecord を詳しく」⇒<a href="https://www.youtube.com/watch?v=LcRlPfpQp4E" class="external">【YouTube】</a>
 </dd>
 <dt> 基調講演：David Heinemeier Hansson</dt>
-<dd> 「One controller, many ins, many outs」⇒<a href="http://video.google.com/videoplay?docid=3936398049327152878&amp;hl=en" class="external">【Google Video】</a>
+<dd> 「One controller, many ins, many outs」⇒<a href="https://www.youtube.com/watch?v=-5-Nkv_Gv8U" class="external">【YouTube】</a>
 </dd>
 </dl>
 <h3><a name="l10"><span class="sanchor"> </span></a>16：35-17:35</h3>
-<p>ライトニングトークス ⇒<a href="http://video.google.com/videoplay?docid=-2911090413304718549&amp;hl=en" class="external">【Google Video】</a></p>
+<p>ライトニングトークス ⇒<a href="https://www.youtube.com/watch?v=IEu5twst4zk" class="external">【YouTube】</a></p>
 <table border="1">
 <tr><td> 片山俊明	</td><td>「BioRuby」
 </td></tr>
@@ -153,7 +153,7 @@
 </td></tr>
 </table>
 <h3><a name="l11"><span class="sanchor"> </span></a>17:35-17:50</h3>
-<p>閉会：高橋征義⇒<a href="http://video.google.com/videoplay?docid=3035661476109136375&amp;hl=en" class="external">【Google Video】</a></p>
+<p>閉会：高橋征義⇒<a href="https://www.youtube.com/watch?v=y2y-0a_m9v4" class="external">【YouTube】</a></p>
     </div>
   </div>
 </div>

--- a/2007/Program-LT.html
+++ b/2007/Program-LT.html
@@ -34,6 +34,9 @@
 <dt>講演資料</dt>
 <dd><a href="http://www.gfd-dennou.org/arch/davis/gfdnavi/presen/RubyKaigi2007-070609.pdf" class="external">http://www.gfd-dennou.org/arch/davis/gfdnavi/presen/RubyKaigi2007-070609.pdf</a>
 </dd>
+<dt>講演動画</dt>
+<dd><a href="https://www.youtube.com/watch?v=izTeGg3TEAc" class="external">https://www.youtube.com/watch?v=izTeGg3TEAc</a>
+</dd>
 </dl>
 <h4><a name="l3"> </a>LT2. 平鍋 健児　　Software is Made of Design and Communication</h4>
 <p>＠ (株)チェンジビジョン 代表取締役社長 / (株)永和システムマネジメント 副社長</p>
@@ -47,6 +50,9 @@
 <dt>講演資料(2)</dt>
 <dd><a href="RubyKaigi2007-LT-hiranabe.pdf">RubyKaigi2007-LT-hiranabe.pdf</a> / <a href="http://www.flickr.com/photos/68498640@N00/sets/72157602641219277/" class="external">Flickr Photo Set</a>(JPEG画像)
 </dd>
+<dt>講演動画</dt>
+<dd><a href="https://www.youtube.com/watch?v=NqlHtyMozMo" class="external">https://www.youtube.com/watch?v=NqlHtyMozMo</a>
+</dd>
 </dl>
 <h4><a name="l4"> </a>LT3. サイロス誠　　「Ruby+Miyako」でおもろいプレゼン</h4>
 <dl>
@@ -55,6 +61,9 @@
 </dd>
 <dt>講演資料</dt>
 <dd><a href="http://www.twin.ne.jp/~cyross/Miyako/RubyKaigi2007LT.pdf" class="external">http://www.twin.ne.jp/~cyross/Miyako/RubyKaigi2007LT.pdf</a>
+</dd>
+<dt>講演動画</dt>
+<dd><a href="https://www.youtube.com/watch?v=LgMcr9uid5g" class="external">https://www.youtube.com/watch?v=LgMcr9uid5g</a>
 </dd>
 </dl>
 <h4><a name="l5"> </a>LT4. takkaw　Rubyでファミコンプログラミング</h4>
@@ -68,6 +77,9 @@
 <dt>講演資料(2)</dt>
 <dd><a href="RubyKaigi2007_takkaw.nes">RubyKaigi2007_takkaw.nes</a> (ファミコンソフト)
 </dd>
+<dt>講演動画</dt>
+<dd><a href="https://www.youtube.com/watch?v=jAVbQErEYk0" class="external">https://www.youtube.com/watch?v=jAVbQErEYk0</a>
+</dd>
 </dl>
 <h4><a name="l6"> </a>LT5. 山形 頼之　　Ruby on Railsでデータマイニング</h4>
 <dl>
@@ -76,6 +88,9 @@
 </dd>
 <dt>講演資料</dt>
 <dd>発表スライド <a href="yamagata_lt_presenslide.pdf">yamagata_lt_presenslide.pdf</a><br>発表原稿 <a href="http://d.hatena.ne.jp/yoriyuki/20070616/p1" class="external">http://d.hatena.ne.jp/yoriyuki/20070616/p1</a>
+</dd>
+<dt>講演動画</dt>
+<dd><a href="https://www.youtube.com/watch?v=pFx-ZmMj-2A" class="external">https://www.youtube.com/watch?v=pFx-ZmMj-2A</a>
 </dd>
 </dl>
 <h4><a name="l7"> </a>LT6. 山野 ゆき菜　　Rubyのパーサーを拡張して "end" の対応付けをチェックする</h4>
@@ -97,20 +112,34 @@
 <dt>講演資料</dt>
 <dd><a href="http://www.qd.info.kanagawa-u.ac.jp/yonezawa/RubyKaigi2007.html" class="external">http://www.qd.info.kanagawa-u.ac.jp/yonezawa/RubyKaigi2007.html</a>
 </dd>
+<dt>講演動画</dt>
+<dd><a href="https://www.youtube.com/watch?v=KD-ygO5fams" class="external">https://www.youtube.com/watch?v=KD-ygO5fams</a>
+</dd>
 </dl>
 <h4><a name="l9"> </a>LT8. 野田 哲夫　　「地域資源」Rubyと島根県の産業振興の取り組み</h4>
 <dl>
 <dt>プロフィール</dt>
 <dd>日本のオープンソースの「故郷」・島根で昨年９月に立ち上がったOSS協議会の副会長。
 </dd>
+<dt>講演動画</dt>
+<dd><a href="https://www.youtube.com/watch?v=NbMsg7OQFlo" class="external">https://www.youtube.com/watch?v=NbMsg7OQFlo</a>
+</dd>
 </dl>
 <h4><a name="l10"> </a>LT9. 瀧内 元気　　５分で作るCometチャット</h4>
 <p>＠ 株式会社ドリコム</p>
+<dl>
+<dt>講演動画</dt>
+<dd><a href="https://www.youtube.com/watch?v=Q20ZNapb9Kw" class="external">https://www.youtube.com/watch?v=Q20ZNapb9Kw</a>
+</dd>
+</dl>
 <h4><a name="l11"> </a>LT10. 田中 哲　　データで予想する Ruby のリリース</h4>
 <p>＠ 産業技術総合研究所</p>
 <dl>
 <dt>プロフィール</dt>
 <dd>継続的インテグレーションツールの一種 chkbuild の作者。
+</dd>
+<dt>講演動画</dt>
+<dd><a href="https://www.youtube.com/watch?v=FOxTLAy-5zs" class="external">https://www.youtube.com/watch?v=FOxTLAy-5zs</a>
 </dd>
 </dl>
 <h4><a name="l12"> </a>LT11. 高橋 征義　　第2日本Rubyの会について</h4>
@@ -118,6 +147,9 @@
 <dl>
 <dt>プロフィール</dt>
 <dd>北大SF研OB。星新一を経由して新井素子読みに。ここのところSFよりもコバルトばかり読んでます。祝竹岡葉月復活。
+</dd>
+<dt>講演動画</dt>
+<dd><a href="https://www.youtube.com/watch?v=lw-zFmsxqaQ" class="external">https://www.youtube.com/watch?v=lw-zFmsxqaQ</a>
 </dd>
 </dl>
     </div>

--- a/2007/Program-SP.html
+++ b/2007/Program-SP.html
@@ -31,12 +31,18 @@
 <dt>発表資料</dt>
 <dd> <a href="RubyKaigi2007_IBM.pdf">RubyKaigi2007_IBM.pdf</a> （344 KB）
 </dd>
+<dt>講演動画</dt>
+<dd><a href="https://www.youtube.com/watch?v=Hd4IP2cel2c" class="external">https://www.youtube.com/watch?v=Hd4IP2cel2c</a>
+</dd>
 </dl>
 <h4><a name="l3"> </a>ニフティ株式会社　成田 智也</h4>
 <p>Ruby と Ruby on Rails の活用事例 - @nifty TimeLine βはいかにして作られたか -</p>
 <dl>
 <dt>発表資料</dt>
 <dd> <a href="http://timeline.cocolog-nifty.com/blog/2007/06/ruby2007_2d8b.html" class="external">http://timeline.cocolog-nifty.com/blog/2007/06/ruby2007_2d8b.html</a>
+</dd>
+<dt>講演動画</dt>
+<dd><a href="https://www.youtube.com/watch?v=ZBH14YbW8N8" class="external">https://www.youtube.com/watch?v=ZBH14YbW8N8</a>
 </dd>
 </dl>
 <h4><a name="l4"> </a>楽天株式会社　森 正弥</h4>
@@ -45,12 +51,18 @@
 <dt>発表資料</dt>
 <dd> <a href="RubyKaigi2007_Rakuten.pdf">RubyKaigi2007_Rakuten.pdf</a> （805 KB）
 </dd>
+<dt>講演動画</dt>
+<dd><a href="https://www.youtube.com/watch?v=YbRvFJizzIc" class="external">https://www.youtube.com/watch?v=YbRvFJizzIc</a>
+</dd>
 </dl>
 <h4><a name="l5"> </a>株式会社ネットワーク応用通信研究所　前田 修吾</h4>
 <p>NaClのRuby戦略: NaCl の事業戦略に関して</p>
 <dl>
 <dt>発表資料</dt>
 <dd> <a href="RubyKaigi2007_NaCl.pdf">RubyKaigi2007_NaCl.pdf</a> （1.9 MB）
+</dd>
+<dt>講演動画</dt>
+<dd><a href="https://www.youtube.com/watch?v=wW7vXAlC7WE" class="external">https://www.youtube.com/watch?v=wW7vXAlC7WE</a>
 </dd>
 </dl>
 <h4><a name="l6"> </a>株式会社アスタリクス　大西 正太</h4>
@@ -59,12 +71,18 @@
 <dt>発表資料</dt>
 <dd> <a href="RubyKaigi2007_Asteriks.pdf">RubyKaigi2007_Asteriks.pdf</a> （402 KB）
 </dd>
+<dt>講演動画</dt>
+<dd><a href="https://www.youtube.com/watch?v=niNH_hkjusc" class="external">https://www.youtube.com/watch?v=niNH_hkjusc</a>
+</dd>
 </dl>
 <h4><a name="l7"> </a>インフォテリア株式会社　中川 智史</h4>
 <p>Inside Lingr: Comet を用いた高速チャットサービス Lingr は、Comet 用のフロントサーバと、バックエンドの Ruby on Rails との組み合わせにより実現されている。実稼働するサービスの裏側での Rails の使われ方について、Comet の実現方法と合わせて紹介する。</p>
 <dl>
 <dt>発表資料</dt>
 <dd> <a href="RubyKaigi2007_inside_lingr.pdf">RubyKaigi2007_inside_lingr.pdf</a> （430 KB）
+</dd>
+<dt>講演動画</dt>
+<dd><a href="https://www.youtube.com/watch?v=ujloBfesMRs" class="external">https://www.youtube.com/watch?v=ujloBfesMRs</a>
 </dd>
 </dl>
 <h4><a name="l8"> </a>株式会社ドリコム　瀧内 元気</h4>

--- a/2007/Program0609.html
+++ b/2007/Program0609.html
@@ -41,6 +41,9 @@
 <dt>プロフィール</dt>
 <dd>株式会社ツインスパークでひっそりと働く（本当に）普通のプログラマ。<br>会社での主な役割はお酒を飲むこととツッコミ。
 </dd>
+<dt>講演動画</dt>
+<dd><a href="https://www.youtube.com/watch?v=gfU6gz6BsaE" class="external">https://www.youtube.com/watch?v=gfU6gz6BsaE</a>
+</dd>
 </dl>
 <h3><a name="l3"><span class="sanchor"> </span></a>セッション 壱　10:10 - 11:55 Rubyコア</h3>
 <h4><a name="l4"> </a>Ruby 1.9実装の現状と今後　（ささだ こういち）</h4>
@@ -62,6 +65,9 @@
 </dd>
 <dd> <a href="http://www.atdot.net/yarv/RK2007-sasada-public.ppt" class="external">http://www.atdot.net/yarv/RK2007-sasada-public.ppt</a>
 </dd>
+<dt>講演動画</dt>
+<dd><a href="https://www.youtube.com/watch?v=pWw3flPCQmE" class="external">https://www.youtube.com/watch?v=pWw3flPCQmE</a>
+</dd>
 </dl>
 <h4><a name="l5"> </a>安定版rubyとその今後　（卜部 昌平）</h4>
 <p>12月のブランチ作成とリリースポリシー変更のおさらい、そして2007上半期半年での進捗と今後の展望について。</p>
@@ -77,6 +83,9 @@
 </dd>
 <dt>講演資料</dt>
 <dd><a href="http://mput.dip.jp/mput/Kaigi2007.odp" class="external">http://mput.dip.jp/mput/Kaigi2007.odp</a> (ooimpress presentation)<br><a href="http://mput.dip.jp/mput/Kaigi2007.pdf" class="external">http://mput.dip.jp/mput/Kaigi2007.pdf</a> (PDF)
+</dd>
+<dt>講演動画</dt>
+<dd><a href="https://www.youtube.com/watch?v=xYwjy4Fg17E" class="external">https://www.youtube.com/watch?v=xYwjy4Fg17E</a>
 </dd>
 </dl>
 <h4><a name="l6"> </a>日本Rubyのリファレンスマニュアル2007・初夏　（青木 峰郎）</h4>
@@ -94,6 +103,9 @@
 <dt>講演資料</dt>
 <dd>index <a href="http://i.loveruby.net/rubykaigi2007/" class="external">http://i.loveruby.net/rubykaigi2007/</a><br>PDF <a href="http://i.loveruby.net/rubykaigi2007/rubykaigi2007-aoki.pdf" class="external">http://i.loveruby.net/rubykaigi2007/rubykaigi2007-aoki.pdf</a>
 </dd>
+<dt>講演動画</dt>
+<dd><a href="https://www.youtube.com/watch?v=EJWTyAY2JwU" class="external">https://www.youtube.com/watch?v=EJWTyAY2JwU</a>
+</dd>
 </dl>
 <h4><a name="l7"> </a>JRuby: Ruby for the Java Platform　（Charles Nutter / Thomas Enebo）</h4>
 <p>Ruby has become one of the fastest-growing languages in the world. Java is the most widespread platform in the world. JRuby brings Ruby to the Java platform, allowing Java developers access to the beauty and elegance of Ruby and Ruby developers access to the scalability and strength of the JVM and Java's vast collection of libraries. This talk will describe JRuby's history, design, status, and future.</p>
@@ -109,6 +121,9 @@
 </dd>
 <dt>講演資料</dt>
 <dd><a href="JRuby_RubyKaigi-2007_j.pdf">JRuby_RubyKaigi-2007_j.pdf</a> （和訳付き, 284 KB）
+</dd>
+<dt>講演動画</dt>
+<dd><a href="https://www.youtube.com/watch?v=JXp-0IImWfE" class="external">https://www.youtube.com/watch?v=JXp-0IImWfE</a>
 </dd>
 </dl>
 <h3><a name="l8"><span class="sanchor"> </span></a>セッション 弐　13:00 - 14:00 基調講演　（まつもと ゆきひろ）</h3>
@@ -127,6 +142,9 @@
 <dt>講演資料</dt>
 <dd><a href="http://www.rubyist.net/~matz/slides/rk2007-matz/" class="external">http://www.rubyist.net/~matz/slides/rk2007-matz/</a>
 </dd>
+<dt>講演動画</dt>
+<dd><a href="https://www.youtube.com/watch?v=hBu-klw_sg0" class="external">https://www.youtube.com/watch?v=hBu-klw_sg0</a>
+</dd>
 </dl>
 <h3><a name="l10"><span class="sanchor"> </span></a>セッション 参　14:10 - 15:40 Rubyイロイロ１</h3>
 <h4><a name="l11"> </a>他言語ライブラリの利用　（立石 孝彰）</h4>
@@ -140,6 +158,9 @@
 </dd>
 <dt>講演時間</dt>
 <dd>14：10〜14：40
+</dd>
+<dt>講演動画</dt>
+<dd><a href="https://www.youtube.com/watch?v=2CJ5S2yMI3w" class="external">https://www.youtube.com/watch?v=2CJ5S2yMI3w</a>
 </dd>
 </dl>
 <h4><a name="l12"> </a>Cより速いRubyプログラム　（桑田 誠）</h4>
@@ -157,6 +178,9 @@
 <dt>講演資料</dt>
 <dd><a href="http://www.kuwata-lab.com/presen/rubykaigi2007.pdf" class="external">http://www.kuwata-lab.com/presen/rubykaigi2007.pdf</a><br><a href="http://www.kuwata-lab.com/presen/erubybench-1.1.zip" class="external">http://www.kuwata-lab.com/presen/erubybench-1.1.zip</a>
 </dd>
+<dt>講演動画</dt>
+<dd><a href="https://www.youtube.com/watch?v=FDgpmrPDpZc" class="external">https://www.youtube.com/watch?v=FDgpmrPDpZc</a>
+</dd>
 </dl>
 <h4><a name="l13"> </a>YAR(V)I (Yet Another Ruby (on VM) Implementations)　（arton）</h4>
 <p>本セッションでは、Ruby 1.9以外のRubyの実装について、入手方法から実際にプログラミングする場合の開発環境、オリジナルRubyと比較した場合の特徴についてデモを交えて紹介します。取り上げる実装は、JRuby（インタプリタ）、RubyCLR（ブリッジ）、Gardens Point Ruby.NET（コンパイラ）です。</p>
@@ -172,6 +196,9 @@
 </dd>
 <dt>講演資料</dt>
 <dd><a href="http://artonx.org/data/RubyKaigi2007/" class="external">http://artonx.org/data/RubyKaigi2007/</a>
+</dd>
+<dt>講演動画</dt>
+<dd><a href="https://www.youtube.com/watch?v=ZIUTR6ougtw" class="external">https://www.youtube.com/watch?v=ZIUTR6ougtw</a>
 </dd>
 </dl>
 <h3><a name="l14"><span class="sanchor"> </span></a>セッション 肆　16:00 - 17:30 Rubyイロイロ２</h3>
@@ -190,6 +217,9 @@
 <dt>講演資料</dt>
 <dd>page: <a href="http://tisphie.net/typo/pages/RubyKaigi2007" class="external">http://tisphie.net/typo/pages/RubyKaigi2007</a><br>PDF: <a href="http://tisphie.net/web-scraping.pdf" class="external">http://tisphie.net/web-scraping.pdf</a>
 </dd>
+<dt>講演動画</dt>
+<dd><a href="https://www.youtube.com/watch?v=SX5L1Mr3dj0" class="external">https://www.youtube.com/watch?v=SX5L1Mr3dj0</a>
+</dd>
 </dl>
 <h4><a name="l16"> </a>The World In 30 Minutes　（Tim Bray）</h4>
 <p>Ruby was born in Japan and is becoming increasingly popular around the world.  Therefore, Ruby should try to be a good citizen of the world.  This means speaking to people in their own language; more precisely, performing text input, processing, and output correctly in all the world's languages.  The good news is that this is not too difficult.  The bad news is that up to version 1.8.5, Ruby has not given enough attention to this problem.  We will describe the problems and look at what's being done to solve them in the world of Ruby.</p>
@@ -206,6 +236,9 @@
 <dt>講演資料</dt>
 <dd><a href="http://www.tbray.org/talks/rubykaigi2007.pdf" class="external">http://www.tbray.org/talks/rubykaigi2007.pdf</a><br><a href="the_world_in_30minutes.pdf">the_world_in_30minutes.pdf</a> （オリジナル, 3.90 MB）
 </dd>
+<dt>講演動画</dt>
+<dd><a href="https://www.youtube.com/watch?v=_tgzzLh6X4g" class="external">https://www.youtube.com/watch?v=_tgzzLh6X4g</a>
+</dd>
 </dl>
 <h4><a name="l17"> </a>Rinda: Answering the RubyConf and RubyKaigi　（関 将俊）</h4>
 <p>RubyKaigiを模したUSのカンファレンス、RubyConfにてRinda in the Real Worldと題したプレゼンテーションが行われた。Rindaの作者であり、言い訳駆動開発の実践者である発表者が、先のプレゼンテーションの疑問、提案、そしてRubyKaigi2006の宿題に対して回答する。Rindaが示唆する何かについてあっさりと熱く語りたい。</p>
@@ -221,6 +254,9 @@
 </dd>
 <dt>講演資料</dt>
 <dd><a href="http://www.druby.org/RK07.pdf" class="external">http://www.druby.org/RK07.pdf</a>
+</dd>
+<dt>講演動画</dt>
+<dd><a href="https://www.youtube.com/watch?v=qhKenN39d8o" class="external">https://www.youtube.com/watch?v=qhKenN39d8o</a>
 </dd>
 </dl>
 <h3><a name="l18"><span class="sanchor"> </span></a>セッション 伍　17:40 - 18:40 LT</h3>

--- a/2007/Program0610.html
+++ b/2007/Program0610.html
@@ -52,6 +52,9 @@
 <dt>講演資料</dt>
 <dd><a href="http://www.webrick.org/misc/20070610-rubykaigi2007-gotoken.pdf" class="external">http://www.webrick.org/misc/20070610-rubykaigi2007-gotoken.pdf</a>
 </dd>
+<dt>講演動画</dt>
+<dd><a href="https://www.youtube.com/watch?v=COYKFyiF4to" class="external">https://www.youtube.com/watch?v=COYKFyiF4to</a>
+</dd>
 </dl>
 <h4><a name="l4"> </a>JRuby on Rails でエンタープライズ Ruby　（高井 直人）</h4>
 <p>Ruby on Railsの登場以来、ますますRubyへの注目が高まっています。しかしながら、エンタープライズ分野へのRubyの活用は、まだまだ本格的であるとは言い難いのではないでしょうか。このセッションでは、Java EEアプリケーションサーバ上でJRuby on Railsを稼働させる手法について、解説とデモを行ないます。Java EEアーキテクチャとRubyとの新たな結び付きと、その可能性をご覧ください。</p>
@@ -67,6 +70,9 @@
 </dd>
 <dt>講演資料</dt>
 <dd><a href="http://recompile.net/rubykaigi2007/enterprise_ruby_with_jruby_on_rails.pdf" class="external">http://recompile.net/rubykaigi2007/enterprise_ruby_with_jruby_on_rails.pdf</a>
+</dd>
+<dt>講演動画</dt>
+<dd><a href="https://www.youtube.com/watch?v=Sjk4dIvKZs4" class="external">https://www.youtube.com/watch?v=Sjk4dIvKZs4</a>
 </dd>
 </dl>
 <h4><a name="l5"> </a>OpenWFEru, a Ruby workflow engine　（John Mettraux）</h4>
@@ -84,6 +90,9 @@
 <dt>講演資料</dt>
 <dd><a href="openwferu_rk2007_j.pdf">openwferu_rk2007_j.pdf</a> （和訳付き, 538 KB）
 </dd>
+<dt>講演動画</dt>
+<dd><a href="https://www.youtube.com/watch?v=VNH-UQfYJGg" class="external">https://www.youtube.com/watch?v=VNH-UQfYJGg</a>
+</dd>
 </dl>
 <h4><a name="l6"> </a>AP4R ： Ruby のための非同期メッセージングライブラリ　（篠原 俊一 / 加藤 究）</h4>
 <p>AP4R とは、Ruby のための Ruby による非同期メッセージングライブラリです。AP4R を活用したシステムでは、クライアントへの素早いレスポンスと負荷分散によるスケーラブルな構成を実現できます。<br>このセッションでは、信頼性と水平分散をサポートする実装と、Ruby on Rails とのシームレスな連携を含めた API を解説します。また、実際のシステムへの適用事例をご紹介します。 2007年は SIer の間でも Ruby が広く利用されると思います （希望的観測）。 Ruby におけるメッセージングの活躍の場はこれまで以上に増えるのではないでしょうか？<br>RubyForge: AP4R: Project Info <a href="http://rubyforge.org/projects/ap4r/" class="external">http://rubyforge.org/projects/ap4r/</a></p>
@@ -99,6 +108,9 @@
 </dd>
 <dt>講演資料</dt>
 <dd><a href="http://rubyforge.org/docman/view.php/1765/1256/AP4R_on_RubyKaigi2007.pdf" class="external">http://rubyforge.org/docman/view.php/1765/1256/AP4R_on_RubyKaigi2007.pdf</a><br><a href="http://rubyforge.org/docman/view.php/1765/1257/AP4R_on_RubyKaigi2007_EN.pdf" class="external">http://rubyforge.org/docman/view.php/1765/1257/AP4R_on_RubyKaigi2007_EN.pdf</a> （英語版）
+</dd>
+<dt>講演動画</dt>
+<dd><a href="https://www.youtube.com/watch?v=ya-sbgJTejw" class="external">https://www.youtube.com/watch?v=ya-sbgJTejw</a>
 </dd>
 </dl>
 <h3><a name="l7"><span class="sanchor"> </span></a>セッション 弐　13:00 - 14:20 スポンサーセッション</h3>
@@ -120,6 +132,9 @@
 <dt>講演資料</dt>
 <dd><a href="http://www.dumbo.ai.kyutech.ac.jp/~nagai/RubyKaigi2007-nagai.pdf" class="external">http://www.dumbo.ai.kyutech.ac.jp/~nagai/RubyKaigi2007-nagai.pdf</a><br><a href="http://www.dumbo.ai.kyutech.ac.jp/~nagai/RubyKaigi2007-nagai.swf" class="external">http://www.dumbo.ai.kyutech.ac.jp/~nagai/RubyKaigi2007-nagai.swf</a>
 </dd>
+<dt>講演動画</dt>
+<dd><a href="https://www.youtube.com/watch?v=Y8in_Y4t1Ik" class="external">https://www.youtube.com/watch?v=Y8in_Y4t1Ik</a>
+</dd>
 </dl>
 <h4><a name="l10"> </a>Hello Ruby-GNOME2 World　（武藤 昌夫（むとう まさお））</h4>
 <p>Ruby-GNOME2はLinux, *BSDやMS Windowsで使うことのできる歴史のあるGUIライブラリを中心とした20個以上もあるライブラリのパッケージです。本セッションではRuby-GNOME2の中でも代表的なライブラリの魅力をご紹介します。</p>
@@ -135,6 +150,9 @@
 </dd>
 <dt>講演資料</dt>
 <dd><a href="http://www.yotabanana.com/hiki/ja/?rubykaigi2007" class="external">http://www.yotabanana.com/hiki/ja/?rubykaigi2007</a>
+</dd>
+<dt>講演動画</dt>
+<dd><a href="https://www.youtube.com/watch?v=hfV9nNNA37c" class="external">https://www.youtube.com/watch?v=hfV9nNNA37c</a>
 </dd>
 </dl>
 <h4><a name="l11"> </a>VisualuRuby計画(仮称)によるWindowsでのGUI開発　（nyasu）</h4>
@@ -152,6 +170,9 @@
 <dt>講演資料</dt>
 <dd><a href="http://www.osk.3web.ne.jp/~nyasu/vruby/rubykaigi2007/" class="external">http://www.osk.3web.ne.jp/~nyasu/vruby/rubykaigi2007/</a><br><a href="http://www.osk.3web.ne.jp/~nyasu/vruby/rubykaigi2007/rk2007vr-3.pdf" class="external">http://www.osk.3web.ne.jp/~nyasu/vruby/rubykaigi2007/rk2007vr-3.pdf</a>
 </dd>
+<dt>講演動画</dt>
+<dd><a href="https://www.youtube.com/watch?v=49xBSMCjjEs" class="external">https://www.youtube.com/watch?v=49xBSMCjjEs</a>
+</dd>
 </dl>
 <h4><a name="l12"> </a>RubyCocoa - RubyによるMac OS Xソフトウェア開発　（藤本 尚邦）</h4>
 <p>RubyでMac OS X用のソフトウェアを開発するためのフレームワークRubyCocoaについて、簡単なデモをまじえながら最新の開発状況・動向をお伝えします。</p>
@@ -167,6 +188,15 @@
 </dd>
 <dt>講演資料</dt>
 <dd><a href="http://www.fobj.com/hisa/d/20070611.html#p01" class="external">http://www.fobj.com/hisa/d/20070611.html#p01</a>
+</dd>
+<dt>講演動画</dt>
+<dd><a href="https://www.youtube.com/watch?v=bOB_JGrbF2U" class="external">https://www.youtube.com/watch?v=bOB_JGrbF2U</a>
+</dd>
+</dl>
+<h4>質疑応答(セッション 参)</h4>
+<dl>
+<dt>講演動画</dt>
+<dd><a href="https://www.youtube.com/watch?v=8v46GlJvHE8" class="external">https://www.youtube.com/watch?v=8v46GlJvHE8</a>
 </dd>
 </dl>
 <h3><a name="l13"><span class="sanchor"> </span></a>セッション 肆　15:50 - 16:50 ビジュアル系</h3>
@@ -186,6 +216,9 @@
 <dt>講演資料</dt>
 <dd><a href="http://d.hatena.ne.jp/secondlife/20070612/1181618706" class="external">http://d.hatena.ne.jp/secondlife/20070612/1181618706</a>
 </dd>
+<dt>講演動画</dt>
+<dd><a href="https://www.youtube.com/watch?v=F0N7FvLafbk" class="external">https://www.youtube.com/watch?v=F0N7FvLafbk</a>
+</dd>
 </dl>
 <h4><a name="l15"> </a>Ruby/SDLとその周辺　（大林 一平（ohai） / 原 悠（yhara））</h4>
 <p>Rubyでゲームを始めとしたマルチメディアアプリケーションを作るためのライブラリ、Ruby/SDL。開発6年目に入ったRuby/SDLの概要および最近のトピックを紹介します。Ruby/SDLを使ったことのない人にも興味を持って欲しいと思っています。<br><a href="http://www.kmc.gr.jp/~ohai/rubysdl.html" class="external">http://www.kmc.gr.jp/~ohai/rubysdl.html</a><br><a href="http://mono.kmc.gr.jp/~yhara/w/?RubySDLStarterKit" class="external">http://mono.kmc.gr.jp/~yhara/w/?RubySDLStarterKit</a></p>
@@ -201,6 +234,9 @@
 </dd>
 <dt>講演資料</dt>
 <dd><a href="http://www.kmc.gr.jp/~ohai/RubyKaigi2007/" class="external">http://www.kmc.gr.jp/~ohai/RubyKaigi2007/</a>
+</dd>
+<dt>講演動画</dt>
+<dd><a href="https://www.youtube.com/watch?v=JAii2ufLphs" class="external">https://www.youtube.com/watch?v=JAii2ufLphs</a>
 </dd>
 </dl>
 <h4><a name="l16"> </a>rcairo　（須藤 功平）</h4>
@@ -218,6 +254,9 @@
 <dt>講演資料</dt>
 <dd> <a href="http://pub.cozmixng.org/~gallery/kou/screenshot/rabbit/RubyKaigi2007/" class="external">http://pub.cozmixng.org/~gallery/kou/screenshot/rabbit/RubyKaigi2007/</a><br><br>HTML: <a href="http://pub.cozmixng.org/~kou/archives/RubyKaigi2007/" class="external">http://pub.cozmixng.org/~kou/archives/RubyKaigi2007/</a><br>PDF: <a href="http://pub.cozmixng.org/~kou/archives/RubyKaigi2007/rcairo.pdf" class="external">http://pub.cozmixng.org/~kou/archives/RubyKaigi2007/rcairo.pdf</a><br>上記HTMLとPDF: <a href="http://pub.cozmixng.org/~kou/archives/RubyKaigi2007.tar.gz" class="external">http://pub.cozmixng.org/~kou/archives/RubyKaigi2007.tar.gz</a>
 </dd>
+<dt>講演動画</dt>
+<dd><a href="https://www.youtube.com/watch?v=yPlUUrqrf50" class="external">https://www.youtube.com/watch?v=yPlUUrqrf50</a>
+</dd>
 </dl>
 <h4><a name="l17"> </a>私はいかにRubyでメディア・アート作品をつくり、しかも一円も損をしなかったか　（えと こういちろう）</h4>
 <p>私がこれまでRubyを使用して制作してきたメディア・アート作品を紹介する。昨年度は「インターネット物理モデル」を紹介したが，それ以外にも，インタラクティブな作品，ネットワークを用いた作品，音楽の自動生成を行った作品がある．それらの実例をお見せする．</p>
@@ -230,6 +269,15 @@
 </dd>
 <dt>講演時間</dt>
 <dd>16：35〜16：50
+</dd>
+<dt>講演動画</dt>
+<dd><a href="https://www.youtube.com/watch?v=RJ4nmB5YGv8" class="external">https://www.youtube.com/watch?v=RJ4nmB5YGv8</a>
+</dd>
+</dl>
+<h4>質疑応答(セッション 肆)</h4>
+<dl>
+<dt>講演動画</dt>
+<dd><a href="https://www.youtube.com/watch?v=Tz5BxrcTxrA" class="external">https://www.youtube.com/watch?v=Tz5BxrcTxrA</a>
 </dd>
 </dl>
 <h3><a name="l18"><span class="sanchor"> </span></a>セッション 伍　17:10 - 18:10 基調講演　（Dave Thomas）</h3>
@@ -250,8 +298,16 @@
 <dt>講演資料</dt>
 <dd><a href="the_island_of_ruby_j.pdf">the_island_of_ruby_j.pdf</a> （和訳付き, 8.24 MB）
 </dd>
+<dt>講演動画</dt>
+<dd><a href="https://www.youtube.com/watch?v=ECFGb6JX2yI" class="external">https://www.youtube.com/watch?v=ECFGb6JX2yI</a>
+</dd>
 </dl>
 <h3><a name="l20"><span class="sanchor"> </span></a>クロージング　18:10 - 18:20</h3>
+<dl>
+<dt>講演動画</dt>
+<dd><a href="https://www.youtube.com/watch?v=7Qy2ws5zctI" class="external">https://www.youtube.com/watch?v=7Qy2ws5zctI</a>
+</dd>
+</dl>
 <br>
 <hr>
 <p>※プログラムは予定です。予告無く変更する場合があります。</p>

--- a/2008/0thDay.html
+++ b/2008/0thDay.html
@@ -44,20 +44,20 @@
                         <p>オープニングの挨拶と、「<a href="/2008/Golf.html">RubyKaigi2008 Golfコンペ</a>」に関する説明があります。</p>
                         <p><img src="/2008/video/2008-06-20_rubykaigi2008-day0_1.jpg" alt="2008-06-20_rubykaigi2008-day0_1.jpg"></p>
                         <ul>
-                            <li><a href="/2008/video/2008-06-20_rubykaigi2008-day0_1.ogg" class="external">動画（Ogg Theora形式）</a></li>
+                            <li><a href="https://www.youtube.com/watch?v=P0MaYYGDvp4" class="external">動画（YouTube）</a></li>
                         </ul>
                         <h3><a name="l2"><span class="sanchor"> </span></a>13:30 対談『まつもとゆきひろ×最首英裕』〜Rubyを仕事に2008〜</h3>
                         <p>Rubyの生みの親であるまつもとゆきひろさんと、<a href="http://rubybizcommons.blogspot.com/" class="external">Rubyビジネスコモンズ</a>の最首英裕さんによる対談をお届けします。</p>
                         <p><img src="/2008/video/2008-06-20_rubykaigi2008-day0_1_2.jpg" alt="2008-06-20_rubykaigi2008-day0_1_2.jpg"></p>
                         <ul>
-                            <li><a href="/2008/video/2008-06-20_rubykaigi2008-day0_1_2.ogg" class="external">動画（Ogg Theora形式）</a></li>
+                            <li><a href="https://www.youtube.com/watch?v=uKjVFjyMY5Q" class="external">動画（YouTube）</a></li>
                             <li>資料はありません</li>
                         </ul>
                         <h3><a name="l3"><span class="sanchor"> </span></a>14:30 Ruby技術者認定試験について(CTC)</h3>
                         <p>別会場で行われているRuby技術者認定試験について、主催のCTC様より解説があります。</p>
                         <p><img src="/2008/video/2008-06-20_rubykaigi2008-day0_2.jpg" alt="2008-06-20_rubykaigi2008-day0_2.jpg"></p>
                         <ul>
-                            <li><a href="/2008/video/2008-06-20_rubykaigi2008-day0_2.ogg" class="external">動画（Ogg Theora形式）</a></li>
+                            <li><a href="https://www.youtube.com/watch?v=eUoBWO392kQ" class="external">動画（YouTube）</a></li>
                         </ul>
                         <h3><a name="l4"><span class="sanchor"> </span></a>15:05 スポンサーによる事例紹介</h3>
                         <h4>
@@ -71,7 +71,7 @@
                         </dl>
                         <p><img src="/2008/video/2008-06-20_rubykaigi2008-day0_3.jpg" alt="2008-06-20_rubykaigi2008-day0_3.jpg"></p>
                         <ul>
-                            <li><a href="/2008/video/2008-06-20_rubykaigi2008-day0_3.ogg" class="external">動画（Ogg Theora形式）</a></li>
+                            <li><a href="https://www.youtube.com/watch?v=lKQQy9JMTzs" class="external">動画（YouTube）</a></li>
                             <li>資料: <a href="/2008/pdf/rubykaigi2008_nacl.pdf">rubykaigi2008_nacl.pdf</a> (PDF)</li>
                         </ul>
                         <h4>
@@ -84,7 +84,7 @@
                         </dl>
                         <p><img src="/2008/video/2008-06-20_rubykaigi2008-day0_4.jpg" alt="2008-06-20_rubykaigi2008-day0_4.jpg"></p>
                         <ul>
-                            <li><a href="/2008/video/2008-06-20_rubykaigi2008-day0_4.ogg" class="external">動画（Ogg Theora形式）</a></li>
+                            <li><a href="https://www.youtube.com/watch?v=brnJrK8JDUw" class="external">動画（YouTube）</a></li>
                             <li>資料: <a href="/2008/pdf/rubykaigi2008_sun.pdf">rubykaigi2008_sun.pdf</a> (PDF)</li>
                         </ul>
                         <h4>
@@ -97,7 +97,7 @@
                         </dl>
                         <p><img src="/2008/video/2008-06-20_rubykaigi2008-day0_5.jpg" alt="2008-06-20_rubykaigi2008-day0_5.jpg"></p>
                         <ul>
-                            <li><a href="/2008/video/2008-06-20_rubykaigi2008-day0_5.ogg" class="external">動画（Ogg Theora形式）</a></li>
+                            <li><a href="https://www.youtube.com/watch?v=ook1ImTgThY" class="external">動画（YouTube）</a></li>
                             <li>資料: (調整中)</li>
                         </ul>
                         <h4>
@@ -110,7 +110,7 @@
                         </dl>
                         <p><img src="/2008/video/2008-06-20_rubykaigi2008-day0_6.jpg" alt="2008-06-20_rubykaigi2008-day0_6.jpg"></p>
                         <ul>
-                            <li><a href="/2008/video/2008-06-20_rubykaigi2008-day0_6.ogg" class="external">動画（Ogg Theora形式）</a></li>
+                            <li><a href="https://www.youtube.com/watch?v=ty7l7JGJv0Q" class="external">動画（YouTube）</a></li>
                             <li>資料: <a href="/2008/pdf/rubykaigi2008_eiwa.pdf">rubykaigi2008_eiwa.pdf</a> (PDF)</li>
                         </ul>
                         <h4>
@@ -123,7 +123,7 @@
                         </dl>
                         <p><img src="/2008/video/2008-06-20_rubykaigi2008-day0_7.jpg" alt="2008-06-20_rubykaigi2008-day0_7.jpg"></p>
                         <ul>
-                            <li><a href="/2008/video/2008-06-20_rubykaigi2008-day0_7.ogg" class="external">動画（Ogg Theora形式）</a></li>
+                            <li><a href="https://www.youtube.com/watch?v=zSHFA8OIf7o" class="external">動画（YouTube）</a></li>
                             <li>資料: <a href="/2008/pdf/rubykaigi2008_tis.pdf">rubykaigi2008_tis.pdf</a> (PDF)</li>
                         </ul>
                         <h4>
@@ -143,7 +143,7 @@
                         </dl>
                         <p><img src="/2008/video/2008-06-20_rubykaigi2008-day0_8.jpg" alt="2008-06-20_rubykaigi2008-day0_8.jpg"></p>
                         <ul>
-                            <li><a href="/2008/video/2008-06-20_rubykaigi2008-day0_8.ogg" class="external">動画（Ogg Theora形式）</a></li>
+                            <li><a href="https://www.youtube.com/watch?v=8upDyoiqwis" class="external">動画（YouTube）</a></li>
                             <li>資料: <a href="/2008/pdf/rubykaigi2008_nifty.pdf">rubykaigi2008_nifty.pdf</a> (PDF)</li>
                         </ul>
                         <h4>
@@ -156,7 +156,7 @@
                         </dl>
                         <p><img src="/2008/video/2008-06-20_rubykaigi2008-day0_9.jpg" alt="2008-06-20_rubykaigi2008-day0_9.jpg"></p>
                         <ul>
-                            <li><a href="/2008/video/2008-06-20_rubykaigi2008-day0_9.ogg" class="external">動画（Ogg Theora形式）</a></li>
+                            <li><a href="https://www.youtube.com/watch?v=Af3k8napVQs" class="external">動画（YouTube）</a></li>
                             <li>資料: (調整中)</li>
                         </ul>
                         <h3><a name="l12"><span class="sanchor"> </span></a>17:00 内外コミュニティ紹介 〜コミュニティが育てるRuby、コミュニティを育てるRuby〜</h3>
@@ -169,7 +169,7 @@
                         </ul>
                         <p><img src="/2008/video/2008-06-20_rubykaigi2008-day0_10.jpg" alt="2008-06-20_rubykaigi2008-day0_10.jpg"></p>
                         <ul>
-                            <li><a href="/2008/video/2008-06-20_rubykaigi2008-day0_10.ogg" class="external">動画（Ogg Theora形式）</a></li>
+                            <li><a href="https://www.youtube.com/watch?v=XPRfhV2H50s" class="external">動画（YouTube）</a></li>
                         </ul>
                         <h4>
                             <a name="l14"> </a>国内コミュニティ</h4>
@@ -185,7 +185,7 @@
                         </ul>
                         <p><img src="/2008/video/2008-06-20_rubykaigi2008-day0_11.jpg" alt="2008-06-20_rubykaigi2008-day0_11.jpg"></p>
                         <ul>
-                            <li><a href="/2008/video/2008-06-20_rubykaigi2008-day0_11.ogg" class="external">動画（Ogg Theora形式）</a></li>
+                            <li><a href="https://www.youtube.com/watch?v=pkGnayGZ0iE" class="external">動画（YouTube）</a></li>
                         </ul>
                         <h3><a name="l15"><span class="sanchor"> </span></a>19:00 前夜祭</h3>
                         <p>会場はそのままに、飲食物各自持ち込み方式の前夜祭に突入します。開始までに30分程度の空き時間があるので、食料品の買出しに行けます。 前夜祭に関する詳細はRubyKaigi日記の「

--- a/2008/LT.html
+++ b/2008/LT.html
@@ -50,7 +50,7 @@
                         </dl>
                         <p><img src="/2008/video/2008-06-21_rubykaigi2008-day1_10_LT01.jpg" alt="2008-06-21_rubykaigi2008-day1_10_LT01.jpg"></p>
                         <ul>
-                            <li><a href="/2008/video/2008-06-21_rubykaigi2008-day1_10_LT01.ogg" class="external">動画（Ogg Theora形式）</a></li>
+                            <li><a href="https://www.youtube.com/watch?v=w3KZBTaoBBI" class="external">動画（YouTube）</a></li>
                             <li>資料: <a href="/2008/pdf/rubykaigi2008_kuwata.pdf">rubykaigi2008_kuwata.pdf</a> (PDF)</li>
                         </ul>
                         <h4>
@@ -62,7 +62,7 @@
                         </dl>
                         <p><img src="/2008/video/2008-06-21_rubykaigi2008-day1_10_LT02.jpg" alt="2008-06-21_rubykaigi2008-day1_10_LT02.jpg"></p>
                         <ul>
-                            <li><a href="/2008/video/2008-06-21_rubykaigi2008-day1_10_LT02.ogg" class="external">動画（Ogg Theora形式）</a></li>
+                            <li><a href="https://www.youtube.com/watch?v=NhCfi6pSKOM" class="external">動画（YouTube）</a></li>
                             <li>資料: <a href="/2008/pdf/rubykaigi2008_znz.pdf">rubykaigi2008_znz.pdf</a> (PDF)</li>
                         </ul>
                         <h4>
@@ -74,7 +74,7 @@
                         </dl>
                         <p><img src="/2008/video/2008-06-21_rubykaigi2008-day1_10_LT03.jpg" alt="2008-06-21_rubykaigi2008-day1_10_LT03.jpg"></p>
                         <ul>
-                            <li><a href="/2008/video/2008-06-21_rubykaigi2008-day1_10_LT03.ogg" class="external">動画（Ogg Theora形式）</a></li>
+                            <li><a href="https://www.youtube.com/watch?v=1JWAkFUThTg" class="external">動画（YouTube）</a></li>
                             <li>資料(作業中)</li>
                         </ul>
                         <h4>
@@ -86,7 +86,7 @@
                         </dl>
                         <p><img src="/2008/video/2008-06-21_rubykaigi2008-day1_10_LT04.jpg" alt="2008-06-21_rubykaigi2008-day1_10_LT04.jpg"></p>
                         <ul>
-                            <li><a href="/2008/video/2008-06-21_rubykaigi2008-day1_10_LT04.ogg" class="external">動画（Ogg Theora形式）</a></li>
+                            <li><a href="https://www.youtube.com/watch?v=FGpUUiHJ4eY" class="external">動画（YouTube）</a></li>
                             <li>資料: <a href="/2008/pdf/rubykaigi2008_imai.pdf">rubykaigi2008_imai.pdf</a> (PDF)</li>
                         </ul>
                         <h4>
@@ -98,7 +98,7 @@
                         </dl>
                         <p><img src="/2008/video/2008-06-21_rubykaigi2008-day1_10_LT05.jpg" alt="2008-06-21_rubykaigi2008-day1_10_LT05.jpg"></p>
                         <ul>
-                            <li><a href="/2008/video/2008-06-21_rubykaigi2008-day1_10_LT05.ogg" class="external">動画（Ogg Theora形式）</a></li>
+                            <li><a href="https://www.youtube.com/watch?v=7FakLJ8BQ44" class="external">動画（YouTube）</a></li>
                             <li>資料: <a href="/2008/pdf/rubykaigi2008_mootoh.pdf">rubykaigi2008_mootoh.pdf</a> (PDF)</li>
                         </ul>
                         <h4>
@@ -110,7 +110,7 @@
                         </dl>
                         <p><img src="/2008/video/2008-06-21_rubykaigi2008-day1_10_LT06.jpg" alt="2008-06-21_rubykaigi2008-day1_10_LT06.jpg"></p>
                         <ul>
-                            <li><a href="/2008/video/2008-06-21_rubykaigi2008-day1_10_LT06.ogg" class="external">動画（Ogg Theora形式）</a></li>
+                            <li><a href="https://www.youtube.com/watch?v=liivnTlBrN0" class="external">動画（YouTube）</a></li>
                             <li>資料: <a href="/2008/pdf/rubykaigi2008_fuji.pdf">rubykaigi2008_fuji.pdf</a> (PDF)</li>
                         </ul>
                         <h4>
@@ -122,7 +122,7 @@
                         </dl>
                         <p><img src="/2008/video/2008-06-21_rubykaigi2008-day1_10_LT07.jpg" alt="2008-06-21_rubykaigi2008-day1_10_LT07.jpg"></p>
                         <ul>
-                            <li><a href="/2008/video/2008-06-21_rubykaigi2008-day1_10_LT07.ogg" class="external">動画（Ogg Theora形式）</a></li>
+                            <li><a href="https://www.youtube.com/watch?v=xoNWYRtvcQc" class="external">動画（YouTube）</a></li>
                             <li>資料: <a href="/2008/pdf/rubykaigi2008_ikezawa.pdf">rubykaigi2008_ikezawa.pdf</a> (PDF)</li>
                         </ul>
                         <h4>
@@ -134,7 +134,7 @@
                         </dl>
                         <p><img src="/2008/video/2008-06-21_rubykaigi2008-day1_10_LT08.jpg" alt="2008-06-21_rubykaigi2008-day1_10_LT08.jpg"></p>
                         <ul>
-                            <li><a href="/2008/video/2008-06-21_rubykaigi2008-day1_10_LT08.ogg" class="external">動画（Ogg Theora形式）</a></li>
+                            <li><a href="https://www.youtube.com/watch?v=2YJmXOaepUY" class="external">動画（YouTube）</a></li>
                             <li>資料: <a href="/2008/pdf/rubykaigi2008_matsuda.pdf">rubykaigi2008_matsuda.pdf</a> (PDF)</li>
                         </ul>
                         <h4>
@@ -146,7 +146,7 @@
                         </dl>
                         <p><img src="/2008/video/2008-06-21_rubykaigi2008-day1_10_LT09.jpg" alt="2008-06-21_rubykaigi2008-day1_10_LT09.jpg"></p>
                         <ul>
-                            <li><a href="/2008/video/2008-06-21_rubykaigi2008-day1_10_LT09.ogg" class="external">動画（Ogg Theora形式）</a></li>
+                            <li><a href="https://www.youtube.com/watch?v=qM7-QENsSmo" class="external">動画（YouTube）</a></li>
                             <li><a href="http://dame.dyndns.org/misc/misc/test-based-code-reading.ppt" class="external">資料</a> (Link, PPT)</li>
                         </ul>
                         <h4>
@@ -158,7 +158,7 @@
                         </dl>
                         <p><img src="/2008/video/2008-06-21_rubykaigi2008-day1_10_LT10.jpg" alt="2008-06-21_rubykaigi2008-day1_10_LT10.jpg"></p>
                         <ul>
-                            <li><a href="/2008/video/2008-06-21_rubykaigi2008-day1_10_LT10.ogg" class="external">動画（Ogg Theora形式）</a></li>
+                            <li><a href="https://www.youtube.com/watch?v=af5N6LL_kq8" class="external">動画（YouTube）</a></li>
                             <li>資料(作業中)</li>
                         </ul>
                         <h4>
@@ -170,7 +170,7 @@
                         </dl>
                         <p><img src="/2008/video/2008-06-21_rubykaigi2008-day1_10_LT11.jpg" alt="2008-06-21_rubykaigi2008-day1_10_LT11.jpg"></p>
                         <ul>
-                            <li><a href="/2008/video/2008-06-21_rubykaigi2008-day1_10_LT11.ogg" class="external">動画（Ogg Theora形式）</a></li>
+                            <li><a href="https://www.youtube.com/watch?v=EWy3fFUSGbs" class="external">動画（YouTube）</a></li>
                             <li>資料は皆さんの心のなかにあります</li>
                         </ul>
                     </div>

--- a/2008/MainSession.html
+++ b/2008/MainSession.html
@@ -57,7 +57,7 @@
                             <a name="l4"> </a>オープニング</h4>
                         <p><img src="/2008/video/2008-06-21_rubykaigi2008-day1_0.jpg" alt="2008-06-21_rubykaigi2008-day1_0.jpg"></p>
                         <ul>
-                            <li><a href="/2008/video/2008-06-21_rubykaigi2008-day1_0.ogg" class="external">動画（Ogg Theora形式）</a></li>
+                            <li><a href="https://www.youtube.com/watch?v=I32H-lXgiW8" class="external">動画（YouTube）</a></li>
                             <li>資料(作業中)</li>
                         </ul>
                         <h4>
@@ -70,7 +70,7 @@
                         </dl>
                         <p><img src="/2008/video/2008-06-21_rubykaigi2008-day1_1.jpg" alt="2008-06-21_rubykaigi2008-day1_1.jpg"></p>
                         <ul>
-                            <li><a href="/2008/video/2008-06-21_rubykaigi2008-day1_1.ogg" class="external">動画（Ogg Theora形式）</a></li>
+                            <li><a href="https://www.youtube.com/watch?v=epFkhgFiHiQ" class="external">動画（YouTube）</a></li>
                             <li>資料: <a href="/2008/pdf/rubykaigi2008_ko1.pdf">rubykaigi2008_ko1.pdf</a> (PDF)</li>
                         </ul>
                         <h4>
@@ -84,7 +84,7 @@
                         </dl>
                         <p><img src="/2008/video/2008-06-21_rubykaigi2008-day1_2.jpg" alt="2008-06-21_rubykaigi2008-day1_2.jpg"></p>
                         <ul>
-                            <li><a href="/2008/video/2008-06-21_rubykaigi2008-day1_2.ogg" class="external">動画（Ogg Theora形式）</a></li>
+                            <li><a href="https://www.youtube.com/watch?v=i2jaBWCl3uo" class="external">動画（YouTube）</a></li>
                             <li>資料(作業中)</li>
                         </ul>
                         <h4>
@@ -96,7 +96,7 @@
                         </dl>
                         <p><img src="/2008/video/2008-06-21_rubykaigi2008-day1_3.jpg" alt="2008-06-21_rubykaigi2008-day1_3.jpg"></p>
                         <ul>
-                            <li><a href="/2008/video/2008-06-21_rubykaigi2008-day1_3.ogg" class="external">動画（Ogg Theora形式）</a></li>
+                            <li><a href="https://www.youtube.com/watch?v=ZW62w_lYLtQ" class="external">動画（YouTube）</a></li>
                             <li>資料(作業中)</li>
                         </ul>
                         <h3><a name="l8"><span class="sanchor"> </span></a>13:30〜15:30</h3>
@@ -110,7 +110,7 @@
                         </dl>
                         <p><img src="/2008/video/2008-06-21_rubykaigi2008-day1_4.jpg" alt="2008-06-21_rubykaigi2008-day1_4.jpg"></p>
                         <ul>
-                            <li><a href="/2008/video/2008-06-21_rubykaigi2008-day1_4.ogg" class="external">動画（Ogg Theora形式）</a></li>
+                            <li><a href="https://www.youtube.com/watch?v=CxB_P6PbirI" class="external">動画（YouTube）</a></li>
                             <li>資料(作業中)</li>
                         </ul>
                         <h4>
@@ -128,7 +128,7 @@
                         </dl>
                         <p><img src="/2008/video/2008-06-21_rubykaigi2008-day1_5.jpg" alt="2008-06-21_rubykaigi2008-day1_5.jpg"></p>
                         <ul>
-                            <li><a href="/2008/video/2008-06-21_rubykaigi2008-day1_5.ogg" class="external">動画（Ogg Theora形式）</a></li>
+                            <li><a href="https://www.youtube.com/watch?v=yfvVIHNd9UA" class="external">動画（YouTube）</a></li>
                             <li><a href="http://naruse.biz/pub/index.html" class="external">資料(1)</a> (Link)</li>
                             <li><a href="http://www.sw.it.aoyama.ac.jp/2008/pub/RubyKaigiM17N.html" class="external">資料(2)</a> (Link)</li>
                         </ul>
@@ -143,7 +143,7 @@
                         </dl>
                         <p><img src="/2008/video/2008-06-21_rubykaigi2008-day1_6.jpg" alt="2008-06-21_rubykaigi2008-day1_6.jpg"></p>
                         <ul>
-                            <li><a href="/2008/video/2008-06-21_rubykaigi2008-day1_6.ogg" class="external">動画（Ogg Theora形式）</a></li>
+                            <li><a href="https://www.youtube.com/watch?v=6XQbeST_vaY" class="external">動画（YouTube）</a></li>
                             <li>資料: <a href="/2008/pdf/rubykaigi2008_masuhara.pdf">rubykaigi2008_masuhara.pdf</a> (PDF)</li>
                         </ul>
                         <h4>
@@ -157,7 +157,7 @@
                         </dl>
                         <p><img src="/2008/video/2008-06-21_rubykaigi2008-day1_7.jpg" alt="2008-06-21_rubykaigi2008-day1_7.jpg"></p>
                         <ul>
-                            <li><a href="/2008/video/2008-06-21_rubykaigi2008-day1_7.ogg" class="external">動画（Ogg Theora形式）</a></li>
+                            <li><a href="https://www.youtube.com/watch?v=TTD8yCLo2OA" class="external">動画（YouTube）</a></li>
                             <li>資料: <a href="/2008/pdf/rubykaigi2008_yoshida.pdf">rubykaigi2008_yoshida.pdf</a> (PDF)</li>
                         </ul>
                         <h4>
@@ -170,7 +170,7 @@
                         </dl>
                         <p><img src="/2008/video/2008-06-21_rubykaigi2008-day1_8.jpg" alt="2008-06-21_rubykaigi2008-day1_8.jpg"></p>
                         <ul>
-                            <li><a href="/2008/video/2008-06-21_rubykaigi2008-day1_8.ogg" class="external">動画（Ogg Theora形式）</a></li>
+                            <li><a href="https://www.youtube.com/watch?v=NL_sZyPB9b4" class="external">動画（YouTube）</a></li>
                             <li>資料: <a href="/2008/pdf/rubykaigi2008_yugui.pdf">rubykaigi2008_yugui.pdf</a> (PDF)</li>
                         </ul>
                         <h4>
@@ -183,7 +183,7 @@
                         </dl>
                         <p><img src="/2008/video/2008-06-21_rubykaigi2008-day1_9.jpg" alt="2008-06-21_rubykaigi2008-day1_9.jpg"></p>
                         <ul>
-                            <li><a href="/2008/video/2008-06-21_rubykaigi2008-day1_9.ogg" class="external">動画（Ogg Theora形式）</a></li>
+                            <li><a href="https://www.youtube.com/watch?v=uAzI0NV5Iog" class="external">動画（YouTube）</a></li>
                             <li>資料(作業中)</li>
                         </ul>
                         <h3><a name="l16"><span class="sanchor"> </span></a>17:30〜18:30 Lightning Talks</h3>
@@ -209,7 +209,7 @@
                         </dl>
                         <p><img src="/2008/video/2008-06-22_rubykaigi2008-day2_1.jpg" alt="2008-06-22_rubykaigi2008-day2_1.jpg"></p>
                         <ul>
-                            <li><a href="/2008/video/2008-06-22_rubykaigi2008-day2_1.ogg" class="external">動画（Ogg Theora形式）</a></li>
+                            <li><a href="https://www.youtube.com/watch?v=PCdhenyTfgE" class="external">動画（YouTube）</a></li>
                             <li>資料: <a href="/2008/pdf/rubykaigi2008_arton.pdf">rubykaigi2008_arton.pdf</a> (PDF)</li>
                         </ul>
                         <h4>
@@ -222,7 +222,7 @@
                         </dl>
                         <p><img src="/2008/video/2008-06-22_rubykaigi2008-day2_2.jpg" alt="2008-06-22_rubykaigi2008-day2_2.jpg"></p>
                         <ul>
-                            <li><a href="/2008/video/2008-06-22_rubykaigi2008-day2_2.ogg" class="external">動画（Ogg Theora形式）</a></li>
+                            <li><a href="https://www.youtube.com/watch?v=qRe2BRnbGvo" class="external">動画（YouTube）</a></li>
                             <li>資料: <a href="/2008/pdf/rubykaigi2008_gotoken.pdf">rubykaigi2008_gotoken.pdf</a> (PDF)</li>
                         </ul>
                         <h4>
@@ -235,7 +235,7 @@
                         </dl>
                         <p><img src="/2008/video/2008-06-22_rubykaigi2008-day2_3.jpg" alt="2008-06-22_rubykaigi2008-day2_3.jpg"></p>
                         <ul>
-                            <li><a href="/2008/video/2008-06-22_rubykaigi2008-day2_3.ogg" class="external">動画（Ogg Theora形式）</a></li>
+                            <li><a href="https://www.youtube.com/watch?v=R3mSN961fks" class="external">動画（YouTube）</a></li>
                             <li>資料: <a href="/2008/pdf/rubykaigi2008_seki.pdf">rubykaigi2008_seki.pdf</a> (PDF)</li>
                         </ul>
                         <h3><a name="l24"><span class="sanchor"> </span></a>10:20〜12:00</h3>
@@ -249,7 +249,7 @@
                         </dl>
                         <p><img src="/2008/video/2008-06-22_rubykaigi2008-day2_4.jpg" alt="2008-06-22_rubykaigi2008-day2_4.jpg"></p>
                         <ul>
-                            <li><a href="/2008/video/2008-06-22_rubykaigi2008-day2_4.ogg" class="external">動画（Ogg Theora形式）</a></li>
+                            <li><a href="https://www.youtube.com/watch?v=QPD-H_WHasE" class="external">動画（YouTube）</a></li>
                             <li>資料: <a href="/2008/pdf/rubykaigi2008_akr.pdf">rubykaigi2008_akr.pdf</a> (PDF)</li>
                         </ul>
                         <h4>
@@ -262,7 +262,7 @@
                         </dl>
                         <p><img src="/2008/video/2008-06-22_rubykaigi2008-day2_5.jpg" alt="2008-06-22_rubykaigi2008-day2_5.jpg"></p>
                         <ul>
-                            <li><a href="/2008/video/2008-06-22_rubykaigi2008-day2_5.ogg" class="external">動画（Ogg Theora形式）</a></li>
+                            <li><a href="https://www.youtube.com/watch?v=G5Sc78My2w8" class="external">動画（YouTube）</a></li>
                             <li>資料: <a href="/2008/pdf/rubykaigi2008_aoki.pdf">rubykaigi2008_aoki.pdf</a> (PDF)</li>
                         </ul>
                         <h4>
@@ -279,7 +279,7 @@
                         </dl>
                         <p><img src="/2008/video/2008-06-22_rubykaigi2008-day2_6.jpg" alt="2008-06-22_rubykaigi2008-day2_6.jpg"></p>
                         <ul>
-                            <li><a href="/2008/video/2008-06-22_rubykaigi2008-day2_6.ogg" class="external">動画（Ogg Theora形式）</a></li>
+                            <li><a href="https://www.youtube.com/watch?v=oKyd2tSaV-w" class="external">動画（YouTube）</a></li>
                             <li>資料: <a href="/2008/pdf/rubykaigi2008_laurent.pdf">rubykaigi2008_laurent.pdf</a> (PDF)</li>
                         </ul>
                         <h3><a name="l28"><span class="sanchor"> </span></a>13:30〜14:20</h3>
@@ -293,7 +293,7 @@
                         </dl>
                         <p><img src="/2008/video/2008-06-22_rubykaigi2008-day2_7.jpg" alt="2008-06-22_rubykaigi2008-day2_7.jpg"></p>
                         <ul>
-                            <li><a href="/2008/video/2008-06-22_rubykaigi2008-day2_7.ogg" class="external">動画（Ogg Theora形式）</a></li>
+                            <li><a href="https://www.youtube.com/watch?v=1xGJk1QksCE" class="external">動画（YouTube）</a></li>
                             <li>資料(作業中)</li>
                         </ul>
                         <h4>
@@ -311,7 +311,7 @@
                         </dl>
                         <p><img src="/2008/video/2008-06-22_rubykaigi2008-day2_8.jpg" alt="2008-06-22_rubykaigi2008-day2_8.jpg"></p>
                         <ul>
-                            <li><a href="/2008/video/2008-06-22_rubykaigi2008-day2_8.ogg" class="external">動画（Ogg Theora形式）</a></li>
+                            <li><a href="https://www.youtube.com/watch?v=NA4k7tXEMJQ" class="external">動画（YouTube）</a></li>
                             <li>資料: <a href="/2008/pdf/rubykaigi2008_takai.pdf">rubykaigi2008_takai.pdf</a> (PDF)</li>
                         </ul>
                         <h3><a name="l31"><span class="sanchor"> </span></a>14:40〜15:40</h3>
@@ -328,7 +328,7 @@
                         </dl>
                         <p><img src="/2008/video/2008-06-22_rubykaigi2008-day2_9.jpg" alt="2008-06-22_rubykaigi2008-day2_9.jpg"></p>
                         <ul>
-                            <li><a href="/2008/video/2008-06-22_rubykaigi2008-day2_9.ogg" class="external">動画（Ogg Theora形式）</a></li>
+                            <li><a href="https://www.youtube.com/watch?v=BOhYH0szXl0" class="external">動画（YouTube）</a></li>
                             <li>資料: <a href="/2008/pdf/rubykaigi2008_zev.pdf">rubykaigi2008_zev.pdf</a> (PDF)</li>
                         </ul>
                         <h4>
@@ -342,7 +342,7 @@
                         </dl>
                         <p><img src="/2008/video/2008-06-22_rubykaigi2008-day2_10.jpg" alt="2008-06-22_rubykaigi2008-day2_10.jpg"></p>
                         <ul>
-                            <li><a href="/2008/video/2008-06-22_rubykaigi2008-day2_10.ogg" class="external">動画（Ogg Theora形式）</a></li>
+                            <li><a href="https://www.youtube.com/watch?v=hMUCdf2RlH8" class="external">動画（YouTube）</a></li>
                             <li>資料: <a href="/2008/pdf/rubykaigi2008_kyowa.pdf">rubykaigi2008_kyowa.pdf</a> (PDF)</li>
                         </ul>
                         <h4>
@@ -355,7 +355,7 @@
                         </dl>
                         <p><img src="/2008/video/2008-06-22_rubykaigi2008-day2_11.jpg" alt="2008-06-22_rubykaigi2008-day2_11.jpg"></p>
                         <ul>
-                            <li><a href="/2008/video/2008-06-22_rubykaigi2008-day2_11.ogg" class="external">動画（Ogg Theora形式）</a></li>
+                            <li><a href="https://www.youtube.com/watch?v=HFfuRGjvXiM" class="external">動画（YouTube）</a></li>
                             <li>資料: <a href="/2008/pdf/rubykaigi2008_dara.pdf">rubykaigi2008_dara.pdf</a> (PDF)</li>
                         </ul>
                         <h3><a name="l35"><span class="sanchor"> </span></a>16:00〜16:40</h3>
@@ -375,7 +375,7 @@
                         </dl>
                         <p><img src="/2008/video/2008-06-22_rubykaigi2008-day2_12.jpg" alt="2008-06-22_rubykaigi2008-day2_12.jpg"></p>
                         <ul>
-                            <li><a href="/2008/video/2008-06-22_rubykaigi2008-day2_12.ogg" class="external">動画（Ogg Theora形式）</a></li>
+                            <li><a href="https://www.youtube.com/watch?v=yZQ_-5ubYKQ" class="external">動画（YouTube）</a></li>
                             <li><a href="http://alexkane.net/RubyKaigi2008Slides" class="external">資料</a> (Link)</li>
                         </ul>
                         <h4>
@@ -388,13 +388,13 @@
                         </dl>
                         <p><img src="/2008/video/2008-06-22_rubykaigi2008-day2_13.jpg" alt="2008-06-22_rubykaigi2008-day2_13.jpg"></p>
                         <ul>
-                            <li><a href="/2008/video/2008-06-22_rubykaigi2008-day2_13.ogg" class="external">動画（Ogg Theora形式）</a></li>
+                            <li><a href="https://www.youtube.com/watch?v=oA69Hx2c6SQ" class="external">動画（YouTube）</a></li>
                             <li>資料(作業中)</li>
                         </ul>
                         <h3><a name="l38"><span class="sanchor"> </span></a>16:40〜17:00 Closing</h3>
                         <p><img src="/2008/video/2008-06-22_rubykaigi2008-day2_14.jpg" alt="2008-06-22_rubykaigi2008-day2_14.jpg"></p>
                         <ul>
-                            <li><a href="/2008/video/2008-06-22_rubykaigi2008-day2_14.ogg" class="external">動画（Ogg Theora形式）</a></li>
+                            <li><a href="https://www.youtube.com/watch?v=u3G-wkZkPoE" class="external">動画（YouTube）</a></li>
                             <li>資料(作業中)</li>
                         </ul>
                     </div>

--- a/2008/SubSession.html
+++ b/2008/SubSession.html
@@ -63,7 +63,7 @@
                         </dl>
                         <p><img src="/2008/video/2008-06-21_rubykaigi2008-day1_01_aaron.jpg" alt="2008-06-21_rubykaigi2008-day1_01_aaron.jpg"></p>
                         <ul>
-                            <li><a href="/2008/video/2008-06-21_rubykaigi2008-day1_01_aaron.ogg" class="external">動画（Ogg Theora形式）</a></li>
+                            <li><a href="https://www.youtube.com/watch?v=iY-gGly0WrQ" class="external">動画（YouTube）</a></li>
                             <li>資料(作業中)</li>
                         </ul>
                         <h3><a name="l5"><span class="sanchor"> </span></a>11:30〜12:00</h3>
@@ -77,7 +77,7 @@
                         </dl>
                         <p><img src="/2008/video/2008-06-21_rubykaigi2008-day1_02_nagai.jpg" alt="2008-06-21_rubykaigi2008-day1_02_nagai.jpg"></p>
                         <ul>
-                            <li><a href="/2008/video/2008-06-21_rubykaigi2008-day1_02_nagai.ogg" class="external">動画（Ogg Theora形式）</a></li>
+                            <li><a href="https://www.youtube.com/watch?v=aqSau56Yv74" class="external">動画（YouTube）</a></li>
                             <li>資料: <a href="/2008/pdf/rubykaigi2008_nagai.pdf">rubykaigi2008_nagai.pdf</a> (PDF)</li>
                         </ul>
                         <h3><a name="l7"><span class="sanchor"> </span></a>16:00〜16:30</h3>
@@ -91,7 +91,7 @@
                         </dl>
                         <p><img src="/2008/video/2008-06-21_rubykaigi2008-day1_03_noda.jpg" alt="2008-06-21_rubykaigi2008-day1_03_noda.jpg"></p>
                         <ul>
-                            <li><a href="/2008/video/2008-06-21_rubykaigi2008-day1_03_noda.ogg" class="external">動画（Ogg Theora形式）</a></li>
+                            <li><a href="https://www.youtube.com/watch?v=GMLpCWdZMGY" class="external">動画（YouTube）</a></li>
                             <li>資料(作業中)</li>
                         </ul>
                         <h3><a name="l9"><span class="sanchor"> </span></a>16:30〜17:00</h3>
@@ -105,7 +105,7 @@
                         </dl>
                         <p><img src="/2008/video/2008-06-21_rubykaigi2008-day1_04_arai.jpg" alt="2008-06-21_rubykaigi2008-day1_04_arai.jpg"></p>
                         <ul>
-                            <li><a href="/2008/video/2008-06-21_rubykaigi2008-day1_04_arai.ogg" class="external">動画（Ogg Theora形式）</a></li>
+                            <li><a href="https://www.youtube.com/watch?v=dhOTOkPnO8Q" class="external">動画（YouTube）</a></li>
                             <li>資料(作業中)</li>
                         </ul>
                         <h3><a name="l11"><span class="sanchor"> </span></a>17:00〜17:30</h3>
@@ -119,7 +119,7 @@
                         </dl>
                         <p><img src="/2008/video/2008-06-21_rubykaigi2008-day1_05_ujihisa.jpg" alt="2008-06-21_rubykaigi2008-day1_05_ujihisa.jpg"></p>
                         <ul>
-                            <li><a href="/2008/video/2008-06-21_rubykaigi2008-day1_05_ujihisa.ogg" class="external">動画（Ogg Theora形式）</a></li>
+                            <li><a href="https://www.youtube.com/watch?v=7hIH7h4JP5k" class="external">動画（YouTube）</a></li>
                             <li>資料(作業中)</li>
                         </ul>
                     </div>
@@ -144,7 +144,7 @@
                         </dl>
                         <p><img src="/2008/video/2008-06-22_rubykaigi2008-day2_01_maedak.jpg" alt="2008-06-22_rubykaigi2008-day2_01_maedak.jpg"></p>
                         <ul>
-                            <li><a href="/2008/video/2008-06-22_rubykaigi2008-day2_01_maedak.ogg" class="external">動画（Ogg Theora形式）</a></li>
+                            <li><a href="https://www.youtube.com/watch?v=Ay_m1qvBU-c" class="external">動画（YouTube）</a></li>
                             <li>資料: <a href="/2008/pdf/rubykaigi2008_maedak.pdf">rubykaigi2008_maedak.pdf</a> (PDF)</li>
                         </ul>
                         <h3><a name="l18"><span class="sanchor"> </span></a>10:30〜11:00</h3>
@@ -160,7 +160,7 @@
                         </dl>
                         <p><img src="/2008/video/2008-06-22_rubykaigi2008-day2_02_nomura.jpg" alt="2008-06-22_rubykaigi2008-day2_02_nomura.jpg"></p>
                         <ul>
-                            <li><a href="/2008/video/2008-06-22_rubykaigi2008-day2_02_nomura.ogg" class="external">動画（Ogg Theora形式）</a></li>
+                            <li><a href="https://www.youtube.com/watch?v=x_EJdJ7tY24" class="external">動画（YouTube）</a></li>
                             <li>資料(作業中)</li>
                         </ul>
                         <h3><a name="l20"><span class="sanchor"> </span></a>11:30〜12:00</h3>
@@ -174,7 +174,7 @@
                         </dl>
                         <p><img src="/2008/video/2008-06-22_rubykaigi2008-day2_03_fukuda.jpg" alt="2008-06-22_rubykaigi2008-day2_03_fukuda.jpg"></p>
                         <ul>
-                            <li><a href="/2008/video/2008-06-22_rubykaigi2008-day2_03_fukuda.ogg" class="external">動画（Ogg Theora形式）</a></li>
+                            <li><a href="https://www.youtube.com/watch?v=foutNZ2LIsg" class="external">動画（YouTube）</a></li>
                             <li>資料(作業中)</li>
                         </ul>
                         <h3><a name="l22"><span class="sanchor"> </span></a>13:30〜14:00</h3>
@@ -189,7 +189,7 @@
                         </dl>
                         <p><img src="/2008/video/2008-06-22_rubykaigi2008-day2_04_hoshihajime.jpg" alt="2008-06-22_rubykaigi2008-day2_04_hoshihajime.jpg"></p>
                         <ul>
-                            <li><a href="/2008/video/2008-06-22_rubykaigi2008-day2_04_hoshihajime.ogg" class="external">動画（Ogg Theora形式）</a></li>
+                            <li><a href="https://www.youtube.com/watch?v=A_-L9i_pIi8" class="external">動画（YouTube）</a></li>
                             <li>資料: <a href="/2008/pdf/rubykaigi2008_hoshi.zip">rubykaigi2008_hoshi.zip</a> (ZIP)</li>
                         </ul>
                         <h3><a name="l24"><span class="sanchor"> </span></a>14:00〜14:30</h3>
@@ -203,7 +203,7 @@
                         </dl>
                         <p><img src="/2008/video/2008-06-22_rubykaigi2008-day2_05_cyros.jpg" alt="2008-06-22_rubykaigi2008-day2_05_cyros.jpg"></p>
                         <ul>
-                            <li><a href="/2008/video/2008-06-22_rubykaigi2008-day2_05_cyros.ogg" class="external">動画（Ogg Theora形式）</a></li>
+                            <li><a href="https://www.youtube.com/watch?v=QOaTAYS2PVY" class="external">動画（YouTube）</a></li>
                             <li>資料: <a href="/2008/pdf/rubykaigi2008_cyross.zip">rubykaigi2008_cyross.zip</a> (ZIP)</li>
                         </ul>
                         <h3><a name="l26"><span class="sanchor"> </span></a>14:40〜15:10</h3>
@@ -217,7 +217,7 @@
                         </dl>
                         <p><img src="/2008/video/2008-06-22_rubykaigi2008-day2_06_cho45.jpg" alt="2008-06-22_rubykaigi2008-day2_06_cho45.jpg"></p>
                         <ul>
-                            <li><a href="/2008/video/2008-06-22_rubykaigi2008-day2_06_cho45.ogg" class="external">動画（Ogg Theora形式）</a></li>
+                            <li><a href="https://www.youtube.com/watch?v=SLDNsfKPM5Y" class="external">動画（YouTube）</a></li>
                             <li><a href="http://svn.coderepos.org/share/docs/cho45/20080622-rubykaigi-subsession-net-irc/converted.html" class="external">資料</a> (HTML)</li>
                         </ul>
                         <h3><a name="l28"><span class="sanchor"> </span></a>15:10〜15:40</h3>
@@ -233,7 +233,7 @@
                         </dl>
                         <p><img src="/2008/video/2008-06-22_rubykaigi2008-day2_07_matsumoto.jpg" alt="2008-06-22_rubykaigi2008-day2_07_matsumoto.jpg"></p>
                         <ul>
-                            <li><a href="/2008/video/2008-06-22_rubykaigi2008-day2_07_matsumoto.ogg" class="external">動画（Ogg Theora形式）</a></li>
+                            <li><a href="https://www.youtube.com/watch?v=o92dHBizYCo" class="external">動画（YouTube）</a></li>
                             <li>資料: <a href="/2008/pdf/rubykaigi2008_matsumoto.pdf">rubykaigi2008_matsumoto.pdf</a> (PDF)</li>
                         </ul>
                         <h3><a name="l30"><span class="sanchor"> </span></a>15:40〜16:10</h3>
@@ -248,7 +248,7 @@
                         </dl>
                         <p><img src="/2008/video/2008-06-22_rubykaigi2008-day2_08_authornari.jpg" alt="2008-06-22_rubykaigi2008-day2_08_authornari.jpg"></p>
                         <ul>
-                            <li><a href="/2008/video/2008-06-22_rubykaigi2008-day2_08_authornari.ogg" class="external">動画（Ogg Theora形式）</a></li>
+                            <li><a href="https://www.youtube.com/watch?v=B-J3kvGYyoI" class="external">動画（YouTube）</a></li>
                             <li>資料: <a href="/2008/pdf/rubykaigi2008_nari.pdf">rubykaigi2008_nari.pdf</a> (PDF)</li>
                         </ul>
                         <h3><a name="l32"><span class="sanchor"> </span></a>16:10〜16:40</h3>
@@ -263,7 +263,7 @@
                         </dl>
                         <p><img src="/2008/video/2008-06-22_rubykaigi2008-day2_09_martin.jpg" alt="2008-06-22_rubykaigi2008-day2_09_martin.jpg"></p>
                         <ul>
-                            <li><a href="/2008/video/2008-06-22_rubykaigi2008-day2_09_martin.ogg" class="external">動画（Ogg Theora形式）</a></li>
+                            <li><a href="https://www.youtube.com/watch?v=4oEW7d6Qn3o" class="external">動画（YouTube）</a></li>
                             <li><a href="http://www.sw.it.aoyama.ac.jp/SVuGy/RubyKaigi2008Presentation.html" class="external">資料</a> (Link)</li>
                         </ul>
                     </div>


### PR DESCRIPTION
2006は、Google Videoへの動画リンクページがあったので、そこのリンクを書き換えています。

2007は、動画まとめページが無かったので、「講演資料」のリンクの下に「講演動画」のリンクを足しました。

2008は、サイト上に.oggファイルがあったのをYouTubeに移動したので、元のリンクを置き換えています。

Hikiで生成したHTMLを手で書き換えてるのってどうなのよ？という話はありそうですが、そこはもうしょうがないってことで。