### PR TITLE
Fix charset

### DIFF
--- a/2008/0thDay.html
+++ b/2008/0thDay.html
@@ -6,8 +6,8 @@
 <head>
 
     <meta http-equiv="Content-Language" content="en">
-    <meta http-equiv="Content-Type" content="text/html; charset=EUC-JP">
-    <meta http-equiv="Content-Script-Type" content="text/javascript; charset=euc-jp">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Script-Type" content="text/javascript; charset=utf-8">
     <meta http-equiv="Content-Style-Type" content="text/css">
     <meta name="generator" content="Hiki 0.9dev">
     <title>日本 Ruby 会議 2008 - 0th dayプログラム</title>

--- a/2008/0thDay_en.html
+++ b/2008/0thDay_en.html
@@ -6,8 +6,8 @@
 <head>
 
     <meta http-equiv="Content-Language" content="en">
-    <meta http-equiv="Content-Type" content="text/html; charset=EUC-JP">
-    <meta http-equiv="Content-Script-Type" content="text/javascript; charset=euc-jp">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Script-Type" content="text/javascript; charset=utf-8">
     <meta http-equiv="Content-Style-Type" content="text/css">
     <meta name="generator" content="Hiki 0.9dev">
     <title>日本 Ruby 会議 2008 - 0thDay_en</title>

--- a/2008/BuyTicket.html
+++ b/2008/BuyTicket.html
@@ -6,8 +6,8 @@
 <head>
 
     <meta http-equiv="Content-Language" content="en">
-    <meta http-equiv="Content-Type" content="text/html; charset=EUC-JP">
-    <meta http-equiv="Content-Script-Type" content="text/javascript; charset=euc-jp">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Script-Type" content="text/javascript; charset=utf-8">
     <meta http-equiv="Content-Style-Type" content="text/css">
     <meta name="generator" content="Hiki 0.9dev">
     <title>日本 Ruby 会議 2008 - 参加方法</title>

--- a/2008/BuyTicket_en.html
+++ b/2008/BuyTicket_en.html
@@ -6,8 +6,8 @@
 <head>
 
     <meta http-equiv="Content-Language" content="en">
-    <meta http-equiv="Content-Type" content="text/html; charset=EUC-JP">
-    <meta http-equiv="Content-Script-Type" content="text/javascript; charset=euc-jp">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Script-Type" content="text/javascript; charset=utf-8">
     <meta http-equiv="Content-Style-Type" content="text/css">
     <meta name="generator" content="Hiki 0.9dev">
     <title>日本 Ruby 会議 2008 - BuyTicket_en</title>

--- a/2008/ExecutiveCommittee.html
+++ b/2008/ExecutiveCommittee.html
@@ -6,8 +6,8 @@
 <head>
 
     <meta http-equiv="Content-Language" content="en">
-    <meta http-equiv="Content-Type" content="text/html; charset=EUC-JP">
-    <meta http-equiv="Content-Script-Type" content="text/javascript; charset=euc-jp">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Script-Type" content="text/javascript; charset=utf-8">
     <meta http-equiv="Content-Style-Type" content="text/css">
     <meta name="generator" content="Hiki 0.9dev">
     <title>日本 Ruby 会議 2008 - 日本Ruby会議2008実行委員会</title>

--- a/2008/ExecutiveCommittee_en.html
+++ b/2008/ExecutiveCommittee_en.html
@@ -6,8 +6,8 @@
 <head>
 
     <meta http-equiv="Content-Language" content="en">
-    <meta http-equiv="Content-Type" content="text/html; charset=EUC-JP">
-    <meta http-equiv="Content-Script-Type" content="text/javascript; charset=euc-jp">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Script-Type" content="text/javascript; charset=utf-8">
     <meta http-equiv="Content-Style-Type" content="text/css">
     <meta name="generator" content="Hiki 0.9dev">
     <title>日本 Ruby 会議 2008 - ExecutiveCommittee_en</title>

--- a/2008/Golf.html
+++ b/2008/Golf.html
@@ -6,8 +6,8 @@
 <head>
 
     <meta http-equiv="Content-Language" content="en">
-    <meta http-equiv="Content-Type" content="text/html; charset=EUC-JP">
-    <meta http-equiv="Content-Script-Type" content="text/javascript; charset=euc-jp">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Script-Type" content="text/javascript; charset=utf-8">
     <meta http-equiv="Content-Style-Type" content="text/css">
     <meta name="generator" content="Hiki 0.9dev">
     <title>日本 Ruby 会議 2008 - RubyKaigi2008 Golfコンペ</title>

--- a/2008/Golf_en.html
+++ b/2008/Golf_en.html
@@ -6,8 +6,8 @@
 <head>
 
     <meta http-equiv="Content-Language" content="en">
-    <meta http-equiv="Content-Type" content="text/html; charset=EUC-JP">
-    <meta http-equiv="Content-Script-Type" content="text/javascript; charset=euc-jp">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Script-Type" content="text/javascript; charset=utf-8">
     <meta http-equiv="Content-Style-Type" content="text/css">
     <meta name="generator" content="Hiki 0.9dev">
     <title>日本 Ruby 会議 2008 - Golf_en</title>

--- a/2008/Goodies.html
+++ b/2008/Goodies.html
@@ -6,8 +6,8 @@
 <head>
 
     <meta http-equiv="Content-Language" content="en">
-    <meta http-equiv="Content-Type" content="text/html; charset=EUC-JP">
-    <meta http-equiv="Content-Script-Type" content="text/javascript; charset=euc-jp">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Script-Type" content="text/javascript; charset=utf-8">
     <meta http-equiv="Content-Style-Type" content="text/css">
     <meta name="generator" content="Hiki 0.9dev">
     <title>日本 Ruby 会議 2008 - おまけ</title>

--- a/2008/Information.html
+++ b/2008/Information.html
@@ -6,8 +6,8 @@
 <head>
 
     <meta http-equiv="Content-Language" content="en">
-    <meta http-equiv="Content-Type" content="text/html; charset=EUC-JP">
-    <meta http-equiv="Content-Script-Type" content="text/javascript; charset=euc-jp">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Script-Type" content="text/javascript; charset=utf-8">
     <meta http-equiv="Content-Style-Type" content="text/css">
     <meta name="generator" content="Hiki 0.9dev">
     <title>日本 Ruby 会議 2008 - 参加者向け情報</title>

--- a/2008/Information_en.html
+++ b/2008/Information_en.html
@@ -6,8 +6,8 @@
 <head>
 
     <meta http-equiv="Content-Language" content="en">
-    <meta http-equiv="Content-Type" content="text/html; charset=EUC-JP">
-    <meta http-equiv="Content-Script-Type" content="text/javascript; charset=euc-jp">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Script-Type" content="text/javascript; charset=utf-8">
     <meta http-equiv="Content-Style-Type" content="text/css">
     <meta name="generator" content="Hiki 0.9dev">
     <title>日本 Ruby 会議 2008 - Information_en</title>

--- a/2008/Intent.html
+++ b/2008/Intent.html
@@ -6,8 +6,8 @@
 <head>
 
     <meta http-equiv="Content-Language" content="en">
-    <meta http-equiv="Content-Type" content="text/html; charset=EUC-JP">
-    <meta http-equiv="Content-Script-Type" content="text/javascript; charset=euc-jp">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Script-Type" content="text/javascript; charset=utf-8">
     <meta http-equiv="Content-Style-Type" content="text/css">
     <meta name="generator" content="Hiki 0.9dev">
     <title>日本 Ruby 会議 2008 - 日本Ruby会議2008(RubyKaigi2008) 趣意書</title>

--- a/2008/LT.html
+++ b/2008/LT.html
@@ -6,8 +6,8 @@
 <head>
 
     <meta http-equiv="Content-Language" content="en">
-    <meta http-equiv="Content-Type" content="text/html; charset=EUC-JP">
-    <meta http-equiv="Content-Script-Type" content="text/javascript; charset=euc-jp">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Script-Type" content="text/javascript; charset=utf-8">
     <meta http-equiv="Content-Style-Type" content="text/css">
     <meta name="generator" content="Hiki 0.9dev">
     <title>日本 Ruby 会議 2008 - ライトニング・トークス</title>

--- a/2008/LT_en.html
+++ b/2008/LT_en.html
@@ -6,8 +6,8 @@
 <head>
 
     <meta http-equiv="Content-Language" content="en">
-    <meta http-equiv="Content-Type" content="text/html; charset=EUC-JP">
-    <meta http-equiv="Content-Script-Type" content="text/javascript; charset=euc-jp">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Script-Type" content="text/javascript; charset=utf-8">
     <meta http-equiv="Content-Style-Type" content="text/css">
     <meta name="generator" content="Hiki 0.9dev">
     <title>日本 Ruby 会議 2008 - LT_en</title>

--- a/2008/Live.html
+++ b/2008/Live.html
@@ -6,8 +6,8 @@
 <head>
 
     <meta http-equiv="Content-Language" content="en">
-    <meta http-equiv="Content-Type" content="text/html; charset=EUC-JP">
-    <meta http-equiv="Content-Script-Type" content="text/javascript; charset=euc-jp">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Script-Type" content="text/javascript; charset=utf-8">
     <meta http-equiv="Content-Style-Type" content="text/css">
     <meta name="generator" content="Hiki 0.9dev">
     <title>日本 Ruby 会議 2008 - Live</title>

--- a/2008/MainSession.html
+++ b/2008/MainSession.html
@@ -6,8 +6,8 @@
 <head>
 
     <meta http-equiv="Content-Language" content="en">
-    <meta http-equiv="Content-Type" content="text/html; charset=EUC-JP">
-    <meta http-equiv="Content-Script-Type" content="text/javascript; charset=euc-jp">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Script-Type" content="text/javascript; charset=utf-8">
     <meta http-equiv="Content-Style-Type" content="text/css">
     <meta name="generator" content="Hiki 0.9dev">
     <title>日本 Ruby 会議 2008 - メインセッション・プログラム</title>

--- a/2008/MainSession_en.html
+++ b/2008/MainSession_en.html
@@ -6,8 +6,8 @@
 <head>
 
     <meta http-equiv="Content-Language" content="en">
-    <meta http-equiv="Content-Type" content="text/html; charset=EUC-JP">
-    <meta http-equiv="Content-Script-Type" content="text/javascript; charset=euc-jp">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Script-Type" content="text/javascript; charset=utf-8">
     <meta http-equiv="Content-Style-Type" content="text/css">
     <meta name="generator" content="Hiki 0.9dev">
     <title>日本 Ruby 会議 2008 - MainSession_en</title>

--- a/2008/Party.html
+++ b/2008/Party.html
@@ -6,8 +6,8 @@
 <head>
 
     <meta http-equiv="Content-Language" content="en">
-    <meta http-equiv="Content-Type" content="text/html; charset=EUC-JP">
-    <meta http-equiv="Content-Script-Type" content="text/javascript; charset=euc-jp">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Script-Type" content="text/javascript; charset=utf-8">
     <meta http-equiv="Content-Style-Type" content="text/css">
     <meta name="generator" content="Hiki 0.9dev">
     <title>日本 Ruby 会議 2008 - Party</title>

--- a/2008/Party_en.html
+++ b/2008/Party_en.html
@@ -6,8 +6,8 @@
 <head>
 
     <meta http-equiv="Content-Language" content="en">
-    <meta http-equiv="Content-Type" content="text/html; charset=EUC-JP">
-    <meta http-equiv="Content-Script-Type" content="text/javascript; charset=euc-jp">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Script-Type" content="text/javascript; charset=utf-8">
     <meta http-equiv="Content-Style-Type" content="text/css">
     <meta name="generator" content="Hiki 0.9dev">
     <title>日本 Ruby 会議 2008 - Party_en</title>

--- a/2008/Program.html
+++ b/2008/Program.html
@@ -6,8 +6,8 @@
 <head>
 
     <meta http-equiv="Content-Language" content="en">
-    <meta http-equiv="Content-Type" content="text/html; charset=EUC-JP">
-    <meta http-equiv="Content-Script-Type" content="text/javascript; charset=euc-jp">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Script-Type" content="text/javascript; charset=utf-8">
     <meta http-equiv="Content-Style-Type" content="text/css">
     <meta name="generator" content="Hiki 0.9dev">
     <title>日本 Ruby 会議 2008 - プログラム(タイムテーブル)</title>

--- a/2008/Program_en.html
+++ b/2008/Program_en.html
@@ -6,8 +6,8 @@
 <head>
 
     <meta http-equiv="Content-Language" content="en">
-    <meta http-equiv="Content-Type" content="text/html; charset=EUC-JP">
-    <meta http-equiv="Content-Script-Type" content="text/javascript; charset=euc-jp">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Script-Type" content="text/javascript; charset=utf-8">
     <meta http-equiv="Content-Style-Type" content="text/css">
     <meta name="generator" content="Hiki 0.9dev">
     <title>日本 Ruby 会議 2008 - Program_en</title>

--- a/2008/RubyExam.html
+++ b/2008/RubyExam.html
@@ -6,8 +6,8 @@
 <head>
 
     <meta http-equiv="Content-Language" content="en">
-    <meta http-equiv="Content-Type" content="text/html; charset=EUC-JP">
-    <meta http-equiv="Content-Script-Type" content="text/javascript; charset=euc-jp">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Script-Type" content="text/javascript; charset=utf-8">
     <meta http-equiv="Content-Style-Type" content="text/css">
     <meta name="generator" content="Hiki 0.9dev">
     <title>日本 Ruby 会議 2008 - Ruby技術者認定試験</title>

--- a/2008/SideMenu.html
+++ b/2008/SideMenu.html
@@ -6,8 +6,8 @@
 <head>
 
     <meta http-equiv="Content-Language" content="en">
-    <meta http-equiv="Content-Type" content="text/html; charset=EUC-JP">
-    <meta http-equiv="Content-Script-Type" content="text/javascript; charset=euc-jp">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Script-Type" content="text/javascript; charset=utf-8">
     <meta http-equiv="Content-Style-Type" content="text/css">
     <meta name="generator" content="Hiki 0.9dev">
     <title>日本 Ruby 会議 2008 - SideMenu</title>

--- a/2008/Sponsors.html
+++ b/2008/Sponsors.html
@@ -6,8 +6,8 @@
 <head>
 
     <meta http-equiv="Content-Language" content="en">
-    <meta http-equiv="Content-Type" content="text/html; charset=EUC-JP">
-    <meta http-equiv="Content-Script-Type" content="text/javascript; charset=euc-jp">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Script-Type" content="text/javascript; charset=utf-8">
     <meta http-equiv="Content-Style-Type" content="text/css">
     <meta name="generator" content="Hiki 0.9dev">
     <title>日本 Ruby 会議 2008 - スポンサー</title>

--- a/2008/SubSession.html
+++ b/2008/SubSession.html
@@ -6,8 +6,8 @@
 <head>
 
     <meta http-equiv="Content-Language" content="en">
-    <meta http-equiv="Content-Type" content="text/html; charset=EUC-JP">
-    <meta http-equiv="Content-Script-Type" content="text/javascript; charset=euc-jp">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Script-Type" content="text/javascript; charset=utf-8">
     <meta http-equiv="Content-Style-Type" content="text/css">
     <meta name="generator" content="Hiki 0.9dev">
     <title>日本 Ruby 会議 2008 - サブセッション・プログラム</title>

--- a/2008/SubSession_en.html
+++ b/2008/SubSession_en.html
@@ -6,8 +6,8 @@
 <head>
 
     <meta http-equiv="Content-Language" content="en">
-    <meta http-equiv="Content-Type" content="text/html; charset=EUC-JP">
-    <meta http-equiv="Content-Script-Type" content="text/javascript; charset=euc-jp">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Script-Type" content="text/javascript; charset=utf-8">
     <meta http-equiv="Content-Style-Type" content="text/css">
     <meta name="generator" content="Hiki 0.9dev">
     <title>日本 Ruby 会議 2008 - SubSession_en</title>

--- a/2008/english.html
+++ b/2008/english.html
@@ -6,8 +6,8 @@
 <head>
 
     <meta http-equiv="Content-Language" content="en">
-    <meta http-equiv="Content-Type" content="text/html; charset=EUC-JP">
-    <meta http-equiv="Content-Script-Type" content="text/javascript; charset=euc-jp">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Script-Type" content="text/javascript; charset=utf-8">
     <meta http-equiv="Content-Style-Type" content="text/css">
     <meta name="generator" content="Hiki 0.9dev">
     <title>日本 Ruby 会議 2008 - RubyKaigi, June 20-22, Tsukuba, Japan</title>

--- a/2008/enquete.html
+++ b/2008/enquete.html
@@ -6,8 +6,8 @@
 <head>
 
     <meta http-equiv="Content-Language" content="en">
-    <meta http-equiv="Content-Type" content="text/html; charset=EUC-JP">
-    <meta http-equiv="Content-Script-Type" content="text/javascript; charset=euc-jp">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Script-Type" content="text/javascript; charset=utf-8">
     <meta http-equiv="Content-Style-Type" content="text/css">
     <meta name="generator" content="Hiki 0.9dev">
     <title>日本 Ruby 会議 2008 - アンケート</title>

--- a/2008/rss.xml
+++ b/2008/rss.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="EUC-JP" standalone="yes"?>
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <rdf:RDF xmlns="http://purl.org/rss/1.0/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:content="http://purl.org/rss/1.0/modules/content/" xml:lang="ja-JP">
   <channel rdf:about="/2008/recent">
     <title>日本 Ruby 会議 2008 : 更新日時順</title>


### PR DESCRIPTION
2008年のHTMLは `charset=EUC-JP"` と書いてありますが、UTF-8で書かれてそうなのでmetaタグを修正します。

```
❯ curl --verbose https://rubykaigi.org/2008/Program.html

> GET /2008/Program.html HTTP/2

< HTTP/2 200
< content-type: text/html; charset=utf-8

# snip

    <meta http-equiv="Content-Type" content="text/html; charset=EUC-JP">
    <meta http-equiv="Content-Script-Type" content="text/javascript; charset=euc-jp">
```