### PR TITLE
YAML files for past RubyKaigis

### DIFF
--- a/2015/data/presentations.yml
+++ b/2015/data/presentations.yml
@@ -1,0 +1,664 @@
+matz:
+  title: Keynote
+  type: keynote
+  language: JA
+  description: ''
+  speakers:
+    - id: matz
+  video:
+    youtube_id: E9bO1uqs4Oc
+
+evanphx:
+  title: Keynote
+  type: keynote
+  language: EN
+  description: ''
+  speakers:
+    - id: evanphx
+  video:
+    youtube_id: QaLvtNpoc5o
+
+kosaki:
+  title: Keynote
+  type: keynote
+  language: JA
+  description: ''
+  speakers:
+    - id: kosaki
+  video:
+    youtube_id: idmfWkP5lOw
+
+trick:
+  title: 'TRICK 2015: The second Transcendental Ruby Imbroglio Contest for RubyKaigi'
+  type: discussion
+  language: JA
+  description: "The result presentation of TRICK 2015, an esoteric Ruby programming contest, will take place.
+    You can (perhaps) enjoy some winning entries of unearthly Ruby code selected by esoteric judges."
+  speaker: "@mametter & the judges"
+  video:
+    youtube_id: dmHqtr_GNtg
+  materials:
+    - title: 'TRICK 2015: The second Transcendental Ruby Imbroglio Contest for RubyKaigi'
+      url: http://www.slideshare.net/mametter/trick2015-results
+
+lt:
+  title: Lightning Talks
+  type: lt
+  language: EN/JA
+  description: In Lightning Talks, JA -> EN interpreters won't be available.
+  speaker: LT speakers (JA -> EN interpreters won't be available)
+
+keiju:
+  title: Usage and implementation of Reish which is an Unix shell for Rubyist
+  type: presentation
+  language: JA
+  description: "Reish is an Unix shell for Rubyist. It was a language that was realized
+    Ruby in the syntax of the shell. I will introduce usage and implementation of Reish."
+  speakers:
+    - id: keiju
+  video:
+    youtube_id: xiAyp97ElA8
+
+ngoto:
+  title: Running Ruby on Solaris
+  type: presentation
+  language: JA
+  description: |
+    I'm using Fujitsu SPARC Enterprise server whose OS is Oracle (former Sun) Solaris 10. In Solaris, there is a number of minor differences from other major OS like Linux and Mac OS X, and a number of changes have been made to run Ruby (CRuby) without failure. I'd like to talk about these changes as a user of the Solaris OS.
+
+    The following topics will be included in this presentation.
+
+    Tips to build Ruby and other free software on Solaris
+    Recent changes to Ruby (CRuby) needed for Solaris
+    Bugs potentially affected to all platforms but revealed by running on Solaris
+  speakers:
+    - id: ngoto
+  video:
+    youtube_id: LlcEduexIcU
+  materials:
+    - title: Running Ruby on Solaris
+      url: http://www.slideshare.net/ngotogenome/running-ruby-on-solaris-rubykaigi-2015-12dec2015-56073698
+
+tagomoris:
+  title: Data Analytics Service Company and Its Ruby Usage
+  type: presentation
+  language: JA
+  description: |
+    This talk describes the architecture of data analytics platform service of Treasure Data, what we use Ruby/JRuby for and what we don't use Ruby for. We will discuss the many reasons, not only for productivity and performance.
+
+    Data analytics platform architecture is very far from well-known web service architecture. There are huge scale queues, workers, schedulers and distributed processing clusters, besides well-known parts like web application servers written in RoR and RDBMSs.
+  speakers:
+    - id: tagomoris
+  video:
+    youtube_id: 6qrdqLlgTo8
+  materials:
+    - title: Data Analytics Service Company and Its Ruby Usage
+      url: http://www.slideshare.net/tagomoris/data-analytics-service-company-and-its-ruby-usage-56073823
+
+franckverrot:
+  title: Ruby and PostgreSQL, a love story
+  type: presentation
+  language: EN
+  description: |
+    <code>PostgreSQL</code> 9.1 introduced <code>Foreign Data Wrappers</code>, as an implementation of <code>SQL/MED</code> foreign tables, to provide transparent access to external data. Restricted to being written in <code>C</code>, writing <code>FDW</code>s can be a hard task.
+
+    In this talk we will learn just enough of <code>mruby</code>'s (the ISO-compliant version of <code>Ruby</code>) internals to understand how one can embed <code>mruby</code> in an external program (like <code>PostgreSQL</code>), and start writing <code>Foreign Data Wrappers</code> in <code>Ruby</code>.
+  speakers:
+    - id: franckverrot
+  video:
+    youtube_id: bchlcxAZ9tU
+
+lrz:
+  title: The future of Ruby is in motion!
+  type: presentation
+  language: EN
+  description: "In this presentation we will give a quick and gentle introduction
+    to RubyMotion, a Ruby toolchain to write cross-platform apps for iOS and Android.
+  Then, we will cover 3 of its latest features: Apple Watch, Apple TV and a cross-platform
+    game engine. We will do live demos and coding."
+  speakers:
+    - id: lrz
+  video:
+    youtube_id: uzUmUmEX-Ls
+
+nirvdrum:
+  title: Fast Metaprogramming with Truffle
+  type: presentation
+  language: EN
+  description: |
+    "Metaprogramming is a powerful technique that sets Ruby apart from other contemporary languages. It allows compact and elegant solutions to seemingly intractable problems. Serving as the foundation of some of the mostly widely used frameworks and DSLs in the Ruby ecosystem, it’s arguably the single most defining feature of Ruby. Unfortunately, that expressive power has traditionally come at the expense of performance.
+
+    We’ll show you how JRuby+Truffle has eliminated the cost of metaprogramming so Rubyists can write idiomatic Ruby without having to worry about hidden performance trade-offs."
+  speakers:
+    - id: nirvdrum
+  video:
+    youtube_id: lRMWwjqbXUo
+
+ko1:
+  title: Compiling Ruby scripts
+  type: presentation
+  language: JA
+  description: Ruby (MRI) 2.2 compiles Ruby scripts into bytecode (instruction sequences)
+    at run time. This approach is simple, but has several problems such as overhead
+    of compile time. We are working on making an Ahead of Time compiler which compiles
+    Ruby script before executing the script. This compiler will help to reduce boot
+    time and to reduce memory consumption on multiple Ruby processes. In this presentation,
+    we will introduce the compiler and that mechanism.
+  speakers:
+    - id: ko1
+  video:
+    youtube_id: sFfwQ1-PFt0
+
+hone02_zzak:
+  title: Building CLI Apps for Everyone
+  type: presentation
+  language: EN
+  description: |
+    Many projects rely on command-line tools to provide an efficient and powerful interface to work.
+
+    Building tools for everyone can be difficult, because of conflicting environment or OS.
+
+    How can we build command-line apps that work for everyone and still write Ruby?
+
+    This talk will discuss how to use mruby-cli to build cross-platform apps in Ruby.
+
+    Our goal will be to build a CLI app using mruby and produce a self-contained binary that can be shipped to end users.
+
+    Since mruby is designed to be embedded and statically compiled, it's also really good at packaging ruby code.
+  speakers:
+    - id: hone02
+    - id: zzak
+  video:
+    youtube_id: EhEWn5Uudow
+  materials:
+    - title: Building CLI Apps for Everyone
+      url: https://speakerdeck.com/zzak/rubykaigi2015-building-cli-apps-for-everyone
+
+nusco:
+  title: Refinements - the Worst Feature You Ever Loved
+  type: presentation
+  language: EN
+  description: |
+    Refinements are cool. They are the biggest new language feature in Ruby 2. They help you avoid some of Ruby's most dangerous pitfalls. They make your code cleaner and safer.
+
+    Oh, and some people really hate them.
+
+    Are Refinements the best idea since blocks and modules, or a terrible mistake? Decide for yourself. I'll tell you the good, the bad and the ugly about refinements. At the end of this speech, you'll understand the trade-offs of this controversial feature, and know what all the fuss is about.
+  speakers:
+    - id: nusco
+  video:
+    youtube_id: _gLgE3c5jTU
+
+kazeburo:
+  title: Rhebok, High Performance Rack Handler
+  type: presentation
+  language: JA
+  description: |
+    Rhebok is High Performance Rack Handler/Web Server. 2x performance when compared against Unicorn.
+
+    In this presentation, I'll introduce the Rack interface spec, the architecture of widely used rack servers, and technology that supports performance of Rhebok includes prefork_engine, picohttpparser, system calls.
+  speakers:
+    - id: kazeburo
+  video:
+    youtube_id: EPxWD_2Yekg
+  materials:
+    - title: Rhebok, High Performance Rack Handler
+      url: http://www.slideshare.net/kazeburo/rhebok-high-performance-rack-handker-rubykaigi-2015
+
+juliancheal:
+  title: Charming Robots
+  type: presentation
+  language: EN
+  description: "Web apps are great and everything, but imagine using Ruby to fly drones
+    and make them dance to the sounds of dubstep! Or to control disco lights and other
+    robots! Sounds fun, right? In this talk, we will not only explore how we can write
+    code to make this possible, but it will also be full of exciting, interactive
+    (and possibly dangerous ;) ) demos!"
+  speakers:
+    - id: juliancheal
+  video:
+    youtube_id: t2NoXELaF0E
+
+hsbt:
+  title: Pragmatic Testing of Ruby Core
+  type: presentation
+  language: JA
+  description: |
+    When you need to understand a new library or framework, you might try to invoke the test suite with "rake test" or "rake spec". CRuby also has a test suite like many libraries and frameworks, written in Ruby. But, It's different from typical ruby libraries. Therefore many Rubyists don't know how to run the CRuby test suite.
+    This is because CRuby's test suite has historical and complex structures. In this talk, I explain the details of the CRuby test suite and protips for CRuby's testing technology.
+  speakers:
+    - id: hsbt
+  video:
+    youtube_id: Tgtprqw8_IQ
+  materials:
+    - title: Pragmatic Testing of Ruby Core
+      url: http://www.slideshare.net/hsbt/practical-testing-of-ruby-core
+
+estolfo:
+  title: DIY (Do-it-Yourself) Testing
+  type: presentation
+  language: EN
+  description: |
+    There are so many testing frameworks available to us that we sometimes overlook a completely valid, and sometimes preferable option: writing our own.
+
+    The drivers team at MongoDB focused over the last year on conforming to common APIs and algorithms but we needed a way to validate our consistency. We therefore ended up building our own testing DSL, REST service, and individual test frameworks.
+
+    Using these common tests and the Ruby driver's test suite as examples, this talk will demonstrate when existing test frameworks aren't the best choice and show how you can build your own.
+  speakers:
+    - id: estolfo
+  video:
+    youtube_id: MrfdHpz0-AQ
+
+leinweber:
+  title: Introducing the Crystal Programming Language
+  type: presentation
+  language: EN
+  description: |
+    Developer happiness is what brought me to Ruby in the first place. And of all the new compiled languages, Crystal is the only one that shares this value. The syntax and idioms are entirely Ruby inspired.
+
+    Although Crystal looks very similar to Ruby, there are big differences between the two. Crystal is statically typed and dispatched. While there are no runtime dynamic features, the compile-time macros solve many of the same problems.
+
+    In this session, we’ll take a close look at these differences as well as the similarities, and what Ruby developers can learn from this exciting language.
+  speakers:
+    - id: leinweber
+  video:
+    youtube_id: 7dwDzlVI7OU
+
+toch:
+  title: Prepare yourself against Zombie epidemic
+  type: presentation
+  language: EN
+  description: |
+    The news is everywhere: some weird disease makes the dead walking. We do not know yet if it is highly contagious. What should we do? What we do everyday: writing code.
+
+    This couldn't be a better moment to use an agent based model — a technique that simulates interactions between agents in a environment to understand their effects as a whole. For such, we'll visit its minimal Ruby implementation, address some common design, simulate the Zombie epidemic, visualize it, and test different survival strategies to hopefully find the best one.
+
+    We can code, we'll be prepared ... or not.
+  speakers:
+    - id: toch
+  video:
+    youtube_id: erx00WTzvcY
+
+seki:
+  title: Actor, Thread and me
+  type: presentation
+  language: JA
+  description_ja: |
+    Everybody says. Actor helps to solve the multithreading problem. Actor is awesome. Threads are 💩
+
+    Really?
+
+    An actor model is "just a model", just like MVC.
+
+    Today, Recap what Actor Model is.
+  speakers:
+    - id: seki
+  video:
+    youtube_id: EdB-s2GX-68
+  materials:
+    - title: Actor, Thread and me
+      url: https://speakerdeck.com/m_seki/actor-thread-and-me-rubykaigi2015
+
+eagletmt_k0kubun:
+  title: 'High Performance Template Engine: Guide to optimize your Ruby code'
+  type: presentation
+  language: JA
+  description: |
+    Have you ever thought about performance of your Ruby code? If not, you might write ineffective code and slow down your application. Poor performance disappoints the users of your app causing you to lose their confidence.
+
+    In this talk, we show the process of creating faster Haml implementations: Faml and Hamlit. You will see how to improve the performance of your code.
+    We will show you the typical structure of template engines first, so experience with them is not required. After this talk, you'll be able to optimize your application using the techniques we will show you.
+  speakers:
+    - id: eagletmt
+    - id: k0kubun
+  video:
+    youtube_id: vM9XfqlqyNw
+  materials:
+    - title: 'High Performance Template Engine: Guide to optimize your Ruby code'
+      url: https://speakerdeck.com/k0kubun/high-performance-template-engine
+
+yurie:
+  title: making robot with mruby
+  type: presentation
+  language: JA
+  description: |
+    Linuxの入っているハードウェアをあえてLinuxを使わないでTOPPERS EV3RT というRTOS を入れたり、bare metal の状態にしてmrubyを動かします。
+    今回の対象はLEGO Mindstorms EV3とraspberry pi。
+    Cに比べて遅いのでハードウェア制御には向かないのでは？と言われがちなmrubyを使って倒立振子の制御をします。
+  speakers:
+    - id: yurie
+  video:
+    youtube_id: u7WCIN5HMDI
+  materials:
+    - title: making robot with mruby
+      url: http://www.slideshare.net/yamanekko/rubykaigi2015-making-robotswithmruby
+
+shotantan:
+  title: mruby on the minimal embedded resource
+  type: presentation
+  language: JA
+  description: |
+    Introducing how mruby comes to term with the embedded board's poor resource.
+    I suggest a solution that they can mount an external NOR Flash chip as RAM cache.
+    Although mruby is a minimal implementation of Ruby, it requires huge RAM as is Embed field. A lot of embedded board has poor RAM less than 128KB, except for rich embedded board, like Raspberry Pi.
+    An external NOR Flash as mruby RAM cache is cheap solution. Typically, NOR Flash's writing frequency is limited, 100 thousand times. I also introduce performance measurement to reduce mruby RAM writting.
+  speakers:
+    - id: shotantan
+  video:
+    youtube_id: EXvDKb2LTYM
+
+youchan:
+  title: Writing web application in Ruby
+  type: presentation
+  language: JA
+  description: |
+    Does this happen to you?
+    You were developing web application with Ruby on Rails, but somehow you ended up writing front-end in JavaScript.
+    Ruby on Rails seemed very cool to me! And Rubyists are always happy to build applications with it!
+    However, front-end development is becoming important today.
+    Then I found Opal, and my dream of writing Ruby on the front-end is possible!
+    Recently, React.js, a kind of Virtual DOM, has become very popular in the front-end community.
+    It's not only intended for front-end web, there is also ReactNative for other platforms too.
+    I think many Rubyists are still lost, so I created a Virtual DOM implementation in Ruby called Hyalite.
+    All right, Opal, Hyalite ... tools have been gathered. Let's build web applications on server-side and front-end with Ruby!
+  speakers:
+    - id: youchan
+  video:
+    youtube_id: xEK1hg8noSc
+
+kou:
+  title: The history of testing framework in Ruby
+  type: presentation
+  language: JA
+  description: |
+    This talk describes about the history of testing framework in Ruby.
+
+    Ruby 2.2 bundles two testing frameworks. They are minitest and test-unit. Do you know why two testing frameworks are bundled? Do you know that test-unit was bundled and then removed from Ruby distribution? If you can't answer these questions and you're interested in testing framework, this talk will help you.
+
+    This talk describes about the history of bundled testing framework in Ruby and some major testing frameworks for Ruby in chronological order.
+  speakers:
+    - id: kou
+  video:
+    youtube_id: g33d9SSbvd8
+
+emorima:
+  title: Discussion on Thread between version 1.8.6 and 2.2.3
+  type: presentation
+  language: JA
+  description: |
+    Thread in Ruby 1.8.6 often got stuck and I had to implement my own Thread monitoring framework. How is it improved in the latest release, Ruby 2.2.3? Now can we use an implementation that I couldn't use with 1.8.6 because of the broken Thread?
+  description_ja: |
+    Ruby1.8.6 のThreadはよく刺さり、自前でのThread監視機能を作成を余儀なくされた。では、最新のRuby2.2.3ではどうだろうか？
+    またRuby1.8.6では、Threadが高確率で刺さるために回避せざるを得なかった、あの実装方法は、Ruby2.2.3では使えるのだろうか？
+  speakers:
+    - id: emorima
+  video:
+    youtube_id: 9C98Eyr9jOY
+
+joshk:
+  title: 'Beyond Saas: Building for Enterprise'
+  type: presentation
+  language: EN
+  description: |
+    Travis CI found itself growing a great SaaS product, when Enterprise users began unexpectedly asking to use our product on-premise. Our small team had to quickly understand:
+
+    The maintenance implications for different ways to package our app.
+    How to provide enterprise customers great support, despite the new constraints.
+    How to prioritize Enterprise-specific features.
+
+    This talk is the story of how we added an Enterprise offering to our existing hosted Continuous Integration service, the bumps we hit along the way, and what we would do differently now.
+  speakers:
+    - id: joshk
+  video:
+    youtube_id: gVm7dd2G7CQ
+
+prodis:
+  title: The worst Ruby codes I've seen in my life
+  type: presentation
+  language: EN
+  description: |
+    Most applications written in Ruby are great, but also exists evil code applying WOP techniques. There are many workarounds in several programming languages, but in Ruby, when it happens, the proportion is bigger. It's very easy to write Ruby code with collateral damage.
+
+    You will see a collection of bad Ruby codes, with a description of how these codes affected negatively their applications and the solutions to fix and avoid them. Long classes, coupling, misapplication of OO, illegible code, tangled flows, naming issues and other things you can ever imagine are examples what you'll get.
+  speakers:
+    - id: prodis
+  video:
+    youtube_id: jLAFXQ1Av50
+  materials:
+    - title: The worst Ruby codes I've seen in my life
+      url: http://www.slideshare.net/Prodis/the-worst-ruby-codes-ive-seen-in-my-life-rubykaigi-2015
+
+tenderlove:
+  title: Request and Response
+  type: presentation
+  language: JA
+  description: |
+    What goes in to a request and response in a Rails application?  Where does the
+    application get its data, and how does that data get to the client when you are
+    done?  In this talk we'll look at the request and response lifecycle in Rails.
+    We'll start with how a request and response are serviced today, then move on
+    to more exciting topics like adding HTTP2 support and what that means for
+    developing Rails applications.
+  speakers:
+    - id: tenderlove
+  video:
+    youtube_id: 0cmXVXMdbs8
+
+yuki24:
+  title: Saving people from typos
+  type: presentation
+  language: JA
+  description: |
+    Whenever you make a typo on Google or a <code>git …</code> cmd, they’ll automagically correct it for you. It’s great, but have you ever wondered why programming languages don’t have such a cool feature? The next major version of Ruby will! The <code>did_you_mean</code> gem was built to add on a “Did you mean?” experience and Ruby 2.3 will ship with it.
+
+    So what does the whole story look like? How can you use it in your app or gem? How does it correct typos? What even is a typo?
+
+    Let's learn how to take advantage of this new feature in Ruby 2.3 and save ourselves from typos forever!
+  speakers:
+    - id: yuki24
+  video:
+    youtube_id: b9621w7_vxc
+
+yhara:
+  title: Let's make a functional language!
+  type: presentation
+  language: JA
+  description: Recently, functional programming with type inference has become popular, let's try to make it! But what if you don't know where to start...? For such a Rubyist, this talk will explain from basics of language implementation to the Hindley-Milner type inference. We can make a functional language!
+  speakers:
+    - id: yhara
+  video:
+    youtube_id: NNsX92hKirM
+  materials:
+    - title: Let's make a functional language!
+      url: https://speakerdeck.com/yhara/lets-make-a-functional-language
+
+youngrw_CraigLehmann:
+  title: It's dangerous to GC alone. Take this!
+  type: presentation
+  language: EN
+  description: |
+    Every language community implements the same core components. Things like garbage collection, just-in-time compilation and threading. Wouldn't it be great if these were shared between languages? An improvement to one language would mean an improvement to all.
+
+    We’re actually doing it: open sourcing the core components of IBM’s Java Virtual Machine into an open language toolkit. Our first proof of concept language is Ruby. This talk will discuss the process and results of integrating a new garbage collector into Ruby.
+  speakers:
+    - id: youngrw
+    - id: CraigLehmann
+  video:
+    youtube_id: nhqNaZxHbHY
+  materials:
+    - title: It's dangerous to GC alone. Take this!
+      url: http://www.slideshare.net/craiglehmann/the-omr-gc-talk-ruby-kaigi-2015
+
+ohai:
+  title: Ruby for one day game programming camp for beginners
+  type: presentation
+  language: JA
+  description: |
+    KMC, Kyoto university Microcomputer Club, a computer circle in Kyoto University, holds one day game programming camp for newcomers (undergraduate students interested in KMC and programming) in April and May to invite an enjoyable programming world.
+
+    As you know, Ruby is one of the best languages to learn programming itself and used in the camp to build a simple game within one day. This talk provides experiences and messages coming from the events, and explains the history of frameworks used in the event.  This talk give you a hint to educate beginners.
+  speakers:
+    - id: ohai
+  video:
+    youtube_id: bvXYCpcOQ3E
+
+MattStudies:
+  title: Experiments in sharing Java VM technology with CRuby
+  type: presentation
+  language: EN
+  description: |
+    What happens you have a virtual machine full of powerful technology and you start pulling out the language independent parts, with plans to open source these technologies?
+
+    You get the ability to experiment! This talk covers a set of experiments where IBM has tested out language-agnostic runtime technologies inside of CRuby, including a GC, JIT and more-- all while still running real Ruby applications, including Rails.
+
+    We want to share results from these experiments, talk about how we connected to CRuby, and discuss how this may one day become a part of everyone's CRuby.
+  speakers:
+    - id: MattStudies
+  video:
+    youtube_id: EDxoaEdR-_M
+  materials:
+    - title: Experiments in Sharing Java VM Technology with CRuby
+      url: http://www.slideshare.net/MatthewGaudet/experiments-in-sharing-java-vm-technology-with-cruby
+
+matsumotory:
+  title: The future of mruby in HTTP Server
+  type: presentation
+  language: JA
+  description: "As the HTTP/2 RFC was published, implementations of HTTP/2 have been
+    actively developed. In this session, from the standpoint of an author of an extension
+    mechanism using mruby for typical HTTP/1.x and HTTP/2 servers like apache, nginx
+    and H2O, I show the possibility of design using mruby in HTTP server with new
+    special features of HTTP/2 like server push.  I explain how to design the complex
+    web service system using both HTTP/1.x and HTTP/2 servers based on the need for
+    HTTP/2 considering the changes in the architecture of Web service systems."
+  speakers:
+    - id: matsumotory
+
+frsyuki:
+  title: Plugin-based software design with Ruby and RubyGems
+  type: presentation
+  language: EN
+  description: |
+    Plugin architecture is known as a technique that brings extensibility to a program. Ruby has good language features for plugins. RubyGems.org is an excellent platform for plugin distribution. However, creating plugin architecture is not as easy as writing code without it: plugin loader, packaging, loosely-coupled API, and performance. Loading two versions of a gem is a unsolved challenge that is solved in Java on the other hand.
+      I have designed some open-source software such as Fluentd and Embulk. They provide most of functions by plugins. I will talk about their plugin-based architecture.
+  speakers:
+    - id: frsyuki
+  video:
+    youtube_id: C6SP3CzCb5k
+
+wycats_chancancode:
+  title: Turbo Rails with Rust
+  type: presentation
+  language: EN
+  description: |
+    Ruby is not the fastest language in the world, there is no doubt about it. This doesn't turn out to matter all that much – Ruby and its ecosystem has so much more to offer, making it a worthwhile tradeoff a lot of the times.
+
+    However, you might occasionally encounter workloads that are simply not suitable for Ruby. In this talk, we will explore building a native extension with Rust to speed up parts of Rails. (No prior experience with Rust required!) What does Rust has to offer in this scenario over plain-old C? Let's find out!
+  speakers:
+    - id: wycats
+    - id: chancancode
+  video:
+    youtube_id: uiNpoDB4dA0
+
+mmasaki:
+  title: Ruby meets Go
+  type: presentation
+  language: JA
+  description: |
+    In this talk, I will present how to extend your Ruby code with Golang.
+    Since Go 1.5, you can build C compatible binaries by using buildmode c-shared/c-archive. This is a very exciting feature for rubyists.
+    First, I'd like to show you how to use Go code from Ruby with FFI and fiddle.
+    Then, I will talk about how to build gems with Golang.
+  speakers:
+    - id: mmasaki
+  video:
+    youtube_id: xIVrUWmmass
+  materials:
+    - title: Ruby meets Go
+      url: http://www.slideshare.net/td-nttcom/ruby-meets-go
+
+SoManyHs:
+  title: 'Time flies like an arrow; Fruit flies like a banana: Parsers for Great Good'
+  type: presentation
+  language: EN
+  description: |
+    When you type <code>print "Hello, world!"</code>, how does your computer
+    know what to do? Humans are able to naturally parse spoken language by
+    analyzing the role and meaning of each word in context of its
+    sentence, but we usually take for granted the way computers make sense
+    of the code we write.
+
+    By exploring the way our brains construct grammars to parse sentences,
+    we can better understand how parsers are used for computering --
+    whether it be in the way Ruby and other languages are implemented or
+    in webserver routing -- and recognize when they may be the right tool
+    to use in our own code.
+  speakers:
+    - id: SoManyHs
+  video:
+    youtube_id: a_mJIR0Rk9U
+  materials:
+    - title: 'Time flies like an arrow; Fruit flies like a banana: Parsers for Great Good'
+      url: https://speakerdeck.com/somanyhs/time-flies-like-an-arrow-fruit-flies-like-a-banana-parsers-for-great-good-1
+
+headius_enebo:
+  title: Upcoming Improvements to JRuby 9000
+  type: presentation
+  language: EN
+  description: "JRuby 9000 is here! After years of work, JRuby now supports Ruby 2.2
+    and ships with a redesigned optimizing runtime. The first update release improved
+    performance and compatibility, and we've only just begun. In this talk we'll
+    show you where we stand today and cover upcoming work that will keep JRuby moving
+  forward: profiling, inlining, unboxing...oh my!"
+  speakers:
+    - id: headius
+    - id: enebo
+  video:
+    youtube_id: QAqjtdExtJw
+
+committers:
+  title: Ruby Committers vs the World
+  type: discussion
+  language: JA
+  description: TBA
+  speaker: Ruby committers
+  video:
+    youtube_id: LcXKSHsniTY
+
+lightning_talks:
+
+  - JuanitoFatas:
+    language: EN
+    title: Update Early, Update Often
+
+  - meriy100:
+    language: EN
+    title: Automating View Internationalization in Ruby on Rails
+
+  - _ksss_:
+    language: JA
+    title: A new testing framework Rgot
+
+  - a_turl:
+    title: Building an Unbreakable MRI-based Embedded Computer Appliance
+
+  - zunda:
+    title: Do you trust that certificate?
+
+  - k0kubun:
+    title: How I debugged debugger
+
+  - namusyaka:
+    title: Padrino Travel Guide
+
+  - johnlinvc:
+    title: What I learned by implementing a Ruby VM in Erlang
+
+  - joker1007:
+    title: Rubygemsで作るお手軽データ分析基盤 〜あるいは 私はどうやって他人の褌で相撲を取ったか〜
+
+  - _tad_:
+    title: Rationalを最適化してみた
+
+  - Althaire:
+    title: The Mythical Creatures of Summer of Code

--- a/2015/data/schedule.yml
+++ b/2015/data/schedule.yml
@@ -1,0 +1,214 @@
+dec11:
+  events:
+  - type: break
+    begin: '09:30'
+    end: ''
+    name: 'Door open'
+
+  - type: break
+    begin: '10:30'
+    end: '10:55'
+    name: 'Opening & Ruby 2.3 Preview Release'
+
+  - type: talk
+    begin: '11:00'
+    end: '12:00'
+    talks:
+      hall_a: matz
+
+  - type: break
+    begin: '12:00'
+    end: '13:30'
+    name: Lunch on your own
+
+  - type: talk
+    begin: '13:30'
+    end: '14:05'
+    talks:
+      hall_a: ko1
+
+  - type: talk
+    begin: '14:10'
+    end: '14:45'
+    talks:
+      hall_a: MattStudies
+      hall_b: yuki24
+
+  - type: talk
+    begin: '14:50'
+    end: '15:25'
+    talks:
+      hall_a: shotantan
+      hall_b: SoManyHs
+
+  - type: break
+    begin: '15:30'
+    end: '16:00'
+    name: Afternoon Break
+
+  - type: talk
+    begin: '16:00'
+    end: '16:35'
+    talks:
+      hall_a: nirvdrum
+      hall_b: estolfo
+
+  - type: talk
+    begin: '16:40'
+    end: '17:15'
+    talks:
+      hall_a: eagletmt_k0kubun
+      hall_b: leinweber
+
+  - type: talk
+    begin: '17:20'
+    end: '18:20'
+    talks:
+      hall_a: trick
+
+
+dec12:
+  events:
+  - type: talk
+    begin: '9:40'
+    end: '10:35'
+    talks:
+      hall_a: kosaki
+
+  - type: talk
+    begin: '10:40'
+    end: '11:15'
+    talks:
+      hall_a: kou
+      hall_b: juliancheal
+
+  - type: talk
+    begin: '11:20'
+    end: '11:55'
+    talks:
+      hall_a: wycats_chancancode
+      hall_b: ngoto
+
+  - type: break
+    begin: '12:00'
+    end: '13:30'
+    name: Lunch on your own
+
+  - type: talk
+    begin: '13:30'
+    end: '14:05'
+    talks:
+      hall_a: tagomoris
+      hall_b: prodis
+
+  - type: talk
+    begin: '14:10'
+    end: '14:45'
+    talks:
+      hall_a: lrz
+      hall_b: ohai
+
+  - type: talk
+    begin: '14:50'
+    end: '15:25'
+    talks:
+      hall_a: mmasaki
+      hall_b: franckverrot
+
+  - type: break
+    begin: '15:30'
+    end: '16:00'
+    name: Afternoon Break
+
+  - type: talk
+    begin: '16:00'
+    end: '16:35'
+    talks:
+      hall_a: hone02_zzak
+      hall_b: kazeburo
+
+  - type: talk
+    begin: '16:40'
+    end: '17:15'
+    talks:
+      hall_a: yurie
+      hall_b: hsbt
+
+  - type: talk
+    begin: '17:20'
+    end: '18:20'
+    talks:
+      hall_a: lt
+
+
+dec13:
+  events:
+  - type: talk
+    begin: '10:20'
+    end: '11:15'
+    talks:
+      hall_a: committers
+
+  - type: talk
+    begin: '11:20'
+    end: '11:55'
+    talks:
+      hall_a: youngrw_CraigLehmann
+      hall_b: youchan
+
+  - type: break
+    begin: '12:00'
+    end: '13:30'
+    name: Lunch on your own
+
+
+  - type: talk
+    begin: '13:30'
+    end: '14:05'
+    talks:
+      hall_a: keiju
+      hall_b: nusco
+
+  - type: talk
+    begin: '14:10'
+    end: '14:45'
+    talks:
+      hall_a: headius_enebo
+      hall_b: emorima
+
+  - type: talk
+    begin: '14:50'
+    end: '15:25'
+    talks:
+      hall_a: frsyuki
+      hall_b: toch
+
+  - type: break
+    begin: '15:30'
+    end: '16:00'
+    name: Afternoon Break
+
+  - type: talk
+    begin: '16:00'
+    end: '16:35'
+    talks:
+      hall_a: tenderlove
+      hall_b: yhara
+
+  - type: talk
+    begin: '16:40'
+    end: '17:15'
+    talks:
+      hall_a: seki
+      hall_b: joshk
+
+  - type: talk
+    begin: '17:20'
+    end: '18:20'
+    talks:
+      hall_a: evanphx
+
+  - type: break
+    begin: '18:20'
+    end: '18:40'
+    name: Closing

--- a/2015/data/speakers.yml
+++ b/2015/data/speakers.yml
@@ -1,0 +1,481 @@
+keynotes:
+  matz:
+    id: yukihiro_matz
+    name: 'Yukihiro "Matz" Matsumoto'
+    bio: |
+      Creator of Ruby
+    github_id: matz
+    twitter_id: yukihiro_matz
+    avatar_url: https://www.gravatar.com/avatar/0ec4920185b657a03edf01fff96b4e9b?s=220
+  kosaki:
+    id: kosaki
+    name: KOSAKI Motohiro
+    bio: |
+      KOSAKI Motohiro is on the Ruby core team and Linux memory management
+      core developer.
+
+      He is known as Ruby GVL(Giant VM Lock) author. KOSAKI is currently
+      working at Red Hat for Fujitsu to improve Linux kernel.
+    github_id: kosaki
+    twitter_id:
+    avatar_url: https://www.gravatar.com/avatar/02da662c083396641da96c1d32fc86ed?s=220
+  evanphx:
+    id: evanphx
+    name: Evan Phoenix
+    bio: |
+      Evan is a Director of Ruby Central. He’s worked on many Ruby projects over the years, such as Rubinius, Puma, and benchmark-ips.
+    github_id: evanphx
+    twitter_id: evanphx
+    avatar_url: https://www.gravatar.com/avatar/6f4ffc0ee2525e1a9b1127c1b84e579d?s=220
+speakers:
+  tenderlove:
+    id: tenderlove
+    name: Aaron Patterson
+    bio: |
+      Aaron is on the Ruby core team, the Rails core team, and the team that takes care of his cat, Gorby puff.   Someday he will find the perfect safety gear to wear while extreme programming.
+    github_id:
+    twitter_id: tenderlove
+    avatar_url: https://www.gravatar.com/avatar/f29327647a9cff5c69618bae420792ea?s=220
+  headius:
+    id: headius
+    name: Charles Nutter
+    bio: |
+      Charles works on JVM languages at Red Hat.
+    github_id: headius
+    twitter_id: headius
+    avatar_url: https://www.gravatar.com/avatar/f1d37642fdaa1662ff46e4c65731e9ab?s=220
+  toch:
+    id: _toch
+    name: Christophe Philemotte
+    bio: |
+      Christophe is the founder of PullReview, an automated code review for Ruby and Rails developers. He is a Ruby and C++ developer. When he's not writing code disease simulators or PullReview, Christophe helps others with development challenges, writes at the PullReview blog, (co)organises several Belgian Ruby events (Belgian Ruby User Group, Ruby Burgers, Rails Girls Brussels, Ruby Devroom Fosdem, RubyCamp), and likes to talk at conferences and user groups.
+    github_id: toch
+    twitter_id: _toch
+    avatar_url: https://www.gravatar.com/avatar/3f8fcddf7ab5d1bd90b0a0a9adfd6527?s=220
+  CraigLehmann:
+    id: CraigLehmann
+    name: Craig Lehmann
+    bio: |
+      Craig Lehmann is a virtual machine software developer based out of Ottawa Ontario. He graduated from the University of Guelph in the spring of 2014 with a B.Comp and B.Eng. He started work immediately after graduation as part of a small team replacing the garbage collector in the Ruby virtual machine. His main focus since then has been on increasing performance and getting the project ready for open source.
+    github_id:
+    twitter_id: CraigLehmann
+    avatar_url: https://www.gravatar.com/avatar/22717b8de7488343644f593974f5683c?s=220
+  estolfo:
+    id: estolfo
+    name: Emily Stolfo
+    bio: |
+      Emily is a software engineer at MongoDB where she co-maintains the Ruby driver and the Mongoid ODM. She is an adjunct faculty member of Columbia University and is currently based in Berlin.
+    github_id: estolfo
+    twitter_id:
+    avatar_url: https://www.gravatar.com/avatar/36a412f9961180973697973cc7b30a52?s=220
+  prodis:
+    id: Prodis
+    name: Fernando Hamasaki de Amorim
+    bio: |
+      I am a Ruby Developer, currently developing SaaS applications at Locaweb, a hosting company in Brazil. Working with web development since 2000, I already used another platforms and programming languages such .NET, Java, Javascript, PHP and ASP.
+      I spoke at RubyConf Brazil this year and 2001 and I have presented lectures at Brazilian software conferences.
+      In my free time I enjoy playing basketball, play with my 5 old years son and have fun with my beautiful wife.
+    github_id: prodis
+    twitter_id: Prodis
+    avatar_url: https://www.gravatar.com/avatar/5996ec6efc2f04ae9b4dd72960e817a3?s=220
+  franckverrot:
+    id: franckverrot
+    name: Franck Verrot
+    bio: |
+      Franck is a software engineer. He specializes in Ruby and JavaScript, with a focus on performance.
+    github_id:
+    twitter_id: franckverrot
+    avatar_url: https://www.gravatar.com/avatar/0256f4863b3a08d20a382766f842e63c?s=220
+  chancancode:
+    id: chancancode
+    name: Godfrey Chan
+    bio: |
+      Godfrey Chan is a member of the Rails core team and a contributor to various open-source projects. He works at Tilde Inc, splitting his time between building Skylight and open-source consulting. In his previous life, he was also an award-winning WordPress™ plugin author.
+    github_id: chancancode
+    twitter_id: chancancode
+    avatar_url: https://www.gravatar.com/avatar/22bb3e56828870ee9a0dd93aeadbe04a?s=220
+  SoManyHs:
+    id: SoManyHs
+    name: Hsing-Hui Hsu
+    bio: |
+      Hsing-Hui Hsu is a graduate of the first cohort of Ada Developers
+      Academy. She enjoys learning languages (both computer and human),
+      playing ultimate frisbee, and rabbit-hole spelunking. Hsing-Hui
+      currently works as a full-stack developer at CareZone.
+    github_id: Elffers
+    twitter_id: SoManyHs
+    avatar_url: https://www.gravatar.com/avatar/3628a16b0829f76f84f94eb83970762c?s=220
+  ohai:
+    id: _ohai
+    name: Ippei Obayashi
+    bio: |
+      A member of KMC (Kyoto university Microcomputer Club).
+      An applied mathematician working in WPI-AIMR, Tohoku University
+      as an assistant professor.
+      A maintainer of rurema (RUby REference MAnual).
+      A developer of @Ruby/SDL, some numerical libraries for Ruby,
+      and a development tool for ruby with emacs(rrse).
+      A former member of Ruby Kansai.
+      https://github.com/ohai
+      https://bitbucket.org/ohai/
+    github_id: ohai
+    twitter_id: _ohai
+    avatar_url: https://www.gravatar.com/avatar/40e32c218bc954cdc22e9d7ceaede46a?s=220
+  joshk:
+    id: joshk
+    name: Josh Kalderimis
+    bio: |
+      Coder turned Post-It manager by day, craft beer and karaoke legend by night. Hailing from New Zealand, Josh has been with Travis CI since the beginning, when shite shirts and onsies were barely thought about. Now he helps place post-it notes on carefully crafted product roadmaps, while listening to the best German polka music available.
+    github_id: joshk
+    twitter_id:
+    avatar_url: https://www.gravatar.com/avatar/21b21efe14359ec323f9a70464b91e39?s=220
+  juliancheal:
+    id: juliancheal
+    name: Julian Cheal
+    bio: |
+      A British Ruby/Rails developer, with a penchant for tweed, fine coffee, and homebrewing. When not deploying enterprise clouds, I help organise fun events around the world that teach people to program flying robots. I also occasionally speak at international conferences on the intersection of programming and robotics.
+    github_id: juliancheal
+    twitter_id:
+    avatar_url: https://www.gravatar.com/avatar/ba5ce2541928927c1ea3ceeaf3a4d604?s=220
+  keiju:
+    id: keiju
+    name: Keiju Ishitsuka
+    bio: |
+      Ruby's godfather.
+    github_id: keiju
+    twitter_id:
+    avatar_url: https://www.gravatar.com/avatar/97f338629741aa42d6717bfba0c2830f?s=220
+  nirvdrum:
+    id: nirvdrum
+    name: Kevin Menard
+    bio: |
+      Kevin is a researcher at Oracle Labs where he works as part of a team developing a high performance Ruby implementation in conjunction with the JRuby team. He’s been involved with the Ruby community since 2008 and has been doing open source in some capacity since 1999. In his spare time he’s a father of two and enjoys playing drums.
+    github_id: nirvdrum
+    twitter_id: nirvdrum
+    avatar_url: https://www.gravatar.com/avatar/303aae3354beb438eaa44000b1f2f3fd?s=220
+  eagletmt:
+    id: eagletmt
+    name: Kohei Suzuki
+    bio: |
+      Author of Faml - Faster implementation of Haml template language.
+      Working for Cookpad Inc.
+      https://github.com/eagletmt/faml
+    github_id: eagletmt
+    twitter_id: eagletmt
+    avatar_url: https://www.gravatar.com/avatar/56e7384c63183f95690cb73ed28f6ec6?s=220
+  ko1:
+    id: ko1
+    name: Koichi Sasada
+    bio: |
+      Koichi Sasada is a programmer, mainly developing Ruby interpreter (CRuby/MRI). He received Ph.D (Information Science and Technology) from the University of Tokyo, 2007. He became a faculty of University of Tokyo (Assistant associate 2006-2008, Assistant professor 2008-2012). After the 13 years life in university, now, he is a member of Matz's team in Heroku, Inc. He is also a director of Ruby Association.
+    github_id: ko1
+    twitter_id:
+    avatar_url: https://www.gravatar.com/avatar/59d6310279ceb4b864b2330bb6873796?s=220
+  kou:
+    id: ktou
+    name: Kouhei Sutou
+    bio: |
+      He is a free software programmer and the president of ClearCode Inc. He is also the namer of ClearCode Inc. The origin of the company name is "clear code". We will be programmers that code clear code as our company name suggests. He is interested in how to tell other programmers about how he codes clear code.
+      He is the current maintainer of test-unit gem. This talk is based on his experience.
+    github_id: kou
+    twitter_id: ktou
+    avatar_url: https://www.gravatar.com/avatar/2d9386b1504e581be390af978e05a8b9?s=220
+  lrz:
+    id: lrz
+    name: Laurent Sansonetti
+    bio: |
+      Founder and CEO of HipByte. Creator and Lead Developer of RubyMotion.
+    github_id:
+    twitter_id: lrz
+    avatar_url: https://www.gravatar.com/avatar/935b9d1a50dd855aba577e69f4a59fdf?s=220
+  matsumotory:
+    id: matsumotory
+    name: MATSUMOTO, Ryosuke
+    bio: |
+      I'm a web operation and research engineer in GMO Pepabo, inc.
+    github_id: matsumoto-r
+    twitter_id: matsumotory
+    avatar_url: https://www.gravatar.com/avatar/2b692bd83f4418103142a053ecf5ff59?s=220
+  kazeburo:
+    id: kazeburo
+    name: Masahiro Nagano
+    bio: |
+      Principal Site Reliability Engineer at Mercari, Inc. Author of rhebok - High Performance Rack Handler/Web Server.
+    github_id: kazeburo
+    twitter_id: kazeburo
+    avatar_url: https://www.gravatar.com/avatar/700669515ee872152d8b9403c2a0cf8c?s=220
+  mmasaki:
+    id: _mmasaki
+    name: Masaki Matsushita
+    bio: |
+      Masaki is a software engineer at NTT Communications.
+      He is a CRuby commiter and he mainly works for performance improvement.
+    github_id: mmasaki
+    twitter_id: _mmasaki
+    avatar_url: https://www.gravatar.com/avatar/c042517d59bed4761cc88681bf71fca8?s=220
+  seki:
+    id: m_seki
+    name: Masatoshi SEKI
+    bio: |
+      Masatoshi Seki is a Ruby committer and the author of several Ruby standard libraries including dRuby, ERB, and Rinda. He’s an expert in object-oriented programming, distributed systems, and eXtreme programming. He has been speaking at RubyKaigi every year since 2006 when the Kaigi first started.
+    github_id: seki
+    twitter_id: m_seki
+    avatar_url: https://www.gravatar.com/avatar/40f4d1f2e77078955bd01e9fb4a503ba?s=220
+  MattStudies:
+    id: MattStudies
+    name: Matthew Gaudet
+    bio: |
+      JIT Developer for IBM, focused on Ruby.
+    github_id:
+    twitter_id: MattStudies
+    avatar_url: https://www.gravatar.com/avatar/da1b038f633613bb7e6c2a95a503e34b?s=220
+  emorima:
+    id: emorima
+    name: Mayumi EMORI
+    bio: |
+      Unit Manager of Development Department, KCS Carrot Corp.
+      I've been engaged in mission-critical system development.
+      Chief organaizer of Rails Girls Tokyo 3rd and 4th,
+      Member of Asakusarb and Rails Girls Japan.
+    github_id: emorima
+    twitter_id: emorima
+    avatar_url: https://www.gravatar.com/avatar/5c72a69ad460347a01aa05de9915c3e0?s=220
+  ngoto:
+    id: ngotogenome
+    name: Naohisa Goto
+    bio: |
+      A researcher of Bioinformatics. Assistant Professor in Research Institute for Microbial Diseases, Osaka University.
+    github_id: ngoto
+    twitter_id: ngotogenome
+    avatar_url: https://www.gravatar.com/avatar/205ca9566e14fb669ed977cae5af88e0?s=220
+  nusco:
+    id: nusco
+    name: Paolo Perrotta
+    bio: |
+      Paolo is the author of Metaprogramming Ruby. He’s been a developer for a long time, ranging from embedded to enterprise software, computer games, and even those web applications things that young people do today. He lives a nomadic life, usually mentoring software teams around Europe. He has a base camp in Bologna, Italy.
+    github_id: nusco
+    twitter_id: nusco
+    avatar_url: https://www.gravatar.com/avatar/0d509031a015eb9e28228723963e2628?s=220
+  youngrw:
+    id: youngrw
+    name: Robert Young
+    bio: |
+      Robert is a virtual machine(VM) and garbage collection(GC) developer at IBM Runtime Technologies. Robert is part of a recently announced project transforming language-agnostic components of the J9 Java VM into a new open toolkit for language development. Robert has worked on MRI Ruby, J9 Java, and CPython, and currently works on integrating J9's garbage collection technologies with MRI Ruby. Robert obtained A BEng in Software Engineering from McMaster University in 2013.
+    github_id: youngrw
+    twitter_id:
+    avatar_url: https://www.gravatar.com/avatar/d2b435adb8ce3e66d296485211310455?s=220
+  hsbt:
+    id: hsbt
+    name: SHIBATA Hiroshi
+    bio: |
+      Ruby Committer, Chief Engineer at GMO Pepabo, Inc.
+    github_id: hsbt
+    twitter_id: hsbt
+    avatar_url: https://www.gravatar.com/avatar/eabad423977cfc6873b8f5df62b848a6?s=220
+  frsyuki:
+    id: frsyuki
+    name: Sadayuki Furuhashi
+    bio: |
+      Founder & Software Architect at Treasure Data, Inc. "Sada" is an enthusiast for open-source software design that helps application of distributed systems. An example is MessagePack, an efficient binary serialization format. github: https://github.com/frsyuki
+    github_id: frsyuki
+    twitter_id: frsyuki
+    avatar_url: https://www.gravatar.com/avatar/aba3c1870b6cea67493617e5a343b586?s=220
+  shotantan:
+    id: shotantan
+    name: Shota Nakano
+    bio: |
+      Shota Nakano is the founder of Manycolors, Inc., a hardware startup in Japan. He made enzi: an mruby rapid prototyping platform and is one of an initial developper of mruby-debugger. Also, other projects are mruby marine M2M device, a consumer device using mruby. His backgrounds are Robotics and Signal Processing.
+    github_id: shotantan
+    twitter_id:
+    avatar_url: https://www.gravatar.com/avatar/297b300dbb30937229c70fbd4b9eaa16?s=220
+  tagomoris:
+    id: tagomoris
+    name: TAGOMORI "moris" Satoshi
+    bio: |
+      OSS developer/maintainer: Fluentd, Norikra, MessagePack-Ruby, and many others.
+      Living in Tokyo, and day job is for Treasure Data.
+    github_id: tagomoris
+    twitter_id: tagomoris
+    avatar_url: https://www.gravatar.com/avatar/002525eada5741b7954ce22c1a066d32?s=220
+  k0kubun:
+    id: k0kubun
+    name: Takashi Kokubun
+    bio: |
+      I'm an author of faster Haml implementation called Hamlit.
+      I work for Cookpad Inc.
+      https://github.com/k0kubun/hamlit
+    github_id: k0kubun
+    twitter_id: k0kubun
+    avatar_url: https://www.gravatar.com/avatar/891b47483032106fb81228a40d7ea7bb?s=220
+  hone02:
+    id: hone02
+    name: Terence Lee
+    bio: |
+      Terence leads Heroku’s Ruby Task Force curating the Ruby experience on the platform. He's worked on some OSS projects such as Ruby (the language), mruby, Bundler, Resque, as well as helping with the Rails Girls movement. When he’s not going to an awesome Heroku or Ruby event, he lives in Austin, TX, the taco capital of America. Terence loves Friday hugs, EVERY DAY OF THE WEEK! Give him a big one when you see him! In addition to hugs, he believes in getting people together for #rubykaraoke.
+    github_id:
+    twitter_id: hone02
+    avatar_url: https://www.gravatar.com/avatar/ac7f7f050ade421ee11b467c8570a3cd?s=220
+  enebo:
+    id: tom_enebo
+    name: Thomas E Enebo
+    bio: |
+      Thomas works on JVM languages at Red Hat.
+    github_id: enebo
+    twitter_id: tom_enebo
+    avatar_url: https://www.gravatar.com/avatar/13313ac2ec7ba7c43b1b952db034ff3b?s=220
+  leinweber:
+    id: leinweber
+    name: Will Leinweber
+    bio: |
+      Will started out as a normal, happy web developer. But over the last several years building Heroku Postgres and related projects, he's turned into a normal, curmudgeonly infrastructure developer. Despite this, he's been unexpectedly drawn to Crystal, but it's no surprise his main project is a Postgres driver…
+    github_id: will
+    twitter_id: leinweber
+    avatar_url: https://www.gravatar.com/avatar/7e042c238dffcc90a7535ccb682e47be?s=220
+  wycats:
+    id: wycats
+    name: Yehuda Katz
+    bio: |
+      Yehuda Katz is one of the creators of Ember.js, a member of the Rust Core Team, and a retired Ruby on Rails and jQuery Core Team member. His 9-to-5 home is at the startup he founded, Tilde Inc.. There he works on Skylight, the smart profiler for Rails, and does Ember.js consulting. He's best known for his open source work, which also includes having created projects like Thor, Handlebars and Bundler. He travels the world doing open source evangelism and web standards work.
+    github_id: wycats
+    twitter_id: wycats
+    avatar_url: https://www.gravatar.com/avatar/428167a3ec72235ba971162924492609?s=220
+  yuki24:
+    id: yuki24
+    name: Yuki Nishijima
+    bio: |
+      Yuki is a Rubyist who was raised in Tokyo and used to work for Pivotal Labs in New York. He moved back to Tokyo in August 2015 as one of the founding members of Pivotal Labs Tokyo. He is a maintainer of the kaminari gem, the creator of the did_you_mean gem, and a frequent contributor to many open source projects including Rails.
+    github_id: yuki24
+    twitter_id: yuki24
+    avatar_url: https://www.gravatar.com/avatar/bcd6fc0618a420ba3d59fe5bfaf2b323?s=220
+  yhara:
+    id: yhara
+    name: Yutaka HARA
+    bio: |
+      Yutaka Hara is a programmer works for NaCl (ネットワーク応用通信研究所), same as Matz. He proposed Enumerable#lazy. He is interested in designing/implementing programming languages. He authored the book 『Rubyでつくる奇妙なプログラミング言語』, a book about esoteric programming languages, such as Brainf*ck, Whitespace, etc.
+    github_id: yhara
+    twitter_id: yhara
+    avatar_url: https://www.gravatar.com/avatar/26e1ba9a02729b2d6013604135221aae?s=220
+  youchan:
+    id: youchan
+    name: youchan
+    bio: |
+      Yoh Osaki
+      Software engineer in Ubiregi inc.
+    github_id: youchan
+    twitter_id: youchan
+    avatar_url: https://www.gravatar.com/avatar/b54abc5e7463fe6470c379e97e3f2477?s=220
+  zzak:
+    id: _zzak
+    name: zzak
+    bio: |
+      Call me zee zak.
+      Committed to ruby, rails, sinatra, and mruby; likes cats, ramen, and 日本酒.
+      Made in Vermont, shade-grown and organic.
+    github_id: zzak
+    twitter_id: _zzak
+    avatar_url: https://www.gravatar.com/avatar/054b5f6b8afdd5f6190bad08e46cd782?s=220
+  yurie:
+    id: yurie
+    name: Yurie Yamane
+    bio: |
+      "nora" mrubyist.
+      A member of Team Yamanekko.
+      A staff of ET robocon TOKYO.
+    github_id: yurie
+    twitter_id:
+    avatar_url: https://www.gravatar.com/avatar/0607f2778a478327d55f9b4fb7954a60?s=220
+
+lightning_talks:
+  JuanitoFatas:
+    id: JuanitoFatas
+    name: Juanito Fatas
+    bio: Juanito Fatas joined Jolly Good Code in 2014 as one of their first engineering
+      hires. He loves Emoji, an amateur translator, hacks on https://www.deppbot.com
+      and contribute to Open Source frequently. He spent most of his time producing
+      typos, checking spellings and deciding which Emoji to use every day.
+    github_id: JuanitoFatas
+    twitter_id: JuanitoFatas
+    avatar_url: https://www.gravatar.com/avatar/771951f55ed37335f238e1a80dfda9cd?s=220
+  meriy100:
+    id: meriy100
+    name: Kouta Kariyado
+    bio: "Kota Kariyado is currently a senior student at the Software Laboratory (directed
+      by Martin Dürst) of the Department of Integrated Information Science, College
+      of Science and Engineering, Aoyama Gakuin University, Japan. Kota's main fields
+      of interests are Ruby, Web Applications, and Internationalization."
+    github_id: meriy100
+    twitter_id:
+    avatar_url: https://www.gravatar.com/avatar/f2de3554528ee63e514073921e76370f?s=220
+  _ksss_:
+    id: _ksss_
+    name: Yuki Kurihara
+    bio: King Size Sound System
+    github_id: ksss
+    twitter_id: _ksss_
+    avatar_url: https://www.gravatar.com/avatar/77897395d9b84463bd474a69b922b2ec?s=220
+  a_turl:
+    id: a_turl
+    name: Arkadiusz Turlewicz
+    bio: Arek Turlewicz loves Ruby, Ruby-on-Rails, Docker, and Linux. He is currently
+      working at MediWeb here in Tokyo, where he develops web applications for healthcare,
+      using cutting edge technology.
+    github_id: arekt
+    twitter_id: a_turl
+    avatar_url: https://www.gravatar.com/avatar/ae4f5e2b1389fda0dd8b25d0f3f332ab?s=220
+  zunda:
+    id: zunda
+    name: zunda
+    bio: Heroku/Support
+    github_id: zunda
+    twitter_id: zundan
+    avatar_url: https://www.gravatar.com/avatar/909b2370f34733bbfefb9a69185c717f?s=220
+  k0kubun:
+    id: k0kubun
+    name: Takashi Kokubun
+    bio:
+      "I'm an author of faster Haml implementation called Hamlit.
+      I work for CookpadInc.
+      https://github.com/k0kubun/hamlit"
+    github_id: k0kubun
+    twitter_id: k0kubun
+    avatar_url: https://www.gravatar.com/avatar/891b47483032106fb81228a40d7ea7bb?s=220
+  namusyaka:
+    id: namusyaka
+    name: namusyaka
+    bio: Padrino Framework maintainer, Infrastructure Engineer at DWANGO Co., Ltd.
+      Loves Rack, Sinatra and Padrino.
+    github_id: namusyaka
+    twitter_id: namusyaka
+    avatar_url: https://www.gravatar.com/avatar/0d1cf45095971fe360ce275c65ecec4c?s=220
+  johnlinvc:
+    id:  johnlinvc
+    name: Lin Yu Hsiang
+    bio: Head of Algorithm at SpoonRocket. Creator of Livehouse.in(beta).Ruby lover.
+      Full-stack developer. iOS developer. FP lover.
+    github_id: johnlinvc
+    twitter_id: johnlinvc
+    avatar_url: https://www.gravatar.com/avatar/3f7d9611fc919c98512b779cde637dfc?s=220
+  joker1007:
+    id: joker1007
+    name: joker1007
+    bio: Freelance Rails Programmer.
+    github_id: joker1007
+    twitter_id: joker1007
+    avatar_url: https://www.gravatar.com/avatar/a5e5ee2fb9e4ce3c728ed9e3ef6e916f?s=220
+  _tad_:
+    id: _tad_
+    name: Tadashi Saito
+    bio: A mere rubyist who uses Ruby for 15 years. His proposal was adopted in Ruby Association Grant of this year.
+    github_id: tadd
+    twitter_id: _tad_
+    avatar_url: https://www.gravatar.com/avatar/852ee3dd3c2f9889e49cbec473a58e75?s=220
+  Althaire:
+    id: Althaire
+    name: Pilar Huidobro
+    bio: Pilar is a media informatics student and part-time developer, aiming to make
+      people happy with tech. She spends her time creating art, playing video games,
+      obsessing over code, taming puppies and above all, making people fall in love
+      with tech.
+    github_id: Althaire
+    twitter_id: Althaire
+    avatar_url: https://www.gravatar.com/avatar/662499be39704ef7f0083ecae8015759?s=220

--- a/2017/data/presentations.yml
+++ b/2017/data/presentations.yml
@@ -1,0 +1,932 @@
+---
+n0kada:
+  title: Keynote
+  type: keynote
+  language: JA
+  description: Nobu's keynote speech
+  speakers:
+  - id: n0kada
+  materials:
+    - title: Making Ruby? ゆるふわRuby生活
+      url: https://slide.rabbit-shocker.org/authors/nobu/rubykaigi-2017/
+  video:
+    youtube_id: Bt-PvFLbMbU
+ko1:
+  title: Fiber in the 10th year
+  type: presentation
+  language: JA
+  description: |-
+    10 years ago I introduced new class Fiber into Ruby 1.9 as  (semi-)coroutine.
+
+    Fiber is a powerful tool to make generators and self managing context switching scheduler. Recently we receive a new proposal "auto-Fiber" to use Fiber aggressively in asynchronous operations.
+
+    In this talk, I will introduce a Fiber itself and a brief histroy of Fiber implementations. What is coroutine and semi-coroutine? Why we need to require 'fiber' library to use `Fiber#transfer`? How to implement fibers and how to speed up them? Also I introduce new proposal "auto-Fiber" and this discussion.
+  speakers:
+  - id: ko1
+  materials:
+    - title: Fiber in the 10th year
+      url: https://www.slideshare.net/KoichiSasada/fiber-in-the-10th-year
+  video:
+    youtube_id: pgFx8DFjN8M
+onk:
+  title: API Development in 2017
+  type: presentation
+  language: JA
+  description: |-
+    Summarize "How to develop API server efficiently."
+
+    This talk will talk while looking back on the history like
+
+    * Why REST (RESTful API) was born?
+    * The world has became to need Native client / Web front-end
+    * API documentation tool are widely used
+       * API Blueprint, Swagger, RAML, JSON Hyper-Schema
+       * Schema driven development
+    * API Query Language (GraphQL)'s birth
+
+    And I talk about the library concept and code that we implemented as necessary.
+    There were many challenges such as how to communicate at the interface boundary, how to implement without any mistakes, etc.
+  speakers:
+  - id: onk
+  video:
+    youtube_id: a28jJ62ZfZM
+matschaffer:
+  title: Mapping your world with Ruby
+  type: presentation
+  language: EN
+  description: |-
+    In the wake of the March 2011 earthquake, many noticed a lack of good environmental data regarding radiation. The Safecast project was born from that need and our Ruby-based infrastructure how is home to nearly 70 million data points.
+
+    In this talk we'll go over the basics of the project, what we've learned over the last 6 years of running a volunteer-based Ruby project, and our plans for future expansion into tracking both radiation and air quality data.
+  speakers:
+  - id: matschaffer
+  materials:
+    - title: Mapping your world with Ruby
+      url: https://speakerdeck.com/matschaffer/rubykaigi-2017-mapping-your-world-with-ruby
+  video:
+    youtube_id: Qk3VSCDZITs
+codefolio:
+  title: How Close is Ruby 3x3 For Production Web Apps?
+  type: presentation
+  language: EN
+  description: How much faster is current Ruby than Ruby 2.0 for a production web
+    application? Let's look at a mixed workload in the real commercial Discourse forum
+    software. We'll see how the speed has changed overall. We'll also examine slow
+    requests, garbage collection, warmup iterations and more. You'll see how to use
+    this benchmark to test your own Ruby optimizations.
+  speakers:
+  - id: codefolio
+  materials:
+    - title: How Close Is Ruby 3x3 for Real Web Apps?
+      url: http://bit.ly/kaigi2017-gibbs
+  video:
+    youtube_id: xZ5mw3x2pdo
+shugomaeda:
+  title: Handling mails on a text editor
+  type: presentation
+  language: JA
+  description: |-
+    A text editor is perfect for mail handling because mails consist of text.  Ruby is perfect for text editing because it's so powerful.
+
+    In this talk, I introduce [Textbringer](https://github.com/shugo/textbringer), a text editor written in Ruby, and [Mournmail](https://github.com/shugo/mournmail), a message user agent implemented as a plugin of Textbringer, and I tells the fun of text editing and mail handling.
+
+    I also talk about Law, Chaos, and the Cosmic Balance through the design and implementation of Textbringer and Mournmail.
+  speakers:
+  - id: shugomaeda
+  materials:
+    - title: Handling mails on a text editor
+      url: https://github.com/shugo/RubyKaigi2017/blob/master/README.md
+  video:
+    youtube_id: pvSOWiVB-KA
+v0dro:
+  title: C how to supercharge Ruby with Rubex
+  type: presentation
+  language: EN
+  description: CRuby is still one of the most popular Ruby interpreters in use today,
+    but it lacks speed. In this talk you will be introduced to Rubex - a new programming
+    language that compiles to C, looks almost exactly like Ruby and is specifically
+    designed for supercharging your Ruby code with minimal effort.
+  speakers:
+  - id: v0dro
+  materials:
+    - title: Ruby Kaigi 2017 - C how to supercharge your Ruby with Rubex
+      url: https://speakerdeck.com/v0dro/ruby-kaigi-2017-c-how-to-supercharge-your-ruby-with-rubex
+  video:
+    youtube_id: pZSuuyiQNZk
+youchan:
+  title: dRuby on Browser
+  type: presentation
+  language: JA
+  description: |-
+    I implemented dRuby on Browser with [Opal](http://opalrb.org/)(a JavaScript to Ruby source code compiler).
+    Browser communicate with WebSocket to the server.
+    The clients transparently access the server-side objects through the distributed objects.
+    Also, by sharing the server-side objects among multiple clients, it can be applied to collaborative applications like Google Apps.
+    This talk will explain the implementation of [dRuby on Opal](https://github.com/youchan/opal-drb) and demonstrate the collaborative application.
+  speakers:
+  - id: youchan
+  materials:
+    - title: dRuby on Browser
+      url: https://youchan.github.io/RubyKaigi2017/
+  video:
+    youtube_id: Tgq5GhagmcU
+hsbt:
+  title: Gemification for Ruby 2.5/3.0
+  type: presentation
+  language: JA
+  description: |-
+    Ruby have many libraries named standard library, extension and default
+    gems, bundled gems. These are some differences under the bundler and
+    rails application.
+
+    default gems and bundled gems are introduced to resolve dependency
+    problem and development ecosystem around the ruby core. We have the
+    plan to promote default/bundled gems from standard libraries. It says
+    “Gemification” projects.
+
+    What Gemification changes in Ruby ecosystem? In this presentation,
+    from the standpoint of the maintainer of the Ruby programming
+    language, I will explain details of Gemification and its blocker
+    things. Finally, I will also introduce the new features of Ruby 2.5
+    and 3.0.
+  speakers:
+  - id: hsbt
+  materials:
+    - title: Gemification for Ruby 2.5/3.0
+      url: https://www.slideshare.net/hsbt/gemification-for-ruby-2530
+  video:
+    youtube_id: VKm93Mwe__k
+kddeisz:
+  title: Compiling Ruby
+  type: presentation
+  language: EN
+  description: Since Ruby 2.3 and the introduction of `RubyVM::InstructionSequence::load_iseq`,
+    we've been able to programmatically load ruby bytecode. By divorcing the process
+    of running YARV byte code from the process of compiling ruby code, we can take
+    advantage of the strengths of the ruby virtual machine while simultaneously reaping
+    the benefits of a compiler such as macros, type checking, and instruction sequence
+    optimizations. This can make our ruby faster and more readable! This talk demonstrates
+    how to integrate this into your own workflows and the exciting possibilities this
+    enables.
+  speakers:
+  - id: kddeisz
+  materials:
+    - title: Compiling Ruby
+      url: https://speakerdeck.com/kddnewton/compiling-ruby
+  video:
+    youtube_id: B3Uf-aHZwmw
+juliancheal:
+  title: Do Androids Dream of Electronic Dance Music?
+  type: presentation
+  language: EN
+  description: 'AI is everywhere in our lives these days: recommending our TV shows,
+    planning our car trips, and running our day-to-day lives through artificially
+    intelligent assistants like Siri and Alexa. But are machines capable of creativity?
+    Can they write poems, paint pictures, or compose music that moves human audiences?
+    We believe they can! In this talk, we’ll use Ruby and cutting-edge machine learning
+    tools to train a neural network on human-generated Electronic Dance Music (EDM),
+    then see what sorts of music the machine dreams up.'
+  speakers:
+  - id: juliancheal
+  - id: ericqweinstein
+  video:
+    youtube_id: OfDBRfmVFHk
+watson1978:
+  title: How to optimize Ruby internal.
+  type: presentation
+  language: JA
+  description: |-
+    "Ruby 3" has aimed to optimize performance which is one of goals to release.
+    I have made some patches to optimize Ruby internal to realize it.
+
+    This talk describes how optimized Ruby internal at Ruby 2.5.
+  speakers:
+  - id: watson1978
+  materials:
+    - title: How to optimize Ruby internal
+      url: https://speakerdeck.com/watson/how-to-optimize-ruby-internal
+  video:
+    youtube_id: 4VOEdd-BYHE
+anton_davydov:
+  title: Hanami - New Ruby Web Framework
+  type: presentation
+  language: EN
+  description: The hanami is quite new and interesting framework which you are unlikely
+    to write complex applications. But this does not mean that this framework is not
+    worth your attention. Besides old approaches, you can also find new interesting
+    solutions.
+  speakers:
+  - id: anton_davydov
+  materials:
+    - title: viewing ruby blossom kaigi2017
+      url: https://speakerdeck.com/davydovanton/viewing-ruby-blossom-kaigi2017
+  video:
+    youtube_id: aYboQzyIoPc
+mrkn:
+  title: Development of Data Science Ecosystem for Ruby
+  type: presentation
+  language: JA
+  description: |-
+    The importance of data analysis in business is increasing day by day.
+    Considering the future of Ruby which is often adopted as the development of business systems, it is an urgent task to make this programming language available in datascience.
+
+    By the appearance of PyCall, Ruby has became able to use mainstreem tools used in datascience such as pandas and matplotlib.
+    However, in order to establish Ruby as a programming language that can be used in datascience, and to keep it in the future as well, there are many problems now, but only a very few developers are working on solving this problem.
+
+    In this presentation, we will introduce what we'll need in the future to establish Ruby as a programming language that can be used in data science.
+    And we'll aim to stimulate Rubyists who are interested in this field, and to activate the development of the datascience ecosystem for Ruby by encouraging development of missing tools, documentation, and reporting on feeling of use and bugs.
+  speakers:
+  - id: mrkn
+  materials:
+    - title: Development of Data Science Ecosystem for Ruby
+      url: https://speakerdeck.com/mrkn/development-of-data-science-ecosystem-for-ruby
+  video:
+    youtube_id: U9GdgZowmGY
+narittan:
+  title: mruby gateway for huge amount of realtime data processing
+  type: presentation
+  language: JA
+  description: "TreasureData deals with huge amount of streaming data import request
+    and saves them into our database in realtime without any lost. \nNew scalable
+    system is required to process requests increasing day by day, and I decided to
+    replace old system with rails and fluentd to new system with h2o and mruby for
+    gateway server.\n\nI'll introduce why h2o and mruby is good and how I optimized
+    mruby server handler for the system. In addition, I'll talk about my patches for
+    h2o to make it possible for mruby parallel processing/asynchronous processing.
+    And also, I'll show benchmarks of actual product."
+  speakers:
+  - id: narittan
+  materials:
+    - title: mruby gateway for huge amount of realtime data processing
+      url: https://www.slideshare.net/RittaNarita/mruby-gateway-for-huge-amount-of-realtime-data-processing
+  video:
+    youtube_id: 7DuwISRyqGE
+_st0012:
+  title: 'I quit my job to write my own language: Goby'
+  type: presentation
+  language: EN
+  description: |-
+    That day, for no particular reason, I decided to write my own language. So I followed a [book](https://interpreterbook.com) and wrote the `monkey`. And when I wrote `monkey`, I thought maybe I'd create my own language. And when I created it, I thought maybe I'd just make it more like Ruby. And I figured, since I've spent so many time, maybe I'd just make it a VM-based language. And that's what I did. I wrote VM and compiler just like Ruby did in version 1.9. For no particular reason I just kept on going. I created file and http library. And when I made them, I figured, since I'd gone this far, I might as well add a web server. When I created the web server, I figured, since I'd gone this far, I might just quit my job and make it my own programming language: [Goby](https://github.com/goby-lang/goby)
+
+    For leanring more about Goby, please also checkout our [Gitbook](https://www.gitbook.com/book/goby-lang/goby) (constantly updated!)
+  speakers:
+  - id: _st0012
+  materials:
+    - title: Goby and its compiler
+      url: https://www.slideshare.net/LoStan/goby-and-its-compiler
+  video:
+    youtube_id: GRNlTWzoC74
+rubylangorg:
+  title: Ruby Committers vs the World
+  type: discussion
+  language: JA
+  description: Live discussions and Q&A from the Ruby Core team
+  speakers:
+  - id: rubylangorg
+  video:
+    youtube_id: Vw36kmRmH5I
+yukihiro_matz:
+  title: Keynote
+  type: keynote
+  language: JA
+  description: TBD
+  speakers:
+  - id: yukihiro_matz
+  video:
+    youtube_id: OnDSm-GZCko
+mametter:
+  title: An introduction and future of Ruby coverage library
+  type: presentation
+  language: JA
+  description: Are you using code coverage?  As Ruby is a dynamic language and there
+    is no standard static code checker yet, a good test suite is crucial to write
+    a production-level Ruby code.  Code coverage is a measure of test goodness.  Therefore,
+    it is also important to (properly) use code coverage to take a hint about whether
+    your test suite is good enough or not yet (and if any, which modules are not tested
+    well).  We talk an introduction to code coverage, types and usage of code coverage,
+    the current status of Ruby `coverage` library, and some planned improvements towards
+    Ruby 2.5.
+  speakers:
+  - id: mametter
+  materials:
+    - title: An introduction and future of Ruby coverage library
+      url: https://www.slideshare.net/mametter/an-introduction-and-future-of-ruby-coverage-library
+  video:
+    youtube_id: zkP8pXOpiH0
+yhara:
+  title: Ruby, Opal and WebAssembly
+  type: presentation
+  language: JA
+  description: |-
+    WebAssembly is a state-of-the-art technology to run CPU intensive calculation on the browser. So how does it relate to Ruby? Well, for instance, you would like to use it while writing browser games, with Ruby.
+
+    In this talk, I will introduce [DXOpal](https://github.com/yhara/dxopal), a game programming framework for Opal (Ruby-to-JavaScript compiler). DXOpal takes advantage of WebAssembly for complex calculations like collision detection.
+  speakers:
+  - id: yhara
+  materials:
+    - title: Ruby, Opal and WebAssembly
+      url: https://speakerdeck.com/yhara/ruby-opal-and-webassembly
+  video:
+    youtube_id: bNTajEO_ndA
+shioyama:
+  title: The Ruby Module Builder Pattern
+  type: presentation
+  language: EN
+  description: Did you know that Ruby has *configurable modules*? One of the most
+    interesting features of Ruby, the [Module Builder Pattern](http://dejimata.com/2017/5/20/the-ruby-module-builder-pattern)
+    is also probably its least well-known. Simply subclass the `Module` class, dynamically
+    define some methods in an initializer, and boom, you can create named, customizable
+    modules to include in other classes. In this talk, I'll explain how I've leveraged
+    this unique feature of Ruby to build a translation gem called [Mobility](https://github.com/shioyama/mobility)
+    that can handle a wide range of different storage strategies through a single,
+    uniform interface.
+  speakers:
+  - id: shioyama
+  materials:
+    - title: The Ruby Module Builder Pattern
+      url: https://speakerdeck.com/shioyama/the-ruby-module-builder-pattern
+  video:
+    youtube_id: _E1yKPC-r1E
+ktou:
+  title: 'Improve extension API: C++ as better language for extension'
+  type: presentation
+  language: JA
+  description: |-
+    This talk proposes better extension API.
+
+    The current extension API is C API. In the past, some languages such as Rust ([RubyKaigi 2015](http://rubykaigi.org/2015/presentations/wycats_chancancode)), Go ([Oedo RubyKaigi 05](https://speakerdeck.com/naruse/writing-extension-libraries-in-go)), rubex ([RubyKaigi 2016](http://rubykaigi.org/2016/presentations/v0dro.html)) were proposed as languages to write extension.
+
+    This talks proposes C++ as a better language for writing extension. Reasons:
+
+      * C++ API can provide simpler API than C API.
+      * C++ API doesn't need C bindings because C++ can use C API including macro natively. Other languages such as Rust and Go need C bindings.
+      * Less API maintenance cost. Other approaches need more works for Ruby evolution such as introduces new syntax and new API.
+  speakers:
+  - id: ktou
+  materials:
+    - title: "Improve extension API: C++ as better language for extension"
+      url: https://slide.rabbit-shocker.org/authors/kou/rubykaigi-2017/
+  video:
+    youtube_id: gfoizFzJ-oI
+nishimotz:
+  title: What visually impaired programmers are thinking about Ruby?
+  type: presentation
+  language: JA
+  description: |-
+    Computer programming is an important job opportunity for visually impaired people.
+    Several colleges are educating Ruby programming to such students in Japan and overseas.
+    This talk reveals the current situations of visually impaired Ruby programmers, especially in Japan,
+    i.e. what they are developing, which tools or environments they are using, and whether they are satisfied or not regarding the Ruby language.
+    Accessibility of documents, which are generated from Ruby sources via rdoc or yard, is one of the issue I found so far.
+  speakers:
+  - id: nishimotz
+  materials:
+    - title: Rubykaigi 2017-nishimotz-v6
+      url: https://www.slideshare.net/nishimotz/rubykaigi-2017nishimotzv6
+  video:
+    youtube_id: O1coxtDTkwY
+zverok:
+  title: The Curious Case of Wikipedia Parsing
+  type: presentation
+  language: EN
+  description: A case study of developing Wikipedia client/parser for structured information
+    extraction, or How we are making entire world common knowledge information machine
+    accessible (from Ruby). Includes investigation of parser development for semi-structured
+    markup and semantic API design.
+  speakers:
+  - id: zverok
+  materials:
+    - title: The Curious Case Of Wikipedia Parsing
+      url: https://docs.google.com/presentation/d/1r3xUjc9nXlwAOmgzCI26lELdNp8Mnsd5sfXa9JJwIME/edit#slide=id.p
+  video:
+    youtube_id: oqsX8kNq94I
+rubymine:
+  title: Automated Type Contracts Generation for Ruby
+  type: presentation
+  language: EN
+  description: |-
+    Beauty and power of Ruby and Rails pays us back when it comes to finding bugs in large codebases. Static analysis is hindered by magic DSLs and patches. We may annotate the code with YARD which also enables improved tooling such as code completion. Sadly, the benefits of this process rarely compensate for the effort.
+
+    In this session we’ll see a new approach to type annotations generation. We'll learn how to obtain this data from runtime, to cope with DSLs and monkey patching, propose some tooling beyond YARD and create contracts like `(String, T) -> T`
+
+    YARV hacking and minimized DFAs included.
+  speakers:
+  - id: rubymine
+  materials:
+    - title: Automated Type Contracts Generation
+      url: https://speakerdeck.com/valich/automated-type-contracts-generation-1
+    - title: goto.mov
+      url: https://www.dropbox.com/s/bstt1inllswbihn/goto.mov
+    - title: template_contracts.mov
+      url: https://www.dropbox.com/s/noqdt9qofdgwhz1/template_contracts.mov
+  video:
+    youtube_id: JS6m2gke0Ic
+duerst:
+  title: Regular Expressions Inside Out
+  type: presentation
+  language: JA
+  description: |-
+    Regular expressions are a very important part of the toolkit of every Ruby programmer. This talk will help improve your understanding of regular expressions, including how to use them from Ruby, and how they are implemented.
+    Examples will include things Ruby can do but other programming languages can't, huge regular expressions, substitutions that change as we go, and performance improvements for future Ruby versions.
+  speakers:
+  - id: duerst
+  materials:
+    - title: Regular Expressions Inside Out
+      url: https://www.sw.it.aoyama.ac.jp/2017/pub/Ruby_Kaigi/
+  video:
+    youtube_id: sUdZ8s4GbnE
+yuki24:
+  title: Static Typo Checker in Ruby
+  type: presentation
+  language: EN
+  description: "Since 2.3.0, Ruby comes with a dynamic typo checker called the did_you_mean
+    gem, which helps find a bug caused by a typo. However, there's one argument against
+    its design: it runs a naming check at runtime. \n\nSo what makes it difficult
+    to implement a static typo checker? What are the technical challenges to build
+    it? Is Type really necessary? In this talk, we'll discuss techniques for how to
+    write a static typo checker by looking at examples that find an undefined method
+    without running Ruby code. Join us to learn about the future of Ruby's typo checker."
+  speakers:
+  - id: yuki24
+  materials:
+    - title: Static typo checker
+      url: https://speakerdeck.com/yuki24/static-typo-checker
+  video:
+    youtube_id: k9WEDRMvanM
+soutaro:
+  title: Type Checking Ruby Programs with Annotations
+  type: presentation
+  language: EN
+  description: |-
+    Type inference for Ruby programs is really difficult, and no one on earth has implemented successfully yet.
+
+    Q: What if we write type annotations?<br>
+    A: Much easier, but it is still not trivial.
+
+    I will explain why they are difficult, how we can have a practical type checker for Ruby, and how the programming experience will be with types.
+  speakers:
+  - id: soutaro
+  materials:
+    - title: Type Checking Ruby Programs with Annotations
+      url: https://speakerdeck.com/soutaro/type-checking-ruby-programs-with-annotations
+  video:
+    youtube_id: JExXdUux024
+emorima:
+  title: Serial Protocol Analyzer on Ruby
+  type: presentation
+  language: JA
+  description: "It is easy to program serial communication on Ruby. (Thanks to greate
+    useful gems.)  \nHowever it is difficult to judge whether there is a problem in
+    either the sending program or the receiving program if data received cannot be
+    successfully.\nTo solve the difficulty, let's analyze the data the sending program
+    has written to the device.\n\nRubyでシリアル通信プログラムを書くのは簡単だ。\nしかしながら、正しくデータが受信できない場合に、送信側に問題があるのか、受信側に問題があるのかを判断するのが困難である。\nその困難さを解決するために、送信プログラムがデバイスに書き込みしたデータをRubyで解析してみよう。"
+  speakers:
+  - id: emorima
+  materials:
+    - title: Serial Protocol Analyzer on Ruby at RubyKaigi2017
+      url: https://speakerdeck.com/emorima/serial-protocol-analyzer-on-ruby-at-rubykaigi2017
+  video:
+    youtube_id: E6LpGzrYWRc
+codefinger:
+  title: Asynchronous and Non-Blocking IO with JRuby
+  type: presentation
+  language: EN
+  description: Asynchronous and non-blocking IO yields higher throughput, lower resource
+    usage, and more predictable behaviour under load. This programming model has become
+    increasingly popular in recent years, but you don't need to use Node.js to see
+    these benefits in your program. You can build asynchronous applications with JRuby.
+    In this talk, we’ll look at libraries and patterns for doing high performance
+    IO in Ruby.
+  speakers:
+  - id: codefinger
+  materials:
+    - title: Async and Non-blocking IO w/ JRuby
+      url: https://www.slideshare.net/jkutner/async-and-nonblocking-io-w-jruby
+  video:
+    youtube_id: BB5z8cg2Hlc
+chancancode:
+  title: 'Bending The Curve: Putting Rust in Ruby with Helix'
+  type: presentation
+  language: EN
+  description: Two years ago at RubyKaigi, we demonstrated our initial work on Helix,
+    an FFI toolkit that makes it easy for anyone to write Ruby native extensions in
+    Rust. In this talk, we will focus on the challenges and lessons we learned while
+    developing Helix. What did it take to fuse the two languages and still be able
+    to take advantage of their unique features and benefits? How do we distribute
+    the extensions to our end-users? Let's find out!
+  speakers:
+  - id: chancancode
+  - id: hone02
+  materials:
+    - title: "Bending The Curve: Putting Rust in Ruby with Helix"
+      url: https://speakerdeck.com/chancancode/bending-the-curve-putting-rust-in-ruby-with-helix
+  video:
+    youtube_id: M2erAV1CpRk
+mtsmfm:
+  title: Ruby Language Server
+  type: presentation
+  language: JA
+  description: |-
+    This talk describes [a ruby language server implementation I created](https://github.com/mtsmfm/languageserver-ruby).
+    I want to increase developers interested in Ruby language server
+    because I hope it will improve Ruby development experience.
+
+    In last year, Microsoft published [Language Server Protocol](http://langserver.org/).
+    This protocol is created to communicate between editors and language servers which provide useful information for development (ex. linting, completion, method definition).
+
+    In this talk, I'll show you why it is important to create language server for Ruby community and how it's implemented.
+  speakers:
+  - id: mtsmfm
+  materials:
+    - title: Ruby Language Server
+      url: https://speakerdeck.com/mtsmfm/ruby-language-server
+  video:
+    youtube_id: spPAdvskyLI
+happywinebot:
+  title: 'Food, Wine and Machine Learning: Teaching a Bot to Taste'
+  type: presentation
+  language: EN
+  description: To use machine learning effectively, you have to understand its strengths,
+    limitations and look for creative ways to apply it. Even if you are already familiar
+    with machine learning, we can all learn more! Let me show you how I have used
+    machine learning to build a bot that can suggest a wine to accompany your next
+    meal.
+  speakers:
+  - id: happywinebot
+  materials:
+    - title: "Food, Wine and Machine Learning: Teaching a Bot to Taste"
+      url: https://speakerdeck.com/mjnguyen/food-wine-and-machine-learning-teaching-a-bot-to-taste
+  video:
+    youtube_id: FP5Zxd5o_4M
+yuri_at_earth:
+  title: 'Write once, run on every boards: portable mruby'
+  type: presentation
+  language: JA
+  description: |-
+    In embedded programming, the development environment and libraries we use to program are different depending on hardware.
+    So, we have to make different programs for each hardware.
+    Would not it be nice if CRuby works on Mac and Windows, even if the hardware is different, would the same mruby program run?
+    I have a plan off platform to make one same Ruby code run on various microcontrollers.
+    In this session, I will introduce an example of running Ruby code on several microcomputers.
+  speakers:
+  - id: yuri_at_earth
+  video:
+    youtube_id: DF4oLrc7KaE
+masa16tanaka:
+  title: 'Progress of Ruby/Numo: Numerical Computing for Ruby'
+  type: presentation
+  language: JA
+  description: In my view, the primary reason why Python has become popular in scientific
+    computing is that Python has Numpy, a powerful tool for data processing and it
+    serves as the basis of various libraries. As an equivalent to Numpy in Ruby, I
+    have been developing NArray as I reported in RubyKaigi 2010. Now I am developing
+    the new version of NArray as a library in Ruby/Numo (NUmerical MOdule). Currently
+    Ruby/Numo contains interfaces to BLAS/LAPACK, GSL, FFTE, and Gnuplot. However,
+    the development is far from complete and needs further effort. In this talk, I
+    will report the progress of the Ruby/Numo project and discuss issues in scientific
+    computing with Ruby.
+  speakers:
+  - id: masa16tanaka
+  materials:
+    - title: "Progress of Ruby-Numo: Numerical Computing for Ruby"
+      url: https://speakerdeck.com/masa16tanaka/progress-of-ruby-numo-numerical-computing-for-ruby
+  video:
+    youtube_id: qJ6YIfbTLGM
+jmettraux:
+  title: Flor - hubristic interpreter
+  type: presentation
+  language: EN
+  description: |-
+    Originally, the talk was named "I wanted to write less code". We all do. But I fell into a rabbit hole of languages and interpreters. This will be an exposé of my hubristic quest.
+
+    [Flor](https://github.com/floraison/flor) is a workflow engine, a remake of ruote, yet another celebration of the joy of programming in Ruby.
+  speakers:
+  - id: jmettraux
+  materials:
+    - title: flor - hubristic interpreter - RubyKaigi 2017
+      url: https://speakerdeck.com/jmettraux/flor-hubristic-interpreter-rubykaigi-2017
+  video:
+    youtube_id: gXep-LwPvw8
+tenderlove:
+  title: Compacting GC in MRI
+  type: presentation
+  language: JA
+  description: We will talk about implementing a compacting GC for MRI.  This talk
+    will cover compaction algorithms, along with implementation details, and challenges
+    specific to MRI.
+  speakers:
+  - id: tenderlove
+  materials:
+    - title: Building a Compacting GC
+      url: https://speakerdeck.com/tenderlove/building-a-compacting-gc
+  video:
+    youtube_id: AuuYQaoqr24
+i2y_:
+  title: Introducing the Jet Programming Language
+  type: presentation
+  language: JA
+  description: Jet is similar to Ruby and run on Erlang VM. In this talk, I will mainly
+    explain the specification and implementation.
+  speakers:
+  - id: i2y_
+  materials:
+    - title: Introducing the Jet Programming Language
+      url: https://speakerdeck.com/i2y/introducing-the-jet-programming-language
+  video:
+    youtube_id: SfF9va8NGhM
+lctseng:
+  title: Tamashii - Create Rails IoT applications more easily
+  type: presentation
+  language: EN
+  description: "With the rise of embedded devices with general purpose operating system,
+    running arbitrary programs on IoT devices becomes more feasible. Raspberry PI
+    is one of the examples. We can use sensors, speakers and even cameras as building
+    blocks to make our unique IoT devices. However, there must be some framework to
+    integrate these components, and that is why we create the Tamashii system. Tamashii
+    is a Ruby-based IoT framework on Raspberry PI. It defines common interfaces between
+    components. It also provides a Rack-based device management server inspired by
+    Action Cable, and makes it easy to integrate IoT logic into Rails application.
+    We have implemented a check-in system with Tamashii and proved to work fine on
+    Rubyconf.tw 2016.\n\nThere is also a short demo video to help you know more about
+    Tamashii: \nhttps://youtu.be/hH6u4sJx_L4\n\nTamashii Official Website: https://tamashii.io"
+  speakers:
+  - id: lctseng
+  materials:
+    - title: Tamashii at RubyKaigi 2017
+      url: https://speakerdeck.com/lctseng/tamashii-at-rubykaigi-2017
+  video:
+    youtube_id: g7WM6ITZYp0
+keiju:
+  title: 'Irb 20th anniversary  memorial session: Reish and Irb2'
+  type: presentation
+  language: JA
+  description: "Irb has been born 20 years now.. To commemorate it I will talk about
+    Reish and the next generation of Irb.\nReish is an an unix shell for rubyist.
+    \ It is a shell language that realize Ruby's feature. Also, it is an language
+    which is metamorphosed from Ruby for more natural shell operation.\nReish is under
+    development. Reish is similar to Irb in usage, and various knowledge was gained
+    in its development. I will introduce the vision of Irb next generation based on
+    that.\n\nIrbは今年で生まれて20年になります. それを記念してReishとIrbの次世代の話をします. \nReishはRubyistのためのshellで,
+    Rubyの機能を実現しています. また, Ruby操作から自然にshell操作に変換可能な言語です. \nReishは現在開発中です. ReishはIrbと使い方が似ていて,
+    その開発からいろいろな知見を得ることができます。それを基にIrbの次世代の構想をお話しします."
+  speakers:
+  - id: keiju
+  materials:
+    - title: "Irb 20th anniversary memorial session: Reish and Irb2!?"
+      url: https://speakerdeck.com/keiju/irb-20th-anniversary-memorial-session-reish-and-irb2
+  video:
+    youtube_id: mS7fBsBF_gg
+tagomoris:
+  title: Ruby for Distributed Storage System
+  type: presentation
+  language: JA
+  description: |-
+    Storage systems is a big topic in distributed systems, which requires high stability, reliability and performance. There are many OSS distributed storage systems, but most of these are implemented in Java and other JVM languages (just some others are in C++, Riak, etc).
+    An OSS distributed storage, bigdam-pool, is implemented both in Java and Ruby and I'm getting a benchmark score for both implementations. This talk will show the details of benchmark result, and what I learnt from this trial.
+
+    * Providing HTTP API in a daemon
+    * Serializing/Deserializing Data
+    * Performance
+  speakers:
+  - id: tagomoris
+  materials:
+    - title: Ruby and Distributed Storage Systems
+      url: https://www.slideshare.net/tagomoris/ruby-and-distributed-storage-systems
+  video:
+    youtube_id: KrWhhgWHTwE
+DeltonDing:
+  title: High Concurrent Ruby Web Development Without Fear
+  type: presentation
+  language: EN
+  description: |-
+    We've been debating on the concurrency solution of Ruby for several years. Numerous custom "evented" drivers have been built, but for most of these projects, developers are required to think in the "evented" way to get things work properly, which not only breaks the elegance of Ruby programming, but also greatly increases the complexity of the refactoring process.
+
+    We will then think in Ruby, looking for the solution to make your whole web application "evented" with great meta-programming features of Ruby language itself. So that, you could still concentrate on your business models while programming as usual, but the performance may boost to 5 times faster or more without any hesitation.
+  speakers:
+  - id: DeltonDing
+  materials:
+    - title: High Concurrent Ruby Web Development Without Fear
+      url: https://www.slideshare.net/DeltonDing/high-concurrent-ruby-web-development-without-fear
+  video:
+    youtube_id: L_DRmV3LMYA
+yotii23:
+  title: Pattern Matching in Ruby
+  type: presentation
+  language: EN
+  description: |-
+    Do you want pattern matching in Ruby? I want.
+    It will make Ruby more elegant, more useful, and more comfortable.
+    So in this talk, I'll propose a specification about pattern matching in Ruby and will show my implementation in parse.y (a part of them).
+  speakers:
+  - id: yotii23
+  materials:
+    - title: Pattern Matching in Ruby
+      url: https://speakerdeck.com/yotii23/pattern-matching-in-ruby-2017-rubykaigi
+  video:
+    youtube_id: 1m4IPJH0k0E
+aycabta:
+  title: Ruby Parser In IRB 20th Anniversary...Now Let Time Resume
+  type: presentation
+  language: EN
+  description: |-
+    IRB has an internal Ruby code parser by pure Ruby. It's contributing greatly to some Ruby tools. A part of them is RDoc. RDoc uses forked Ruby parser of IRB. It is great works, but so legacy. The maintenance cost for new Ruby syntax continues to increase. For example, Ruby 2.1 supports new feature `<visibility> def` method definition, but RDoc supports it after Ruby 2.4.
+
+    I provide a solution for it. After Ruby 1.9, Ripper is adopted as standard library. Ripper is a parser for Ruby code, it uses `parse.y` of CRuby in common. It's perfect for supporting latest Ruby syntax.
+  speakers:
+  - id: aycabta
+  video:
+    youtube_id: fZGyXwiFNAo
+0xColby:
+  title: Bundler 2
+  type: presentation
+  language: EN
+  description: The Bundler core team has been working hard on the next major release
+    of Bundler. We'll talk about what improvements we've been making, new features
+    & what we've removed.
+  speakers:
+  - id: 0xColby
+  materials:
+    - title: What we’ve been up to with Bundler
+      url: https://speakerdeck.com/colby/what-weve-been-up-to-with-bundler
+  video:
+    youtube_id: sZX7SK3hxk4
+headius:
+  title: 'JRuby at 15 Years: Meeting the Challenges'
+  type: presentation
+  language: EN
+  description: 'JRuby has evolved a lot over 15 years. We''ve met challenges of performance,
+    native integration, and compatibility. What will we face in the future? In this
+    talk we''ll discuss today''s JRuby challenges: startup time, code size, type specialization,
+    and tooling. JRuby is the most-used alternative Ruby, and with your help we''ll
+    continue to make it the best way to run your Ruby apps.'
+  speakers:
+  - id: headius
+  - id: tom_enebo
+  video:
+    youtube_id: rkvrikvoYPQ
+gotoken:
+  title: Ruby in office time reboot
+  type: presentation
+  language: JA
+  description: 'I''ll introduce some uses of Ruby in my everyday office hours. Various
+    kind of tasks are helped by Ruby: deta processiong, scraping, excel sheet generation,
+    Instllation ruby, etc. This is a continuation of old my talk series: Shigoto de
+    tsukau Ruby. '
+  speakers:
+  - id: gotoken
+  materials:
+    - title: Ruby in office time reboot
+      url: https://www.slideshare.net/gotoken/ruby-in-office-time-reboot
+  video:
+    youtube_id: PAQwlSfRjko
+nateberkopec:
+  title: Memory Fragmentation and Bloat in Ruby
+  type: presentation
+  language: EN
+  description: 'Memory is not a simple abstraction. The layers of indirection between
+    "Object.new" and flipping a bit in RAM are numerous: the Ruby heap, the memory
+    allocator, the kernel, the memory management unit and more. Unfortunately, all
+    of these layers can contribute to "bad behavior", resulting in memory fragmentation
+    and bloat. This talk examines each of the different layers of memory abstraction,
+    and how tuning and controlling them can result in reduced memory usage in Ruby
+    applications.'
+  speakers:
+  - id: nateberkopec
+  materials:
+    - title: Memory Fragmentation and Bloat in Ruby
+      url: https://github.com/speedshop/rubykaigi2017/blob/master/rubykaigi-present.pdf
+  video:
+    youtube_id: eBmM-yWPeMw
+tanaka_akr:
+  title: Ruby Extension Library Verified using Coq Proof-assistant
+  type: presentation
+  language: JA
+  description: |-
+    Ruby extension library is written in C.
+    C is great because it is fast and easy to access low-level features of OS and CPU.
+    However it is dangerous and error-prone:
+    it is difficult to avoid failures such as integer overflow and buffer overrun.
+    We explain a method to generate C functions verified using Coq proof-assistant with Coq plugins we developed.
+    We can verify safety (absence of failures) and correctness (functions works as expected) in Coq.
+    The generated functions can be used in Ruby extension library.
+    This provides a way to develop trustful Ruby extension library.
+    Supplement material: https://github.com/akr/coq-html-escape
+  speakers:
+  - id: tanaka_akr
+  materials:
+    - title: Ruby Extension Library Verified using Coq Proof-assistant
+      url: http://www.a-k-r.org/pub/2017-09-20-akr-rubykaigi.pdf
+  video:
+    youtube_id: berjYyI5Bys
+p_ck_:
+  title: Writing Lint for Ruby
+  type: presentation
+  language: JA
+  description: |-
+    This talk describes how to write Lint for Ruby program.
+
+    Lint finds bugs from code automatically. So, if you can write Lint, you can reduce bugs from your code automatically.
+    This talk includes the following topics.
+
+    - Implementation of existing Lint such as [RuboCop](https://github.com/bbatsov/rubocop) and [Reek](https://github.com/troessner/reek).
+    - How to create new Lint or add a new rule to existing Lint yourself.
+  speakers:
+  - id: p_ck_
+  materials:
+    - title: Writing Lint for Ruby
+      url: https://speakerdeck.com/pocke/writing-lint-for-ruby
+  video:
+    youtube_id: xr3uDzQIuBA
+jules2689:
+  title: 'Busting Performance Bottlenecks: Improving Boot Time by 60%'
+  type: presentation
+  language: EN
+  description: 'Lengthy application boot times cause developers to quickly lose context
+    and view applications in a negative light, which in turn costs organizations a
+    lot of money and productivity. We found that there were a few areas that impacted
+    boot time: compiling Ruby bytecode, serializing configurations, looking up files
+    and constants, autoloading files, and booting Bundler. This talk focuses on our
+    strategies and solutions which improved our boot time by 60%. Attendees will leave
+    with knowledge of ways to find and mitigate their own startup performance bottlenecks.'
+  speakers:
+  - id: jules2689
+  materials:
+    - title: Busting Performance Bottlenecks Decreasing Ruby Boot time by 60%
+      url: https://jnadeau.ca/presentations/rubykaigi2017/
+  video:
+    youtube_id: 8BJKrx6rsM0
+m_seki:
+  title: How to write synchronization mechanisms for Fiber
+  type: presentation
+  language: JA
+  description: |-
+    Ruby threads are amazing, but for some reason they don't seem to be very popular. So I decided I'd try experimenting with programming multiple independent execution flows in a single thread using Fibers.
+
+    In this talk, I'll first explain an idiom for easily writing synchronization mechanisms between Fibers. Then I will explain in detail an example which combines a framework abstracting 'select' with the Fiber idiom to achieve blocking-like non-blocking IO. I'll explain this using actual code from examples of timer-based periodic processing and simple TCP/IP server programming, to an over-the-top example running WEBrick on a single thread (using Fiber to handle multiple clients synchronously). I'll also explain ways to combine this with threads.
+
+    In the talk I'd like to present the following:
+    * an example of select abstraction
+    * some essential features for Fibers
+  speakers:
+  - id: m_seki
+  materials:
+    - title: How to write synchronization mechanisms for Fiber
+      url: https://speakerdeck.com/m_seki/how-to-write-synchronization-mechanisms-for-fiber?slide=3
+  video:
+    youtube_id: 0mDnZ0V9OSA
+takaokouji:
+  title: 'Smalruby : The neat thing to connect Rubyists and Scratchers'
+  type: presentation
+  language: JA
+  description: |-
+    The Smalruby is a 2D game development library that aims to be compatible with Scratch (Scratch is most famous visual programming language: https://scratch.mit.edu/).
+
+    Reacently, programming education for kids is expanding rapidly and Scratch is ususally a first-contact programming language for them.
+    Some kids, good Scratchers, try to learn a text-based programming languege.
+
+    Smalruby helps to make Scratcher Rubyist!
+
+    This talk includes the following topics:
+
+    * The recent situation of programming education for kids.
+    * Smalruby's features.
+    * Smalruby inside.
+  speakers:
+  - id: takaokouji
+  - id: nobyuki
+  materials:
+    - title: Smalruby - The neat thing to connect Rubyists and Scratchers -
+      url: https://www.slideshare.net/kouji/smalruby-the-neat-thing-to-connect-rubyists-and-scratchers
+  video:
+    youtube_id: U3pre3Bv9rk
+nirvdrum:
+  title: Improving TruffleRuby’s Startup Time with the SubstrateVM
+  type: presentation
+  language: EN
+  description: 'We’ve solved the startup time problem in TruffleRuby! In this talk,
+    I’ll introduce the SubstrateVM and how we make use of it to compile the Java-based
+    TruffleRuby to a static binary and massively improve our startup time. '
+  speakers:
+  - id: nirvdrum
+  materials:
+    - title: Improving TruffleRuby’s Startup Time with the SubstrateVM
+      url: https://speakerdeck.com/nirvdrum/improving-trufflerubys-startup-time-with-the-substratevm
+  video:
+    youtube_id: 5Ik2qCTmeN0
+vnmakarov:
+  title: Towards Ruby 3x3 performance
+  type: keynote
+  language: EN
+  description: |-
+    Ruby 3x3 project has a very ambitious goal to improve MRI performance in 3 times in comparison with MRI version 2.0.
+
+    This talk is about my attempt to achieve this goal in a project to implement RTL VM instructions and JIT in MRI VM. The project can be found on https://github.com/vnmakarov/ruby.
+
+    We will talk about the project motivation, goals, and approaches, and the current state of the project. Performance comparison with JRuby, Graal/Truffle Ruby, and OMR Ruby and future directions of the project will be given too.
+  speakers:
+  - id: vnmakarov
+  materials:
+    - title: Towards Ruby3x3 Performance - Introducing RTL and MJIT
+      url: https://vmakarov.fedorapeople.org/VMakarov-RubyKaigi2017.pdf
+  video:
+    youtube_id: qpZDw-p9yag

--- a/2017/data/schedule.yml
+++ b/2017/data/schedule.yml
@@ -1,0 +1,190 @@
+---
+sep18:
+  events:
+  - type: break
+    begin: '09:30'
+    end: '10:30'
+    name: Door Open
+  - type: keynote
+    begin: '10:30'
+    end: '11:30'
+    talks:
+      Phoenix: n0kada
+  - type: break
+    begin: '11:30'
+    end: '13:00'
+    name: Lunch
+  - type: talk
+    begin: '13:00'
+    end: '13:40'
+    talks:
+      Phoenix: ko1
+      Dahlia: onk
+      Cosmos: matschaffer
+  - type: talk
+    begin: '13:50'
+    end: '14:30'
+    talks:
+      Phoenix: codefolio
+      Dahlia: shugomaeda
+      Cosmos: v0dro
+  - type: talk
+    begin: '14:40'
+    end: '15:20'
+    talks:
+      Phoenix: youchan
+      Dahlia: hsbt
+      Cosmos: kddeisz
+  - type: break
+    begin: '15:20'
+    end: '15:50'
+    name: Afternoon Break
+  - type: talk
+    begin: '15:50'
+    end: '16:30'
+    talks:
+      Phoenix: juliancheal
+      Dahlia: watson1978
+      Cosmos: anton_davydov
+  - type: talk
+    begin: '16:40'
+    end: '17:20'
+    talks:
+      Phoenix: mrkn
+      Dahlia: narittan
+      Cosmos: _st0012
+  - type: talk
+    begin: '17:30'
+    end: '18:30'
+    talks:
+      Phoenix: rubylangorg
+sep19:
+  events:
+  - type: break
+    begin: '09:00'
+    end: '09:40'
+    name: Door Open
+  - type: keynote
+    begin: '09:40'
+    end: '10:40'
+    talks:
+      Phoenix: yukihiro_matz
+  - type: talk
+    begin: '10:50'
+    end: '11:30'
+    talks:
+      Phoenix: mametter
+      Dahlia: yhara
+      Cosmos: shioyama
+  - type: break
+    begin: '11:30'
+    end: '13:00'
+    name: Lunch
+  - type: talk
+    begin: '13:00'
+    end: '13:40'
+    talks:
+      Phoenix: ktou
+      Dahlia: nishimotz
+      Cosmos: zverok
+  - type: talk
+    begin: '13:50'
+    end: '14:30'
+    talks:
+      Phoenix: rubymine
+      Dahlia: duerst
+      Cosmos: yuki24
+  - type: talk
+    begin: '14:40'
+    end: '15:20'
+    talks:
+      Phoenix: soutaro
+      Dahlia: emorima
+      Cosmos: codefinger
+  - type: break
+    begin: '15:20'
+    end: '15:50'
+    name: Afternoon Break
+  - type: talk
+    begin: '15:50'
+    end: '16:30'
+    talks:
+      Phoenix: chancancode
+      Dahlia: mtsmfm
+      Cosmos: happywinebot
+  - type: talk
+    begin: '16:40'
+    end: '17:20'
+    talks:
+      Phoenix: yuri_at_earth
+      Dahlia: masa16tanaka
+      Cosmos: jmettraux
+  - type: lt
+    begin: '17:30'
+    end: '18:30'
+    name: Lightning Talks
+sep20:
+  events:
+  - type: break
+    begin: '09:00'
+    end: '10:00'
+    name: Door Open
+  - type: talk
+    begin: '10:00'
+    end: '10:40'
+    talks:
+      Phoenix: tenderlove
+      Dahlia: i2y_
+      Cosmos: lctseng
+  - type: talk
+    begin: '10:50'
+    end: '11:30'
+    talks:
+      Phoenix: keiju
+      Dahlia: tagomoris
+      Cosmos: DeltonDing
+  - type: break
+    begin: '11:30'
+    end: '13:00'
+    name: Lunch
+  - type: talk
+    begin: '13:00'
+    end: '13:40'
+    talks:
+      Phoenix: yotii23
+      Dahlia: aycabta
+      Cosmos: 0xColby
+  - type: talk
+    begin: '13:50'
+    end: '14:30'
+    talks:
+      Phoenix: headius
+      Dahlia: gotoken
+      Cosmos: nateberkopec
+  - type: talk
+    begin: '14:40'
+    end: '15:20'
+    talks:
+      Phoenix: tanaka_akr
+      Dahlia: p_ck_
+      Cosmos: jules2689
+  - type: break
+    begin: '15:20'
+    end: '15:50'
+    name: Afternoon Break
+  - type: talk
+    begin: '15:50'
+    end: '16:30'
+    talks:
+      Phoenix: m_seki
+      Dahlia: takaokouji
+      Cosmos: nirvdrum
+  - type: keynote
+    begin: '16:40'
+    end: '17:40'
+    talks:
+      Phoenix: vnmakarov
+  - type: break
+    begin: '17:40'
+    end: '18:00'
+    name: Closing

--- a/2017/data/speakers.yml
+++ b/2017/data/speakers.yml
@@ -1,0 +1,540 @@
+---
+keynotes:
+  yukihiro_matz:
+    id: yukihiro_matz
+    name: Yukihiro "Matz" Matsumoto
+    bio: The Creator of Ruby
+    github_id: matz
+    twitter_id: yukihiro_matz
+    gravatar_hash: 0ec4920185b657a03edf01fff96b4e9b
+  n0kada:
+    id: n0kada
+    name: nobu
+    bio: The patch monster
+    github_id: nobu
+    twitter_id: n0kada
+    gravatar_hash: f1d6cc2b735bfd82c8773172da2aeab9
+  vnmakarov:
+    id: vnmakarov
+    name: Vladimir Makarov
+    bio: Vladimir Makarov is a software developer. His major interests lays in algorithms,
+      programming languages, compilers and JITs. Vladimir finished Moscow Institute
+      of Physics and Technology and got his PhD in computer science in Russian Academy
+      of Sciences. Last 20 years he has been working on GCC in RedHat, Canada. Vladimir
+      started his work on Ruby MRI in 2015.  His MRI projects are new hash tables
+      and ongoing implementation of new VM instructions and JIT. Vladimir lives in
+      Toronto, Canada.
+    github_id: vnmakarov
+    twitter_id: 
+    gravatar_hash: 42979fbb3647ad7cd1ce86e5a1dc0e28
+speakers:
+  0xColby:
+    id: 0xColby
+    name: Colby Swandale
+    bio: Software Developer at Marketplacer in Melbourne, Australia. I'm passionate
+      about open source and currently serving on the Bundler core team.
+    github_id: colby-swandale
+    twitter_id: 0xColby
+    gravatar_hash: 68c6cbe82595ac9e51ee1c160756ad55
+  _st0012:
+    id: _st0012
+    name: Stan Lo
+    bio: "Ruby/Rails developer, cat and boxing lover. Currently working on Goby language
+      https://github.com/goby-lang/goby as a junior language designer \U0001F601"
+    github_id: st0012
+    twitter_id: _st0012
+    gravatar_hash: 90eb4343c490d4fe855eec64e1b1eaa3
+  anton_davydov:
+    id: anton_davydov
+    name: Anton Davydov
+    bio: I'm an indie developer from Moscow. I work on different open source projects
+      and builds Space-Rocket ships at night. I'm Hanami core developer.
+    github_id: davydovanton
+    twitter_id: anton_davydov
+    gravatar_hash: 4c206cf12d71775464e20c58dfa4148b
+  aycabta:
+    id: aycabta
+    name: ITOYANAGI Sakura
+    bio: ''
+    github_id: aycabta
+    twitter_id: 
+    gravatar_hash: 43da97eeeac8fafd2bf196db1f19c534
+  chancancode:
+    id: chancancode
+    name: Godfrey Chan
+    bio: Godfrey Chan is a member of the Ember.js core team and a Ruby on Rails core
+      team alumni. He currently works at Tilde as an in-house Canadian. In his previous
+      life, he was also an award-winning WordPress™ plugin author.
+    github_id: chancancode
+    twitter_id: chancancode
+    gravatar_hash: 22bb3e56828870ee9a0dd93aeadbe04a
+  codefinger:
+    id: codefinger
+    name: Joe Kutner
+    bio: Joe is the JVM Platform Owner at Heroku, where he curates the JRuby experience
+      in the Heroku cloud. He's worked with Ruby and JRuby for a decade, and wrote
+      Deploying with JRuby 9k from the Pragmatic Bookshelf.
+    github_id: jkutner
+    twitter_id: codefinger
+    gravatar_hash: fc9dc18f851317e79ac06ada2d74a99b
+  codefolio:
+    id: codefolio
+    name: Noah Gibbs
+    bio: Noah works on Ruby for AppFolio, working on Ruby performance and related
+      tooling. He wrote the book "Rebuilding Rails" about understanding Rails as "really
+      just Ruby."
+    github_id: noahgibbs
+    twitter_id: codefolio
+    gravatar_hash: 5e8107f48d4471a40de325151d589b6d
+  DeltonDing:
+    id: DeltonDing
+    name: Delton Ding
+    bio: Developer from HeckPsi Lab in Shanghai. Ruby enthusiasts. Main Contributor
+      to Project Midori.
+    github_id: dsh0416
+    twitter_id: DeltonDing
+    gravatar_hash: a3f83ab752e0274d624d297b35ded098
+  duerst:
+    id: duerst
+    name: Martin J. Dürst
+    bio: Martin is a Professor of Computer Science at Aoyama Gakuin University in
+      Japan. He has been one of the main drivers of Internationalization (I18N) and
+      the use of Unicode on the Web and the Internet. He published the first proposals
+      for DNS I18N and for NFC character normalization, and is the main author of
+      the W3C Character Model and the IRI specification (RFC 3987). Since 2007, he
+      and his students have contributed to the implementation of Ruby, mostly in the
+      area of I18N.
+    github_id: duerst
+    twitter_id: 
+    gravatar_hash: f52e87b92cafb1e8c6d155076b56ecff
+  emorima:
+    id: emorima
+    name: Mayumi EMORI
+    bio: Group Manager at KCS Carrot Corp. Member of Asakusa.rb, Chidoriashi.rb and
+      Rails Girls Japan.
+    github_id: emorima
+    twitter_id: emorima
+    gravatar_hash: 8996906240f1da4106cd4913923c7178
+  ericqweinstein:
+    id: ericqweinstein
+    name: Eric Weinstein
+    bio: Eric Weinstein is the author of Ruby Wizardry (No Starch Press), an illustrated
+      guide to the language for children. He enjoys writing Ruby, Clojure, Elixir,
+      Idris, and Swift.
+    github_id: ericqweinstein
+    twitter_id: 
+    gravatar_hash: facce030b679bda34eb7c64885a741fc
+  gotoken:
+    id: gotoken
+    name: Kentaro Goto / ごとけん
+    bio: Chief Engineer of Syngram, small web and graphic design company. Ancient
+      evangelist of Ruby. Author of some standard libraries in their original version.
+    github_id: gotoken
+    twitter_id: gotoken
+    gravatar_hash: 90bf8e8f068efd1ea80f9a66cc5cfac6
+  happywinebot:
+    id: happywinebot
+    name: Mai Nguyen
+    bio: After several years in Java and Ruby software development in Washington,
+      DC, Mai left IT to pursue her passion for food and wine. She earned a  Masters
+      degree in wine science at the University of Adelaide, and continued on her journey,
+      working in wine production in Australia, France, California, and New Zealand.
+      Mai is now based in Wellington, and has since returned to the tech industry.
+      Since then, she has been exploring ways to use technology to make wine more
+      accessible to the public.
+    github_id: 
+    twitter_id: happywinebot
+    gravatar_hash: a9ae99f612eaf56b16cdf12d35ba74e1
+  headius:
+    id: headius
+    name: Charles Nutter
+    bio: Charles works on JVM languages at Red Hat.
+    github_id: headius
+    twitter_id: headius
+    gravatar_hash: f1d37642fdaa1662ff46e4c65731e9ab
+  hone02:
+    id: hone02
+    name: Terence Lee
+    bio: 'Terence leads Heroku’s Ruby Task Force curating the Ruby experience on the
+      platform. He''s worked on some OSS projects such as Ruby (the language), mruby,
+      Bundler, Resque, as well as helping with the Rails Girls movement. When he’s
+      not going to an awesome Heroku or Ruby event, he lives in Austin, TX, the taco
+      capital of America. Terence loves Friday hugs, EVERY DAY OF THE WEEK! Give him
+      a big one when you see him! In addition to hugs, he believes in getting people
+      together for #rubykaraoke.'
+    github_id: hone
+    twitter_id: hone02
+    gravatar_hash: ac7f7f050ade421ee11b467c8570a3cd
+  hsbt:
+    id: hsbt
+    name: SHIBATA Hiroshi
+    bio: Ruby Committer, Executive Officer CPO at GMO Pepabo, Inc.
+    github_id: hsbt
+    twitter_id: hsbt
+    gravatar_hash: eabad423977cfc6873b8f5df62b848a6
+  i2y_:
+    id: i2y_
+    name: Yasushi Itoh
+    bio: Software engineer
+    github_id: i2y
+    twitter_id: i2y_
+    gravatar_hash: 2b11579150bfe89bbe8aa83b0970b38c
+  jmettraux:
+    id: jmettraux
+    name: John Mettraux
+    bio: Programmer
+    github_id: jmettraux
+    twitter_id: jmettraux
+    gravatar_hash: 8d96626e52beb1ff90f57a8e189e1e6f
+  jules2689:
+    id: jules2689
+    name: Julian Nadeau
+    bio: Julian is a Production Engineer at Shopify working on developer productivity
+      and experience. Working on the Shopify application, one of the larger Ruby apps
+      out there, has provided a good look into performance related topics in the Ruby
+      ecosystem that he is anxious to share.
+    github_id: jules2689
+    twitter_id: jules2689
+    gravatar_hash: 6e01dd682c021a600a943b0a539ed6a2
+  juliancheal:
+    id: juliancheal
+    name: Julian Cheal
+    bio: A British Ruby/Rails developer, with a penchant for tweed, fine coffee, homebrewing,
+      and deploying enterprise clouds.
+    github_id: juliancheal
+    twitter_id: 
+    gravatar_hash: ba5ce2541928927c1ea3ceeaf3a4d604
+  kddeisz:
+    id: kddeisz
+    name: Kevin Deisz
+    bio: I am a software engineer at Localytics in Boston, Massachusetts. I'm passionate
+      about music, open-source software, and craft beer.
+    github_id: kddeisz
+    twitter_id: kddeisz
+    gravatar_hash: 8a66c2a7197be751b21ebd35319ec797
+  keiju:
+    id: keiju
+    name: Keiju Ishitsuka
+    bio: Ruby's godfather.
+    github_id: keiju
+    twitter_id: 
+    gravatar_hash: 97f338629741aa42d6717bfba0c2830f
+  ko1:
+    id: ko1
+    name: Koichi Sasada
+    bio: Koichi Sasada is a programmer, mainly developing Ruby interpreter (CRuby/MRI).
+      He received Ph.D (Information Science and Technology) from the University of
+      Tokyo, 2007. He became a faculty of University of Tokyo (Assistant associate
+      2006-2008, Assistant professor 2008-2012). After 13 years in University, he
+      joined Matz's team in Heroku, Inc (2012-2017). At 2017 he joined Cookpad Inc.
+      He is also a director of Ruby Association.
+    github_id: ko1
+    twitter_id: 
+    gravatar_hash: 990397e8b38d6f5f4ae8ff343e8b883a
+  ktou:
+    id: ktou
+    name: Kouhei Sutou
+    bio: 'He is a free software programmer and the president of ClearCode Inc. He
+      is also the namer of ClearCode Inc. The origin of the company name is "clear
+      code". We will be programmers that code clear code as our company name suggests.
+      He is interested in how to tell other programmers about how he codes clear code.
+
+'
+    github_id: kou
+    twitter_id: ktou
+    gravatar_hash: 2d9386b1504e581be390af978e05a8b9
+  lctseng:
+    id: lctseng
+    name: Henry Tseng
+    bio: Software engineer at 5xruby.tw, Taipei, Taiwan. He is also a master student
+      at the Department of Computer Science and Information Engineering at National
+      Taiwan University, Taipei, Taiwan. He loves to create various applications from
+      low to high level using Ruby and Rails. In his free time, he uses RGSS (Ruby
+      Game Scripting System) to develop a large game project.
+    github_id: lctseng
+    twitter_id: lctseng
+    gravatar_hash: 0177cb9d87a24b0f12dca159d4d779dc
+  m_seki:
+    id: m_seki
+    name: Masatoshi SEKI
+    bio: Masatoshi Seki is a Ruby committer and the author of several Ruby standard
+      libraries including dRuby, ERB, and Rinda. He’s an expert in object-oriented
+      programming, distributed systems, and eXtreme programming. He has been speaking
+      at RubyKaigi every year since 2006 when the Kaigi first started.
+    github_id: seki
+    twitter_id: m_seki
+    gravatar_hash: 40f4d1f2e77078955bd01e9fb4a503ba
+  mametter:
+    id: mametter
+    name: Yusuke Endoh
+    bio: '''A MRI committer.  He has been interested in testing, code coverage, and
+      release management of MRI.  He is an advocate of "transcendental programming"
+      that creates a useless program like this bio.''.tap{|s|printf(t=%{''%s''.tap{|s|printf(t=%%{%s},s,t)}},s,t)}'
+    github_id: mame
+    twitter_id: mametter
+    gravatar_hash: e73159002200b33d51b7a6a312f2440e
+  masa16tanaka:
+    id: masa16tanaka
+    name: Masahiro TANAKA
+    bio: Research Fellow at CCS, University of Tsukuba. The author of NArray and Pwrake.
+    github_id: masa16
+    twitter_id: masa16tanaka
+    gravatar_hash: 2cadef577a1d0de8edc459a8b45da21f
+  matschaffer:
+    id: matschaffer
+    name: Mat Schaffer
+    bio: "I'm a volunteer with Safecast.org, an SRE with Elastic and a resident of
+      Gifu, Japan.\nI've been working in Ruby since 2006 and authored a number of
+      Ruby tools \n& resources including knife-solo."
+    github_id: matschaffer
+    twitter_id: matschaffer
+    gravatar_hash: 9b26cb404fe1fdae235e476c55fb2cdd
+  mrkn:
+    id: mrkn
+    name: Kenta Murata
+    bio: |-
+      A Ruby committer.  A BigDecimal maintainer.
+      I'm currently focusing on making Ruby a data-science-ready programming language.
+    github_id: mrkn
+    twitter_id: mrkn
+    gravatar_hash: 819b3c0a25f9708fd32261b8ae2d23f6
+  mtsmfm:
+    id: mtsmfm
+    name: Fumiaki MATSUSHIMA
+    bio: |-
+      Fumiaki is a developer at Quipper in Tokyo and an organizer of Nishinippori.rb.
+      He's mainly developing web applications with Ruby on Rails for Quipper.
+      His main interest is creating a productive development environment.
+    github_id: mtsmfm
+    twitter_id: mtsmfm
+    gravatar_hash: fb1b9f3d7332a7a7e262b70013b5f7dd
+  narittan:
+    id: narittan
+    name: Ritta Narita
+    bio: |-
+      Software Engineer at Treasure Data.Inc.
+      And he is a committer of fluentd/serverengine.
+    github_id: naritta
+    twitter_id: narittan
+    gravatar_hash: a9744697f9c3c315194115d530ac7b14
+  nateberkopec:
+    id: nateberkopec
+    name: Nate Berkopec
+    bio: 'Nate is the owner of Speedshop, a Ruby on Rails performance consultancy.
+      Nate has worked for several startups, including Craft Coffee (YC S14), Unwind
+      Me (YC S14), Scaffold (500 Startups), Branch (now a division of Facebook) and
+      many others. Nate is a contributor to several open source projects, such as
+      Ruby on Rails, Puma and Sentry. '
+    github_id: nateberkopec
+    twitter_id: 
+    gravatar_hash: 360db81fc4d83de5f6b6a13a398d4cb3
+  nirvdrum:
+    id: nirvdrum
+    name: Kevin Menard
+    bio: Kevin is a researcher at Oracle Labs where he works as part of a team developing
+      a high performance Ruby implementation called TruffleRuby. He’s been involved
+      with the Ruby community since 2008 and has been doing open source in some capacity
+      since 1999. In his spare time he’s a father of two and enjoys playing drums.
+    github_id: nirvdrum
+    twitter_id: nirvdrum
+    gravatar_hash: 303aae3354beb438eaa44000b1f2f3fd
+  nishimotz:
+    id: nishimotz
+    name: Takuya Nishimoto
+    bio: |-
+      A self-employed engineer in Hiroshima since 2011.
+      Director of NVDA Japanese Team, an open-source community for developing / translating free screen reader.
+      Doctor of Engineering (Waseda University)
+    github_id: nishimotz
+    twitter_id: 
+    gravatar_hash: e4d754d59634cbec671867f6afa4895c
+  nobyuki:
+    id: nobyuki
+    name: Nobuyuki Honda
+    bio: Vice-president of Ruby Programming Shounendan.
+    github_id: nobyuki
+    twitter_id: 
+    gravatar_hash: 22064db28321b01129834d19da7e14cc
+  onk:
+    id: onk
+    name: Takafumi ONAKA
+    bio: |-
+      https://github.com/onk/
+
+      Rails + iOS/Android programmer at Drecom Co., Ltd.
+      Ruby Kaja 2013
+    github_id: 
+    twitter_id: onk
+    gravatar_hash: f79eeaf69c0ec75a91525a823805c04b
+  p_ck_:
+    id: p_ck_
+    name: Masataka Kuwabara
+    bio: Software Engineer at Actcat Inc. / RuboCop contributor(100+ commits) / Reek
+      collaborator
+    github_id: pocke
+    twitter_id: p_ck_
+    gravatar_hash: 7f432d4a8aaadcea1ca77ec81a200121
+  rubylangorg:
+    id: rubylangorg
+    name: CRuby Committers
+    bio: CRuby committers all stars
+    github_id: 
+    twitter_id: rubylangorg
+    gravatar_hash: ce6d997265cefede13ee7e7e2a2cf9b2
+  rubymine:
+    id: rubymine
+    name: Valentin Fondaratov
+    bio: Having spent some time in ACM ICPC competitions, social network development
+      and bioinformatics, Valentin finally fulfilled himself helping other developers
+      write a better code. Now he is a RubyMine (Ruby/Rails IDE) team lead, but, more
+      importantly, JetBrains employee. Knows Java a little. Learning Kotlin and unicyclcing.
+    github_id: valich
+    twitter_id: rubymine
+    gravatar_hash: 3cb281372ce7485bdc5f261b5589f91f
+  shioyama:
+    id: shioyama
+    name: Chris Salzberg
+    bio: Rubyist and writer originally from Montreal living and working in Tokyo.
+      I'm the author of Mobility, a pluggable translation framework for Ruby. I work
+      with a team of developers at Degica building payment and e-commerce systems
+      for the Japanese and Asian markets.
+    github_id: shioyama
+    twitter_id: shioyama
+    gravatar_hash: eb7f91e7b7b3457ca57701a40f920f2a
+  shugomaeda:
+    id: shugomaeda
+    name: Shugo Maeda
+    bio: A Ruby committer, Director of Network Applied Communication Laboratory, and
+      Secretary general of the Ruby Association
+    github_id: shugo
+    twitter_id: shugomaeda
+    gravatar_hash: 18a797893e6768e048c1d15429f96bb4
+  soutaro:
+    id: soutaro
+    name: Soutaro Matsumoto
+    bio: Soutaro is a software engineer working for SideCI, spending his time to develop
+      program analysis for code review automation.
+    github_id: soutaro
+    twitter_id: soutaro
+    gravatar_hash: 1fab9d01b25e99522f3dfd01e3d4cb51
+  tagomoris:
+    id: tagomoris
+    name: Satoshi "moris" Tagomori
+    bio: |-
+      OSS developer/maintainer: Fluentd, Norikra, MessagePack-Ruby, Woothee and many others mainly about Web services, data collecting and distributed/streaming data processing.
+      Living in Tokyo, and day job is for Treasure Data.
+    github_id: tagomoris
+    twitter_id: tagomoris
+    gravatar_hash: 002525eada5741b7954ce22c1a066d32
+  takaokouji:
+    id: takaokouji
+    name: Kouji Takao
+    bio: President of Ruby Programming Shounendan.
+    github_id: takaokouji
+    twitter_id: 
+    gravatar_hash: 27d6abf0da4a77876e00fa4a0475526a
+  tanaka_akr:
+    id: tanaka_akr
+    name: Tanaka Akira
+    bio: |-
+      Ruby committer,
+      Researcher of National Institute of Advanced Industrial Science and Technology (AIST)
+    github_id: 
+    twitter_id: tanaka_akr
+    gravatar_hash: b11f10c4cd9d53970e7be20caa43f940
+  tenderlove:
+    id: tenderlove
+    name: Aaron Patterson
+    bio: Aaron works for GitHub.  He is on the Ruby core team, the Rails core team,
+      and the team that takes care of his cat, Gorby puff.   Someday he will find
+      the perfect safety gear to wear while extreme programming.
+    github_id: tenderlove
+    twitter_id: tenderlove
+    gravatar_hash: f29327647a9cff5c69618bae420792ea
+  tom_enebo:
+    id: tom_enebo
+    name: Thomas E Enebo
+    bio: Thomas Enebo co-leads the JRuby project. He has been passionately working
+      on JRuby for many years. When not working on JRuby, he is writing Ruby applications,
+      playing with Java, and enjoying a decent beer.
+    github_id: enebo
+    twitter_id: tom_enebo
+    gravatar_hash: 13313ac2ec7ba7c43b1b952db034ff3b
+  v0dro:
+    id: v0dro
+    name: Sameer Deshmukh
+    bio: |-
+      Sameer is a student and a contributor to the Ruby Science Foundation, where he helps build scientific computation tools in Ruby. He is currently working on Rubex, a new language for easily writing C extensions for the CRuby interpreter.
+
+      He enjoys spending spare time with friends, books and his bass guitar.
+    github_id: v0dro
+    twitter_id: v0dro
+    gravatar_hash: 5083e35c5075b75473919524286239b3
+  watson1978:
+    id: watson1978
+    name: Shizuo Fujita
+    bio: |-
+      Shizuo Fujita
+
+      Engineer in Ubiregi, Inc.
+      A newbie of ruby committer.
+    github_id: Watson1978
+    twitter_id: watson1978
+    gravatar_hash: 6e8aca910e7ee095397d3b90acb25f6c
+  yhara:
+    id: yhara
+    name: Yutaka HARA
+    bio: Rubyist since 2000 (Ruby 1.4.6). Works for Network Applied Communication
+      Laboratory. Is not a Ruby committer.
+    github_id: yhara
+    twitter_id: yhara
+    gravatar_hash: 26e1ba9a02729b2d6013604135221aae
+  yotii23:
+    id: yotii23
+    name: YUKI TORII
+    bio: a Rails Developer. translated "Hello Ruby" series, programming picture books
+      for children written by Linda Liukas, and "Programming Elixir" written by Dave
+      Thomas into Japanese. one of the members of RailsGirls in JP.
+    github_id: yakitorii
+    twitter_id: yotii23
+    gravatar_hash: 12c47daebe971e49aec5f449e347ab0f
+  youchan:
+    id: youchan
+    name: Yoh Osaki
+    bio: |-
+      Software engineer at Ubiregi inc.
+      Author of Hyalite which is react like virtual DOM library.
+      Member of Asakusa.rb, Chidoriashi.rb
+    github_id: youchan
+    twitter_id: youchan
+    gravatar_hash: b54abc5e7463fe6470c379e97e3f2477
+  yuki24:
+    id: yuki24
+    name: Yuki Nishijima
+    bio: Yuki is a Rubyist who was raised in Tokyo and a software engineer at Artsy
+      in New York. He is a Ruby committer, the creator of the did_you_mean gem, maintainer
+      of the Kaminari gem, and frequent contributor to many open source projects including
+      Rails.
+    github_id: yuki24
+    twitter_id: yuki24
+    gravatar_hash: 6c7e6a8c3623300cf8992df120e6c2c1
+  yuri_at_earth:
+    id: yuri_at_earth
+    name: Yurie Yamane
+    bio: |-
+      "nora" mrubyist.
+      A member of Team Yamanekko.
+      A member of TOPPERS Project.
+    github_id: yurie
+    twitter_id: yuri_at_earth
+    gravatar_hash: 0607f2778a478327d55f9b4fb7954a60
+  zverok:
+    id: zverok
+    name: Victor Shepelev
+    bio: |-
+      Ukrainian programmer and poet with more than fifteen years of programming experience and ten years of Ruby programming.
+
+      Working at Toptal, mentoring students (including Google Summer of Code-2016/2017, as a mentor for SciRuby organization), developing open source (Ruby Association Grant 2015).
+    github_id: zverok
+    twitter_id: zverok
+    gravatar_hash: 509bf3f9358421fc8ffdfa549099dfd4

--- a/2018/data/presentations.yml
+++ b/2018/data/presentations.yml
@@ -1,0 +1,908 @@
+---
+yukihiro_matz:
+  title: Proverbs
+  type: keynote
+  language: JA
+  description: Matz's keynote
+  speakers:
+  - id: yukihiro_matz
+  video:
+    youtube_id: zb8dXWYUX10
+tenderlove:
+  title: Analyzing and Reducing Ruby Memory Usage
+  type: presentation
+  language: JA
+  description: |-
+    Memory usage can be difficult to analyze.  In this presentation we will cover
+    different techniques for analyzing memory usage of a Ruby process including
+    in-process analysis tools as well as system level tools.  After doing memory
+    analysis, we'll look at some ways to reduce overall memory used by the system.
+    Attendees will leave with practical tips and tricks for memory analysis in
+    their Ruby systems, as well as a better understanding of Ruby internals.
+  speakers:
+  - id: tenderlove
+  materials:
+    - title: Reducing Memory Usage in Ruby
+      url: https://speakerdeck.com/tenderlove/reducing-memory-usage-in-ruby
+  video:
+    youtube_id: ILzQYMDp18o
+kurotaky:
+  title: 'bancor: Token economy made with Ruby'
+  type: presentation
+  language: JA
+  description: |-
+    There is a protocol called "Bancor Protocol" which is said to bring about automation of token liquidity and transaction price finding in Smart Contract.
+
+    To verify the usefulness of this protocol in your project, it is costly to write a smart contract program and implement the application.
+
+    When implementing applications with Ruby, I am making gem "bancor" to easily introduce and verify the Bancor Protocol.
+
+    In this presentation, we will talk about how developers build "token economy" on Ruby application using "bancor" and how to quickly verify effect.
+  speakers:
+  - id: kurotaky
+  materials:
+    - title: 'bancor: Token economy made with Ruby'
+      url: https://speakerdeck.com/kurotaky/bancor-token-economy-made-with-ruby
+  video:
+    youtube_id: gqBWoyMdn4c
+maciejmensfeld:
+  title: Karafka - Ruby Framework for Event Driven Architecture
+  type: presentation
+  language: EN
+  description: Karafka allows you to capture everything that happens in your systems
+    in large scale, providing you with a seamless and stable core for consuming and
+    processing this data, without having to focus on things that are not your business
+    domain. Have you ever tried to pipe data from one application to another, transform
+    it and send it back? Have you ever wanted to decouple for existing code base and
+    make it much more resilient and flexible? Come and learn about Karafka, where
+    it fits in your existing projects and how to use it as a messages backbone for
+    a modern, distributed and scalable ecosystem.
+  speakers:
+  - id: maciejmensfeld
+  materials:
+    - title: Karafka - Ruby Framework for Event Driven Architecture
+      url: https://mensfeld.github.io/karafka-ruby-kaigi-2018/index.html#/
+  video:
+    youtube_id: bzvb1u_kSro
+mrkn:
+  title: Deep Learning Programming on Ruby
+  type: presentation
+  language: JA
+  description: |-
+    We will present you how to program deep learning models with a practical performance by Ruby language.
+    We will use Apache MXNet and Red Chainer from Ruby.  While Apache MXNet is available through pycall.rb, they will be used directly from Ruby without such bridge system in this talk.
+    Our demonstrations will show you that Ruby is ready to do such tasks.
+
+    Additionally, we will show you the latest progress and the future forecasts of the projects that aim to make Ruby available in data science field.
+  speakers:
+  - id: mrkn
+  - id: hatappi
+  materials:
+    - title: Deep Learning Programming on Ruby
+      url: https://speakerdeck.com/mrkn/deep-learning-programming-on-ruby
+  video:
+    youtube_id: J-d_Lk4SFtQ
+joker1007:
+  title: Hijacking Ruby Syntax in Ruby
+  type: presentation
+  language: JA
+  description: |-
+    This talk shows how to introduce new syntax-ish stuffs using meta programming techniques and some more Ruby features not known well by many Rubyists. Have fun with magical code!
+
+    - Show Ruby features to hack Ruby syntax (including Binding, TracePoint, Refinements, etc)
+    - Describe stuffs introduced by these techniques
+      - method modifiers (final, abstract, override)
+      - Table-like syntax for testing DSL
+      - Safe resource allocation/collection (with, defer)
+    - Propose new traceable events, hooks, etc
+  speakers:
+  - id: joker1007
+  - id: tagomoris
+  materials:
+    - title: Hijacking Ruby Syntax in Ruby
+      url: https://www.slideshare.net/tagomoris/hijacking-ruby-syntax-in-ruby
+  video:
+    youtube_id: 04HGQEw3A6Y
+DarkDimius:
+  title: A practical type system for Ruby at Stripe.
+  type: presentation
+  language: EN
+  description: |-
+    At Stripe, we believe that a typesystem provides substantial benefits for a big codebase. They :
+
+     - are documentation that is always kept up-to-date;
+     - speed up the development loop via faster feedback from tooling;
+     - help discover corner cases that are not handled by the happy path;
+     - allow building tools that expose knowledge obtained through type-checking, such as "jump to definition".
+
+    We have built a type system that is currently being adopted by our Ruby code at stripe. This typesystem can be adopted gradually with different teams and projects adopting it at a different pace. We support And and OrTypes as well as basic generics. Our type syntax that is backwards compatible with untyped ruby.
+
+    In this talk we describe our experience in developing and adopting a type system for our multi-million line ruby codebase. We will also discuss what future tools are made possible by having knowledge about types in the code base.
+  speakers:
+  - id: DarkDimius
+  - id: ptarjan
+  - id: nelhage
+  materials:
+    - title: "Sorbet: A Typechecker for Ruby"
+      url: https://sorbet.run/talks/RubyKaigi2018/
+  video:
+    youtube_id: eCnnBS2LXcI
+bbatsov:
+  title: All About RuboCop
+  type: presentation
+  language: EN
+  description: |-
+    In this talk we'll go over everything you need  to know about RuboCop - a powerful Ruby static code analyzer
+    that makes it easy for you to enforce a consistent code style throughout your Ruby projects.
+
+    We'll begin by
+    examining the events that lead to the creation of RuboCop, its early days and its evolution, effective RuboCop usage
+    and some of its cool but little-known features. Then we'll continue with a brief look into RuboCop's internals and show you how easy it is
+    to extend its functionality.
+
+    We'll wrap the talk with a glimpse inside RuboCop's future and discuss some of the challenges the project faces and some of the work that remains to be done, before RuboCop finally reaches
+    the coveted 1.0 version.
+  speakers:
+  - id: bbatsov
+  materials:
+    - title: All About RuboCop
+      url: https://speakerdeck.com/bbatsov/all-about-rubocop-rubykaigi-2018
+  video:
+    youtube_id: nrHjVCuVsGA
+piotr_murach:
+  title: TTY - Ruby alchemist’s secret potion
+  type: presentation
+  language: EN
+  description: What if you were told that there is a set of simple and potent gems
+    developed to exponentially increase productivity when building modern terminal
+    applications such as Bundler, in next to no time? Curious about how you can harness
+    this power and become a command line applications alchemist?
+  speakers:
+  - id: piotr_murach
+  materials:
+    - title: TTY - Ruby alchemist’s secret potion
+      url: https://speakerdeck.com/piotrmurach/tty-ruby-alchemists-secret-potion
+  video:
+    youtube_id: AeUls-THfpQ
+_st0012:
+  title: What would your own version of Ruby look like?
+  type: presentation
+  language: EN
+  description: "I believe most of us love Ruby, but I also believe most of us don't
+    think Ruby is perfect. So what'd your own version of Ruby look like if you can
+    create one?\n\nAs some of you may know, I created a language called Goby about
+    a year ago. It's largely inspired by Ruby, and looks very similar to it. But it
+    also have some design choices different than Ruby or have some unique features
+    that Ruby doesn't have. \n\nIn this talk I'm going to discuss some important things
+    we should focus on when designing a language. And I will also share the design
+    choices made when developing Goby, as well as the philosophy behind these choices."
+  speakers:
+  - id: _st0012
+  materials:
+    - title: What would your own version of Ruby look like?
+      url: https://www.slideshare.net/LoStan/what-would-your-own-version-of-ruby-look-like-rubykaigi
+  video:
+    youtube_id: ldqb5u4pQb0
+sonots:
+  title: Fast Numerical Computing and Deep Learning in Ruby with Cumo
+  type: presentation
+  language: JA
+  description: |-
+    Ruby is far behind than other languages such as Python in scientific computing. One reason is because there is no fast numerical library in Ruby.
+
+    I have made a high speed numerical library for Ruby using CUDA named "Cumo". In this talk, I describe:
+
+    * Overview of Scientific Computing in Ruby
+    * Basic knowledge of GPU programming
+    * Cumo inside, such as
+      * Writing fast CUDA kernel
+      * Implementing GPU memory pool
+      * JIT compiling user-defined kernel
+    * Performance comparison with Numo in an emerging DNN framework written in Ruby, red-chainer
+  materials:
+    - title: Fast Numerical Computing and Deep Learning in Ruby with Cumo
+      url: https://speakerdeck.com/sonots/fast-numerical-computing-and-deep-learning-in-ruby-with-cumo
+  speakers:
+  - id: sonots
+  video:
+    youtube_id: osUvCcwMFnc
+hsbt:
+  title: RubyGems 3 & 4
+  type: presentation
+  language: JA
+  description: |-
+    The RubyGems is a mechanism to install libraries via the Internet without standard libraries. As maintenance manager of RubyGems and core member of Ruby core team, I'm working to merge the latest version of RubyGems with a latest stable version of ruby every year.
+
+    In this presentation, I will introduce the new feature of RubyGems 2.7 and describe the mechanism of integration with Bundler. Finally, I introduce a roadmap for RubyGems 3 and 4, which is developing for Ruby 2.6 and 3 release.
+
+    Through this talk, you will be able to enjoy the ruby world more by understanding RubyGems at the center of ruby's ecosystem.
+  speakers:
+  - id: hsbt
+  materials:
+    - title: RubyGems 3 & 4
+      url: https://www.slideshare.net/hsbt/rubygems-3-4
+  video:
+    youtube_id: wuyhit3-_xA
+thibaut_barrere:
+  title: Kiba 2 - Past, present & future of data processing with Ruby
+  type: presentation
+  language: EN
+  description: |-
+    Kiba ETL (http://www.kiba-etl.org) is a lightweight, generic data processing framework for Ruby, initially released in 2015 & now in v2.
+
+    In this talk, I'll highlight why Kiba was created, how it is used for low-maintenance data preparation and processing in the enterprise (illustrated by many different use cases), why and how the version 2 (leveraging Ruby's Enumerator) brings a massive improvement in authoring reusable & composable data processing components, and why I'm optimistic about the future of data processing with Ruby.
+  speakers:
+  - id: thibaut_barrere
+  materials:
+    - title: Kiba ETL v2
+      url: https://speakerdeck.com/thbar/kiba-etl-v2-rubykaigi-2018
+  video:
+    youtube_id: fxVtbog7pIQ
+Yuryu:
+  title: Exploring Internal Ruby Through C Extensions
+  type: presentation
+  language: JA
+  description: You may have wondered how Ruby objects are represented in the CRuby
+    code. Not really? I would say writing a C extension is a great way to explore
+    and learn how CRuby handles different object types. This session will re-implement
+    our own Hash class, explain basic types in the CRuby, compare performance between
+    native Hash, pure C++ implementation, and the C extension version, and discuss
+    memory layouts and consumption in Ruby. The audience will also become more comfortable
+    with the CRuby code through this session. Experience with C is not required.
+  speakers:
+  - id: Yuryu
+  materials:
+    - title: Exploring Internal Ruby Through C Extensions
+      url: https://speakerdeck.com/yuryu/exploring-internal-ruby-through-c-extensions
+  video:
+    youtube_id: Om_cm120t1E
+p_ck_:
+  title: A parser based syntax highlighter
+  type: presentation
+  language: JA
+  description: |-
+    > It has an elegant syntax that is natural to read and easy to write.
+    > https://www.ruby-lang.org/en/
+
+    Definitely. The syntax is elegant. But it is too complex sometimes. So, syntax highlighters for Ruby are difficult and easy to break.
+    For example, probably your editor cannot correctly highlight `????::?:`, `% %s%% %%%%` or `def end(def:def def;end)end` (They are **valid** Ruby programs!).
+    Yeah, it is edge cases. In real cases, some syntax highlighter cannot correctly highlight a here document.
+
+    I'll talk a robust syntax highlighter for Ruby, it is Iro gem and Iro.vim.  The highlighter never break since it uses Ripper to highlight code.
+  speakers:
+  - id: p_ck_
+  materials:
+    - title: A parser based syntax highlighter
+      url: https://speakerdeck.com/pocke/a-parser-based-syntax-highlighter
+  video:
+    youtube_id: 8tarr2k0kMI
+anton_davydov:
+  title: Architecture of hanami applications
+  type: presentation
+  language: EN
+  description: |-
+    The general part of any web application is business logic. Unforchanotly, it's really hard to find a framework with specific rules and explanations how to work with it. In hanami, we care about long-term maintenance that's why it's really important to us how to work with business logic.
+
+    In my talk, I'll share my ideas how to store and work with business logic in hanami apps. We will talk about hanami, dry and some architecture ideas, like event sourcing. This talk will be interesting for any developers. If you work with other frameworks you can take these ideas and my it to your project.
+  speakers:
+  - id: anton_davydov
+  materials:
+    - title: Architecture of hanami applications
+      url: https://speakerdeck.com/davydovanton/architecture-of-hanami-applications
+  video:
+    youtube_id: Rcbqa0QFXJQ
+ktou:
+  title: My way with Ruby
+  type: keynote
+  language: JA
+  description: |-
+    Here are my activities as a Rubyist:
+
+      * Increase what Ruby can do with free software
+      * Maintain libraries
+
+    In this talk, I introduce my activities.
+  speakers:
+  - id: ktou
+  materials:
+    - title: My way with Ruby
+      url: https://slide.rabbit-shocker.org/authors/kou/rubykaigi-2018/
+  video:
+    youtube_id: d7lDhsE1jXg
+hone02:
+  title: Controlling Droids™ with mruby & Go
+  type: presentation
+  language: EN
+  description: |-
+    Ruby has never been at the forefront of dealing with robots, IoT, or other low level systems. What Ruby is great at is scripting and building DSLs. Using mruby we can leverage existing ecosystems while still using the language we love.
+
+    In this talk, we'll deep dive into how we can execute mruby handlers inside a Go event reactor to control a Sphero R2-D2. With surprisingly few lines of code, you can coordinate motors, lights, and sound concurrently. Come learn about mruby & robotics and see the Droids™ you're looking for in action.
+  speakers:
+  - id: hone02
+  - id: code0100fun
+  materials:
+    - title: A Droid's Journey
+      url: https://speakerdeck.com/hone/a-droids-journey-rubykaigi-2018
+  video:
+    youtube_id: NhQovmLaHfY
+wyhaines:
+  title: It's Rubies All The Way Down
+  type: presentation
+  language: EN
+  description: Ruby is a language with expansive capabilities. One of it's main niches
+    is with web application work. Typically, Ruby is used exclusively in the application
+    container/application layer, with other technologies providing the rest of the
+    stack. Ruby can fill other roles in the application stack, though, so for fun,
+    let's explore a stack that is composed of Ruby software from top to bottom. What
+    would that look like? How would it perform? Why would you do this?
+  speakers:
+  - id: wyhaines
+  materials:
+    - title: It's Rubies All The Way Down
+      url: https://slides.com/wyhaines/its-rubies-all-the-way-down
+  video:
+    youtube_id: _rwfsse7OYk
+codefolio:
+  title: 'Faster Apps, No Memory Thrash: Get Your Memory Config Right'
+  type: presentation
+  language: EN
+  description: |-
+    The Ruby memory system can be tricky. Configuring it isn't easy. I'll show you a new simple tool to optimize your Ruby binary's memory settings.
+    You'll learn about the CRuby memory resources and how you check them. Let's optimize your memory usage to keep memory small and keep garbage collection fast.
+  speakers:
+  - id: codefolio
+  materials:
+    - title: Faster Apps, No Memory Thrash
+      url: https://docs.google.com/presentation/d/1-WrYwz-QnSI9yeRZfCCgUno-KOMuggiGHlmOETXZy9c
+  video:
+    youtube_id: Z4nBjXL-ymI
+ko1:
+  title: Guild Prototype
+  type: presentation
+  language: EN
+  description: |-
+    RubyKaigi 2016, I proposed a new concurrency abstraction named Guild for Ruby 3.
+    Guild will achieve safe concurrency programming and parallel computation.
+    We are making prototype of Guild. This talk will introduce Guild concepts and evaluation with prototype of Guild.
+    Also we are discussing about the name of "Guild" to find out the another appropriate name. I will introduce the discussion of this "naming battle".
+  speakers:
+  - id: ko1
+  materials:
+    - title: Guild Prototype
+      url: https://www.slideshare.net/KoichiSasada/guild-prototype
+  video:
+    youtube_id: BO8ThL2H3tc
+koic:
+  title: Improve Ruby coding style rules and Lint
+  type: presentation
+  language: JA
+  description: |-
+    This talk describes improving a Ruby coding style rules and Lint when using RuboCop.
+
+    Opportunities for using static analysis tools to unify coding style within a repository are not uncommon. However, the real world is not unified by the sole coding rule. Even so, we can approach the coding rule that we think is better. I'd like to talk about that in this topic.
+  speakers:
+  - id: koic
+  materials:
+    - title: Improve Ruby coding styles and Lint
+      url: https://speakerdeck.com/koic/improve-ruby-coding-styles-and-lint
+  video:
+    youtube_id: W4ZvpNpKWXo
+Edouard-chin:
+  title: Journey of a complex gem upgrade
+  type: presentation
+  language: EN
+  description: |-
+    Although every gem bump should be done carefully and with attention, most of the time it’s just a matter of running the `bundle update` command, look at the CHANGELOG, and maybe fix couple tests failing due to the upgrade.
+    But what about upgrading a gem whom introduced a lot of breaking changes in the new version?
+    The upgrade could cause hundreds if not thousands of your existing tests to fail.
+
+    In this talk I’d like to share the different techniques and strategies that will allow you to upgrade any dependency smoothy and safely.
+  speakers:
+  - id: Edouard-chin
+  materials:
+    - title: Journey of a complex gem upgrade
+      url: https://speakerdeck.com/edouardchin/journey-of-a-complex-gem-upgrade
+  video:
+    youtube_id: Lu5aHMxldmg
+m_seki:
+  title: extend your own  programming language
+  type: presentation
+  language: JA
+  description: |-
+    書籍「RubyでつくるRuby」はRubyの（極小の）サブセットMinRubyをRubyで実装しながら、Rubyとプログラミング言語とインタプリタを学ぶ本です。入門者にとって、フルセットのRubyを改造するのはちょっと難しいですが、MinRubyのサイズならちょうどよい教材です。MinRubyを拡張し自分の言語を作ることで得られる万能感は格別です。
+    本講演では、MinRubyを拡張してRuby自体に新しい機能を追加する例を紹介します。末尾呼び出し最適化、実行コンテキストの別プロセスへ移送、変数操作のフックなど、ライブラリだけで実装するのは難しいRubyの変種を示します。
+  speakers:
+  - id: m_seki
+  materials:
+    - title: Extend your own programming language
+      url: https://speakerdeck.com/m_seki/extend-your-own-programming-language-rubykaigi-2018
+  video:
+    youtube_id: FXELyEXajD4
+yuri_at_earth:
+  title: mruby can be more lightweight
+  type: presentation
+  language: JA
+  description: |-
+    mruby is called “lightweight Ruby”, but in fact it consumes rather much RAM memory.
+
+    In this talk, I will explain a proposal of implementation to use ROM instead of RAM.  In addition, I will talk about some configurations for reducing RAM usage.
+
+    I also demonstrate using an evaluation board (RAM:96 KB) which became available as a result of reducing RAM usage.
+  speakers:
+  - id: yuri_at_earth
+  materials:
+    - title: mruby can be more lightweight
+      url: https://www.slideshare.net/yamanekko/mruby-can-be-more-lightweight-102604291
+  video:
+    youtube_id: sFz5-xGTEbI
+jules2689:
+  title: Scaling Teams using Tests for Productivity and Education
+  type: presentation
+  language: EN
+  description: As Ruby organizations scale, more developers join the team. More developers
+    makes it increasingly difficult to enforce code styles, follow best practices,
+    and document mistakes that were made without relying on word of mouth. While we
+    have tools, such as Rubocop, to check some stylistic components, we lack tooling
+    to document issues and best practices. This talk focuses on strategies and solutions,
+    particularly around best practices, that we employ to help educate and accelerate
+    nearly a thousand developers, without getting in their way, by providing them
+    information “just in time”.
+  speakers:
+  - id: jules2689
+  materials:
+    - title: Avoiding Cognitive Overload - Tests for Productivity and Education
+      url: https://docs.google.com/presentation/d/1T1uPY1QX9B-UacA8AuGaDbxWZu8AYnYUC2FzyZmfeag
+  video:
+    youtube_id: InFnu8bYi6s
+soutaro:
+  title: Ruby Programming with Type Checking
+  type: presentation
+  language: EN
+  description: |-
+    Last year, I had a presentation to introduce Steep, a type checker for Ruby. However, the implementation is so experimental that it cannot be used for production at all.
+
+    In this talk, I will report the nine months progress of the project and share the experience how the tool helps Ruby programming.
+  speakers:
+  - id: soutaro
+  materials:
+    - title: Ruby Programming with Type Checking
+      url: https://speakerdeck.com/soutaro/ruby-programming-with-type-checking
+  video:
+    youtube_id: QK_v0XN8kXc
+hasumon:
+  title: Firmware programming with mruby/c
+  type: presentation
+  language: JA
+  description: |-
+    We have a new choice to write firmware for microcomputers(microcontrollers). It's mruby/c.
+    This talk shows how to introduce mruby/c firmware programming. And besides, my actual IoT project for Japanese Sake brewery will be described.
+    Since mruby/c is still a young growing tool, you will know there are several(many?) things you can help it to become better.
+  speakers:
+  - id: hasumon
+  materials:
+    - title: Firmware programming with mruby/c
+      url: https://slide.rabbit-shocker.org/authors/hasumikin/rubykaigi2018/
+  video:
+    youtube_id: ng0N0761N3c
+v0dro:
+  title: 'Ferrari Driven Development: superfast Ruby with Rubex'
+  type: presentation
+  language: EN
+  description: |-
+    Did you ever really really want to speed up your Ruby code with C extensions but got baffled by mountains of documentation and scary C programming and chose to move to another language instead? Did you wish that you could just release that GIL and extract all the juice that your processor has to offer without losing your hair? If yes, then come see this talk!
+
+    This talk will introduce you to Rubex, the fastest and happiest way of writing Ruby C extensions. Rubex is a whole new language designed from the ground up keeping in mind Ruby's core philosophy - make programmers happy.
+  speakers:
+  - id: v0dro
+  materials:
+    - title: 'Ferrari Driven Development: superfast Ruby with Rubex'
+      url: https://speakerdeck.com/v0dro/ferrari-driven-development-superfast-ruby-with-rubex
+  video:
+    youtube_id: 7edbdHZvr8k
+spikeolaf:
+  title: RNode with code positions
+  type: presentation
+  language: JA
+  description: |-
+    This talk describes about code positions on Ruby.
+
+    Code positions are new location information of AST Nodes, introduced from Ruby 2.5.
+    Code positions enable us to improve warning messages, exception messages, `Proc#source_location` and so on.
+
+    This talk includes the following topics.
+
+    * What code positions are.
+    * Why they are needed.
+    * How they are implemented.
+  speakers:
+  - id: spikeolaf
+  materials:
+    - title: RNode with code locations
+      url: https://speakerdeck.com/yui_knk/rnode-with-code-locations
+  video:
+    youtube_id: YjmBJg52aws
+udzura:
+  title: How Ruby Survives in the Cloud Native World
+  type: presentation
+  language: EN
+  description: |-
+    The container orchestration technology is attracting the Ops/SRE's attention along with the gaining importance of microservices and server-less architecture. But in my opinion, around these "cloud-native" developments, the Ruby language shows smaller activities than other younger languages(especially Go and Rust).
+    By the way, in 2016, I created a container runtime Haconiwa with mruby. In 2017, I also scratched up the containers platform for my company's web hosting service using Ruby and mruby in many components. Here in 2018, I'm going to create the brand-new container orchestration tool fully implemented in Ruby and mruby.
+    I will talk about how I used Ruby and mruby in these container and orchestration implementations.  In addition, I will show my opinion about what kind of Ruby's features are good for these implementations, and what kind of features are required for cloud-native Ruby.
+  speakers:
+  - id: udzura
+  materials:
+    - title: How Ruby Survives in the Cloud Native World
+      url: https://speakerdeck.com/udzura/how-ruby-survives-in-the-cloud-native-world
+  video:
+    youtube_id: 7Anlio4nnng
+gsamokovarov:
+  title: Implementing Web Console
+  type: presentation
+  language: EN
+  description: |-
+    Web Console is a debugging tool bundled with Rails. The most popular feature is a console that is shown in every development error, however, it is a general purpose debugging tool that let you execute Ruby code in any binding as it runs, through its web UI.
+
+    In this talk, we'll take a look at how the web-console gem is implemented. This includes a deep dive into how exceptions in Ruby work; how to build Ruby bindings for every part of an exception backtrace, so we can execute code in them; how we interact with the DebugInspector and TracePoint C APIs to make this possible and how we supported alternative Ruby implementations like JRuby.
+  speakers:
+  - id: gsamokovarov
+  materials:
+    - title: Implementing Web Console
+      url: https://kaigi-implementing-web-console.herokuapp.com/
+  video:
+    youtube_id: OCjc0RH5epY
+mrkn2:
+  title: RubyData Workshop (1)  Data Science in Ruby
+  type: presentation
+  language: EN
+  description: |-
+    - Data analysis hands on using Ruby's data tools
+    - Data analysis hands on using pycall.rb and Python data tools
+  speakers:
+  - id: mrkn2
+mametter:
+  title: 'Type Profiler: An analysis to guess type signatures'
+  type: presentation
+  language: JA
+  description: |-
+    After matz set Ruby 3 goals including static analysis, its requirements (and compromises) have been revealed gradually.  We review the current status as far as we know, briefly survey some existing proposals and implementations related to type checking for Ruby, and clarify what is good and what is missing.
+
+    Based on this survey, we prototype a type profiler, one of the missing parts for Ruby type checking system.  A type profiler analyzes existing Ruby programs statically and dynamically, and creates a stub of type definitions.  We discuss its design and show some experiment results.
+  speakers:
+  - id: mametter
+  materials:
+    - title: 'Type Profiler: An Analysis to guess type signatures'
+      url: https://www.slideshare.net/mametter/type-profiler-an-analysis-to-guess-type-signatures
+  video:
+    youtube_id: U6mKwwO7QCg
+scalone:
+  title: 20k MRuby devices in production
+  type: presentation
+  language: EN
+  description: |-
+    I've changed an entire solid runtime for mRuby, and for 3 years, even if is not recommend, we've been running mRuby in production reaching 20k machines and billons of dollars in payment transactions. We faced a lot of problems, but even more benefits adopting mRuby. This talk is about those topics, like:
+
+    - Runtime and application Update/Upgrade
+    - Communication configuration and intelligence
+    - Payment transaction security and cryptography
+    - Concurrency
+    - Code sharing between CRuby and mRuby
+    - Memory management and leaks
+    - Open Source
+  speakers:
+  - id: scalone
+  materials:
+    - title: 20k mRuby devices in Production
+      url: https://speakerdeck.com/scalone/20k-mruby-devices-in-production
+  video:
+    youtube_id: vMjT2DqV_vw
+palkan_tula:
+  title: One cable to rule them all
+  type: presentation
+  language: EN
+  description: |-
+    Modern web applications actively use real-time features. Unfortunately, nowadays Ruby is rarely considered as a technology to implement yet another chat – Ruby performance leaves much to be desired when dealing with concurrency and high-loads.
+
+    Does this mean that we should betray our favorite language, which brings us happiness, in favor of others?
+
+    My answer is NO, and I want to show you, how we can combine the elegance of Ruby with the power of other languages to improve the performance of real-time applications.
+  speakers:
+  - id: palkan_tula
+  materials:
+    - title: 'AnyCable: One cable to rule them all'
+      url: https://speakerdeck.com/palkan/rubykaigi-2018-anycable-one-cable-to-rule-them-all
+  video:
+    youtube_id: jXCPuNICT8s
+ktou2:
+  title: RubyData Workshop (2)  Red Data Tools Lightning Talks
+  type: presentation
+  language: EN
+  description: "- The members of Red Data Tools will present short presentations about
+    their development activities in Red Data Tools."
+  speakers:
+  - id: ktou2
+rubylangorg:
+  title: Ruby Committers vs the World
+  type: presentation
+  language: JA
+  description: Ruby core committers on stage!
+  speakers:
+  - id: rubylangorg
+  video:
+    youtube_id: dhHAaybjCfE
+eregontp:
+  title: Parallel and Thread-Safe Ruby at High-Speed with TruffleRuby
+  type: keynote
+  language: EN
+  description: |-
+    Array and Hash are used in every Ruby program. Yet, current implementations either prevent the use of them in parallel (the global interpreter lock in MRI) or lack thread-safety guarantees (JRuby raises an exception on concurrent Array#<<). Concurrent::Array from concurrent-ruby is thread-safe but prevents parallel access.
+
+    This talk shows a technique to make Array and Hash thread-safe while enabling parallel access, with no penalty on single-threaded performance. In short, we keep the most important thread-safety guarantees of the global lock while allowing Ruby to scale up to tens of cores!
+  speakers:
+  - id: eregontp
+  materials:
+    - title: Parallel and Thread-Safe Ruby at High-Speed with TruffleRuby
+      url: https://speakerdeck.com/eregon/parallel-and-thread-safe-ruby-at-high-speed-with-truffleruby
+  video:
+    youtube_id: mRKjWrNJ8DI
+sugiyama-k:
+  title: Grow and Shrink - Dynamically Extending the Ruby VM Stack
+  type: presentation
+  language: JA
+  description: |-
+    Currently, MRI (the reference implementation of Ruby) allocates 1MB of stack space for each thread. This is clearly sub-optimal, in particular for highly multi-threaded applications.
+
+    We have successfully implemented dynamical stack extension for MRI, starting with a very small stack size and growing each stack only when needed. We will present two different implementations, one very close to the current stack structure, and one with a different stack structure. We will also explain how we made sure that our implementation is stable. On Linux, we achieve a memory reduction per thread of up to 30%, at the cost of an average speed increase (measured across all Ruby benchmarks) of 6%.
+  speakers:
+  - id: sugiyama-k
+  - id: duerst
+  materials:
+    - title: Grow and Shrink - Dynamically Extending the Ruby VM Stack
+      url: https://www.slideshare.net/KeitaSugiyama1/grow-and-shrink-dynamically-extending-the-ruby-vm-stack
+  video:
+    youtube_id: hjTw0T220zs
+kn1kn1:
+  title: Ruby code from the stratosphere - SIAF, Sonic Pi, Petal
+  type: presentation
+  language: JA
+  description: |-
+    Last year I participated in a project called [space-moere](http://space-moere.org/) of [SIAF2017](http://siaf.jp/en/) (Sapporo International Art Festival 2017). In the project we received [Sonic Pi](http://sonic-pi.net/) code generated in the stratosphere and had live performance using it. For the live performance, I made a small language called [Petal](https://github.com/siaflab/petal).
+
+    In this session, I will talk about the topics as follows:
+
+    * space-moere project
+    * Petal
+    * some projects based on it (Sonic Pi and TidalCycles)
+
+    Session Notes: https://gist.github.com/kn1kn1/c28f8029ba5ee069d83b8b6a6c4c8543
+  speakers:
+  - id: kn1kn1
+  materials:
+    - title: Ruby code from the stratosphere - SIAF, Sonic Pi, Petal
+      url: https://github.com/kn1kn1/rubykaigi2018/blob/master/slide/ruby-code-from-the-stratosphere.pdf
+  video:
+    youtube_id: amn6gHJOjIQ
+aycabta:
+  title: 'IRB Reboot: Modernize Implementation and Features'
+  type: presentation
+  language: EN
+  description: |-
+    IRB was written at 20 years ago and contains Ruby code parser by pure Ruby. The parser is contributing greatly to some Ruby tools over many years but the maintenance cost for new Ruby syntax continues to increase. IRB must parse Ruby code certainly for when should evaluate the code. I provide a solution for it. Ruby 1.9 or later has two big new features for this problem, `Ripper` and `RubyVM::InstructionSequence.compile`. The two features provide whether code piece continues by tokens information and syntax check.
+
+    After IRB implementation was modernized, I added some new features to IRB. IRB imports RDoc features as a library, such as show documentation with auto-complete, auto-complete for meta-programmed namespaces.
+  speakers:
+  - id: aycabta
+  materials:
+    - title: 'IRB Reboot: Modernize Implementation and Features'
+      url: https://slide.rabbit-shocker.org/authors/aycabta/rubykaigi-2018/
+  video:
+    youtube_id: zUBxip-bhJA
+k0kubun:
+  title: The Method JIT Compiler for Ruby 2.6
+  type: presentation
+  language: JA
+  description: |-
+    Did you know Ruby 2.6 will be shipped with JIT compiler? Do you know why JIT compiler makes Ruby fast?
+
+    In this talk, you'll see how Ruby can be made faster by surprisingly short ERB code,
+    and the future of Ruby's performance by method inlining.
+  speakers:
+  - id: k0kubun
+  materials:
+    - title: The Method JIT Compiler
+      url: https://speakerdeck.com/k0kubun/the-method-jit-compiler
+  video:
+    youtube_id: svtRUkD0ACg
+keiju:
+  title: 'Reirb: Reborn Irb'
+  type: presentation
+  language: JA
+  description: |-
+    Reirb is a reborn irb, which interactive ruby language.
+    It is a high-functional shell language with ruby's syntax.
+    Its feature are job control, multiline-editor, smart-completion, language-navigation functionalities, etc.
+    Everyone will be able to live more enjoyable Ruby-life by using Reirb.
+  speakers:
+  - id: keiju
+  materials:
+    - title: 'Reirb: reborn Irb.'
+      url: https://speakerdeck.com/keiju/reirb-reborn-irb
+  video:
+    youtube_id: zGbmD7LQP2s
+drbrain:
+  title: Devly, a multi-service development environment
+  type: presentation
+  language: EN
+  description: |-
+    Writing a system alone is hard. Building many systems with many people is harder.
+
+    As our company has grown, we tried many approaches to user-friendly, shared development environments and learned what works and what doesn't. We incorporated what we learned into a tool called devly. Devly is used to develop products at Fastly that span many services written in different languages.
+
+    We learned that the design of our tools must be guided by how teams work and communicate. To respond to these needs, Devly allows self-service, control, and safety so that developers can focus on their work.
+  speakers:
+  - id: drbrain
+  - id: ezkl
+  video:
+    youtube_id: rlZR9jXmvL4
+shugomaeda:
+  title: Build your own tools
+  type: presentation
+  language: JA
+  description: |-
+    Now FLOSS is so common that even Microsoft use it and develop it.  But do you have control over your tools for daily use?
+
+    Building your own tools is the best way to develop software, and Ruby is the best language for such use.  In this talk, I introduce my own tools and my development style.
+  speakers:
+  - id: shugomaeda
+  materials:
+    - title: Build your own tools
+      url: https://slide.rabbit-shocker.org/authors/shugo/RubyKaigi2018/
+  video:
+    youtube_id: H0mn5u28tPo
+take-cheeze:
+  title: LuaJIT as a Ruby backend.
+  type: presentation
+  language: JA
+  description: |-
+    LuaJIT is an excellent implementation of Lua with JIT.
+    It also provides JIT modules that can be reused in other language.
+    In this session I will talk experience using LuaJIT as mruby backend.
+  speakers:
+  - id: take-cheeze
+  materials:
+    - title: LuaJIT as a Ruby backend
+      url: https://speakerdeck.com/takecheeze/luajit-as-a-ruby-backend
+  video:
+    youtube_id: F-lZtxewCcs
+malafortune:
+  title: Deep into Ruby Code Coverage
+  type: presentation
+  language: EN
+  description: |-
+    Code coverage is an easy way to measure if we have enough tests, yet many of us have yet to use it.
+
+    This talk delves into the benefits of meaningful code coverage and how to avoid some of its pitfalls with a new tool called DeepCover.
+  speakers:
+  - id: malafortune
+  materials:
+    - title: Deep into Ruby Code Coverage
+      url: https://www.slideshare.net/MarcAndrLafortune/deep-into-ruby-code-coverage
+  video:
+    youtube_id: HWj3nrvAmRM
+youchan:
+  title: How to get the dark power from ISeq
+  type: presentation
+  language: JA
+  description: "ISeq is a cross-section of the Ruby interpreter.\nIf there is a parser
+    that generates ISeq, it can run languages other than Ruby. If there is a processing
+    system that interprets iSeq, it may be possible to run Ruby on other than MRI's
+    supporting platform. \nJava is actively carrying out such things by disclosing
+    the Virtual Machine specification. For example, Scala is the language running
+    on JavaVM, and there are many versions of JavaVM for various platforms.\nSpecifying
+    Ruby's iSeq may be a good thing or a bad thing. Either way, it will be useful
+    to explore its possibilities.\nThe speaker is trying to document the current spec
+    of ISeq. \nIn this talk, I will talk to three stances of people. The first are
+    \ the most of the audiences who purely interest about hacking of ISeq.  The second
+    are potential users of ISeq, I show hints what we should do. At last I will raise
+    a probrem whether ISeq should be documented to the Ruby core team."
+  speakers:
+  - id: youchan
+  materials:
+    - title: How to get the dark power from ISeq
+      url: http://youchan.org/RubyKaigi2018/RubyKaigi2018/
+  video:
+    youtube_id: zTO2t24IhgI
+i110:
+  title: How happy they became with H2O/mruby, and the future of HTTP
+  type: presentation
+  language: JA
+  description: |-
+    Are you suffering from your messy web server config files? Do you have a craving for maintainability and flexibility, but worry about performance? This talk introduces a real migration story from nginx to H2O in a large-scale photo sharing service, illustrating how mruby scripting makes it easier to write and maintain configurations. We'll see real configuration examples, some issues we faced and the final result with some benchmarks. In addition, I'll show a lot of shiny new features and mrbgems added recently. You'd be surprised how advanced things can be done with H2O and mruby!
+    In the talk, Kazuho Oku will also discuss the standardization of H2 extensions, QUIC, and how they are likely to affect web application development and deployment.
+  speakers:
+  - id: i110
+  - id: kazuho
+  materials:
+    - title: How happy they became with H2O/mruby and the future of HTTP
+      url: https://www.slideshare.net/ichitonagata/how-happy-they-became-with-h2omruby-and-the-future-of-http
+  video:
+    youtube_id: r9zNEY6KtkI
+prasun_anand:
+  title: High Performance GPU computing with Ruby
+  type: presentation
+  language: EN
+  description: |-
+    Ruby being so old and a mature programming is still not preferred for Scientific Computing, mostly because it can’t handle large datasets .
+
+    RbCUDA and ArrayFire gem, that I created have an outstanding performance and can handle real world problems by crunching huge datasets.
+
+    In this talk I would like to show how RbCUDA and ArrayFire help you easily accelerate your code.
+  speakers:
+  - id: prasun_anand
+  materials:
+    - title: High Performance GPU computing with Ruby, Rubykaigi 2018
+      url: https://www.slideshare.net/PrasunAnand2/high-performance-gpu-computing-with-ruby-rubykaigi-2018
+  video:
+    youtube_id: LP9lIqCAbFE
+vnmakarov:
+  title: Three Ruby performance projects
+  type: presentation
+  language: EN
+  description: |2-
+      There are many ways to improve performance of a serious program like CRuby.  This presentation is an illustration of this on three different size projects.
+
+      One project is pretty small. It is to introduce a **new CRuby internal representation of IEEE 754 double precision numbers** to improve CRuby floating point performance. The second one is a medium-size **project to generate RTL from YARV instructions** and to use RTL for the interpretation and JIT compilation.  And the third one is a very ambitious project to create a **light-weight JIT** which can be used together with MJIT as a tier 1 JIT compiler or as a single JIT for mruby.
+  speakers:
+  - id: vnmakarov
+  materials:
+    - title: Three CRuby Performance Projects
+      url: https://www.slideshare.net/VladimirMakarov13/three-cruby-performance-projects
+  video:
+    youtube_id: emhYoI_RiOA
+matsumotory:
+  title: Design pattern for embedding mruby into middleware
+  type: presentation
+  language: JA
+  description: |-
+    mruby released in 2012 and 6 years have passed.
+    I have embedded mruby into a lot of middleware like ngx_mruby, and have designed and implemented both extensibility and performance compatibility in middleware.
+    I want to share not only the specifications and background but also design and implementation that only I know for embedding mruby into middleware since I have been sending patches of specifications and features to mruby.
+    In this presentation, I generalize the design and implementation to connect middleware supporting Internet service with mruby and introduce it as a design pattern.
+  speakers:
+  - id: matsumotory
+  materials:
+    - title: Design pattern for embedding mruby into middleware
+      url: https://speakerdeck.com/matsumoto_r/design-pattern-for-embedding-mruby-into-middleware
+  video:
+    youtube_id: xXvaY-xpfpc
+tom_enebo:
+  title: JRuby 9.2 and Rails 5.x
+  type: presentation
+  language: EN
+  description: "JRuby 9.2 has been released. 9.2 supports Ruby 2.5 compatibility and
+    it also runs Rails 5.x well. This talk will discuss some of the more interesting
+    apects of JRuby 9.2:\n\n  - Performance updates\n    - Graal integration\n    -
+    IR instr refactoring\n    - Object shaping\n  - Full encoding support ( @@かいぎ
+    ||= $\U0001F43B\U0001F33B.send :┬─┬ノº_ºノ' )\n  - Improved Windows support\n\nIt
+    will also give an update on the state of running Rails 5.x on JRuby. This talk
+    will go over updates we have made to ActiveRecord-JDBC and show a real world use-case
+    of getting Discourse running. Get up to date on the state of JRuby!"
+  speakers:
+  - id: tom_enebo
+  materials:
+    - title: JRuby 9.2 and Rails 5.x
+      url: https://speakerdeck.com/enebo/jruby-9-dot-2-and-rails-5-dot-x
+  video:
+    youtube_id: ue5XVN0SJEw
+tric:
+  title: TRICK 2018 (FINAL)
+  type: presentation
+  language: JA
+  description: The 3rd (FINAL) Transcendental Ruby Imbroglio Contest for rubyKaigi
+  speakers:
+  - id: tric
+  materials:
+    - title: TRICK 2018 results
+      url: https://www.slideshare.net/mametter/trick-2018-results
+  video:
+    youtube_id: TB-nmGG6uu0

--- a/2018/data/schedule.yml
+++ b/2018/data/schedule.yml
@@ -1,0 +1,190 @@
+---
+may31:
+  events:
+  - type: break
+    begin: '09:30'
+    end: '10:30'
+    name: Registration
+  - type: keynote
+    begin: '10:30'
+    end: '11:30'
+    talks:
+      Main Hall: yukihiro_matz
+  - type: break
+    begin: '11:30'
+    end: '13:00'
+    name: "Lunch (Bento! \U0001F371)"
+  - type: talk
+    begin: '13:00'
+    end: '13:40'
+    talks:
+      Main Hall: tenderlove
+      Tachibana: maciejmensfeld
+      Hagi: kurotaky
+  - type: talk
+    begin: '13:50'
+    end: '14:30'
+    talks:
+      Main Hall: mrkn
+      Tachibana: DarkDimius
+      Hagi: joker1007
+  - type: talk
+    begin: '14:40'
+    end: '15:20'
+    talks:
+      Main Hall: bbatsov
+      Tachibana: _st0012
+      Hagi: piotr_murach
+  - type: break
+    begin: '15:20'
+    end: '15:50'
+    name: Afternoon Break
+  - type: talk
+    begin: '15:50'
+    end: '16:30'
+    talks:
+      Main Hall: sonots
+      Tachibana: thibaut_barrere
+      Hagi: hsbt
+  - type: talk
+    begin: '16:40'
+    end: '17:20'
+    talks:
+      Main Hall: Yuryu
+      Tachibana: anton_davydov
+      Hagi: p_ck_
+  - type: lt
+    begin: '17:30'
+    end: '18:30'
+    name: Lightning Talks
+jun01:
+  events:
+  - type: break
+    begin: '08:00'
+    end: '09:40'
+    name: Breakfast
+  - type: keynote
+    begin: '09:40'
+    end: '10:40'
+    talks:
+      Main Hall: ktou
+  - type: talk
+    begin: '10:50'
+    end: '11:30'
+    talks:
+      Main Hall: hone02
+      Tachibana: codefolio
+      Hagi: wyhaines
+  - type: break
+    begin: '11:30'
+    end: '13:00'
+    name: "Lunch (Bento! \U0001F371)"
+  - type: talk
+    begin: '13:00'
+    end: '13:40'
+    talks:
+      Main Hall: ko1
+      Tachibana: Edouard-chin
+      Hagi: koic
+  - type: talk
+    begin: '13:50'
+    end: '14:30'
+    talks:
+      Main Hall: m_seki
+      Tachibana: jules2689
+      Hagi: yuri_at_earth
+  - type: talk
+    begin: '14:40'
+    end: '15:20'
+    talks:
+      Main Hall: soutaro
+      Tachibana: v0dro
+      Hagi: hasumon
+  - type: break
+    begin: '15:20'
+    end: '15:50'
+    name: Afternoon Break
+  - type: talk
+    begin: '15:50'
+    end: '16:30'
+    talks:
+      Main Hall: spikeolaf
+      Tachibana: gsamokovarov
+      Hagi: udzura
+      Shirakashi: mrkn2
+  - type: talk
+    begin: '16:40'
+    end: '17:20'
+    talks:
+      Main Hall: mametter
+      Tachibana: palkan_tula
+      Hagi: scalone
+      Shirakashi: ktou2
+  - type: talk
+    begin: '17:30'
+    end: '18:30'
+    talks:
+      Main Hall: rubylangorg
+jun02:
+  events:
+  - type: break
+    begin: '08:00'
+    end: '09:40'
+    name: Breakfast
+  - type: keynote
+    begin: '09:40'
+    end: '10:40'
+    talks:
+      Main Hall: eregontp
+  - type: talk
+    begin: '10:50'
+    end: '11:30'
+    talks:
+      Main Hall: sugiyama-k
+      Tachibana: aycabta
+      Hagi: kn1kn1
+  - type: break
+    begin: '11:30'
+    end: '13:00'
+    name: "Lunch (Bento! \U0001F371)"
+  - type: talk
+    begin: '13:00'
+    end: '13:40'
+    talks:
+      Main Hall: k0kubun
+      Tachibana: drbrain
+      Hagi: keiju
+  - type: talk
+    begin: '13:50'
+    end: '14:30'
+    talks:
+      Main Hall: shugomaeda
+      Tachibana: malafortune
+      Hagi: take-cheeze
+  - type: talk
+    begin: '14:40'
+    end: '15:20'
+    talks:
+      Main Hall: youchan
+      Tachibana: prasun_anand
+      Hagi: i110
+  - type: break
+    begin: '15:20'
+    end: '15:50'
+    name: Afternoon Break
+  - type: talk
+    begin: '15:50'
+    end: '16:30'
+    talks:
+      Main Hall: vnmakarov
+      Tachibana: tom_enebo
+      Hagi: matsumotory
+  - type: talk
+    begin: '16:40'
+    end: '17:40'
+    talks:
+      Main Hall: tric
+  - type: break
+    begin: '17:40'
+    end: '18:00'
+    name: Closing

--- a/2018/data/speakers.yml
+++ b/2018/data/speakers.yml
@@ -1,0 +1,599 @@
+---
+keynotes:
+  yukihiro_matz:
+    id: yukihiro_matz
+    name: Yukihiro "Matz" Matsumoto
+    bio: The Creator of Ruby
+    github_id: matz
+    twitter_id: yukihiro_matz
+    gravatar_hash: 0ec4920185b657a03edf01fff96b4e9b
+  ktou:
+    id: ktou
+    name: Kouhei Sutou
+    bio: 'He is a free software programmer and the president of ClearCode Inc. He
+      is also the namer of ClearCode Inc. The origin of the company name is "clear
+      code". We will be programmers that code clear code as our company name suggests.
+      He is interested in how to tell other programmers about how he codes clear code.
+
+'
+    github_id: kou
+    twitter_id: ktou
+    gravatar_hash: 2d9386b1504e581be390af978e05a8b9
+  eregontp:
+    id: eregontp
+    name: Benoit Daloze
+    bio: Benoit Daloze is a PhD student in Linz, Austria, researching concurrency
+      in Ruby with TruffleRuby for the past several years. He has contributed to many
+      Ruby implementations, including MRI, TruffleRuby and JRuby. He is the maintainer
+      of ruby/spec, a test suite for the behavior of the Ruby programming language.
+    github_id: eregon
+    twitter_id: eregontp
+    gravatar_hash: 0ea7f61aec8fee539be0cf39b7bab77c
+speakers:
+  tenderlove:
+    id: tenderlove
+    name: Aaron Patterson
+    bio: Aaron is on the Ruby core team, the Rails core team, and the team that takes
+      care of his cat, Gorby puff.   Someday he will find the perfect safety gear
+      to wear while extreme programming.
+    github_id: tenderlove
+    twitter_id: tenderlove
+    gravatar_hash: f29327647a9cff5c69618bae420792ea
+  anton_davydov:
+    id: anton_davydov
+    name: Anton Davydov
+    bio: I'm Hanami core developer and an indie developer from Moscow. I work on different
+      open source projects and builds Space-Rocket ships at night.
+    github_id: davydovanton
+    twitter_id: anton_davydov
+    gravatar_hash: 4c206cf12d71775464e20c58dfa4148b
+  bbatsov:
+    id: bbatsov
+    name: Bozhidar Batsov
+    bio: |-
+      Bozhidar is the author of RuboCop and the editor of the community Ruby and Rails style guides. Most people would probably describe him as an Emacs zealot (and they would be right). He's also quite fond of the Lisp family of languages, functional programming in general and Clojure in particular.
+
+      Believe it or not, Bozhidar has hobbies and interests outside the realm of computers, but we won't bore with those here.
+    github_id: bbatsov
+    twitter_id: bbatsov
+    gravatar_hash: 1be785d1d788b82929e55fc83a9f0aaa
+  code0100fun:
+    id: code0100fun
+    name: Chase McCarthy
+    bio: By day, Chase is a full-stack developer at Power Auctions working with Ember,
+      Rails, and Elixir/Phoenix. As a former aircraft electronics technician he's
+      still an electronics geek at heart. Chase is a hardware hacker, building tiny
+      homemade quadcopters and tinkering with embedded applications. He has also been
+      an active voice in the Ember.js community as a host of the EmberWeekend podcast.
+      He's a recent transplant to Austin, TX. so come say howdy!
+    github_id: code0100fun
+    twitter_id: code0100fun
+    gravatar_hash: 808a491e34b06138646482ed8d28a8a8
+  rubylangorg:
+    id: rubylangorg
+    name: CRuby Committers
+    bio: CRuby committers all stars
+    github_id: 
+    twitter_id: rubylangorg
+    gravatar_hash: ce6d997265cefede13ee7e7e2a2cf9b2
+  DarkDimius:
+    id: DarkDimius
+    name: Dmitry Petrashko
+    bio: |-
+      Dmitry works on developer productivity at Stripe,
+      making it easy to confidently write maintainable, fast, and reliable code at Stripe by improving language, core abstractions, tools and educational materials.
+
+      Before this, Dmitry worked on Scala compiler and parallel collection library.
+    github_id: DarkDimius
+    twitter_id: 
+    gravatar_hash: 6ede4f43de82d33e6946486e509e5302
+  Edouard-chin:
+    id: Edouard-chin
+    name: Edouard Chin
+    bio: |+
+      My name is Edouard, I'm a production engineer in the Rails team at Shopify.
+      One of the many project our team has to work on is keeping our monolith up to date.
+      Before that I was working in the Payments team at Shopify where I was helping to define the future of payments on the web.
+
+    github_id: Edouard-chin
+    twitter_id: 
+    gravatar_hash: a478cd8745e3f45919cb5835b321dc6b
+  Yuryu:
+    id: Yuryu
+    name: Emma Haruka Iwao
+    bio: Emma is a developer advocate for Google Cloud Platform, focusing on application
+      developers experience. She is trying to make Cloud adorable for everyone through
+      events, demos, and online content. Emma was a site reliability engineer at a
+      mobile game company companies before coming to Google. Besides software engineering,
+      shes likes games, traveling, and eating delicious food. She has also been working
+      with the Rails Girls community in Japan and teaching Rails to future developers.
+    github_id: yuryu
+    twitter_id: Yuryu
+    gravatar_hash: 8f42a63c15aaa4f3a0372b5d7dc4cd90
+  drbrain:
+    id: drbrain
+    name: Eric Hodel
+    bio: Eric Hodel is a ruby committer and maintainer of many gems. He works at Fastly
+      building developer tools that allow his coworkers to work on distributed teams
+      with minimum difficulty.
+    github_id: drbrain
+    twitter_id: drbrain
+    gravatar_hash: 58479f76374a3ba3c69b9804163f39f4
+  ezkl:
+    id: ezkl
+    name: Ezekiel Templin
+    bio: Ezekiel Templin has worked with people to build systems using networked computers
+      for most of the last 20 years. He also works at Fastly building developer and
+      deployment tools.
+    github_id: ezkl
+    twitter_id: ezkl
+    gravatar_hash: 6f6e0c4b9ea48169dd1432849eb4cd35
+  gsamokovarov:
+    id: gsamokovarov
+    name: Genadi Samokovarov
+    bio: Genadi is a Ruby developer from Sofia, Bulgaria and the maintainer of the
+      web-console gem. Works for Rhyme (https://rhyme.com) where he takes part in
+      changing the way in-person and online trainings are held.
+    github_id: gsamokovarov
+    twitter_id: 
+    gravatar_hash: 1ac5a00efa41cd58c421d3cd98dda7b9
+  hsbt:
+    id: hsbt
+    name: Hiroshi SHIBATA
+    bio: |-
+      A member of Ruby core team. Rake, rdoc, psych, ruby-build, etc. and He is an administrator of ruby-lang.org and supports to develop the environment of Ruby language.
+
+      He is also Executive Officer in GMO Pepabo, Inc. His most interest things are “Productivity”  He believes, there's business value in fun.
+    github_id: hsbt
+    twitter_id: hsbt
+    gravatar_hash: eabad423977cfc6873b8f5df62b848a6
+  hasumon:
+    id: hasumon
+    name: Hitoshi HASUMI
+    bio: Programmer of Monstar Lab at Shimane office
+    github_id: hasumon
+    twitter_id: 
+    gravatar_hash: d62b18efd2549587e712cebf6403861a
+  i110:
+    id: i110
+    name: i110
+    bio: Software Engineer in Fastly
+    github_id: i110
+    twitter_id: i110
+    gravatar_hash: 4372559c5f8e907a832d7a50466c8da9
+  aycabta:
+    id: aycabta
+    name: ITOYANAGI Sakura
+    bio: ''
+    github_id: aycabta
+    twitter_id: 
+    gravatar_hash: 43da97eeeac8fafd2bf196db1f19c534
+  joker1007:
+    id: joker1007
+    name: joker1007
+    bio: |-
+      Repro inc. CTO
+      Ruby/Rails Programmer
+    github_id: joker1007
+    twitter_id: joker1007
+    gravatar_hash: a5e5ee2fb9e4ce3c728ed9e3ef6e916f
+  jules2689:
+    id: jules2689
+    name: Julian Nadeau
+    bio: Julian is a Production Engineer at Shopify working on developer productivity
+      and experience. Working on the Shopify application, one of the larger Ruby apps
+      out there, has provided a good look into performance related topics in the Ruby
+      ecosystem that he is anxious to share.
+    github_id: jules2689
+    twitter_id: jules2689
+    gravatar_hash: 6e01dd682c021a600a943b0a539ed6a2
+  kazuho:
+    id: kazuho
+    name: Kazuho Oku
+    bio: N/A
+    github_id: kazuho
+    twitter_id: kazuho
+    gravatar_hash: a1f8ed12fefd7759ef8838e62ee409a6
+  keiju:
+    id: keiju
+    name: Keiju Ishitsuka
+    bio: Ruby's godfather.
+    github_id: keiju
+    twitter_id: 
+    gravatar_hash: 97f338629741aa42d6717bfba0c2830f
+  sugiyama-k:
+    id: sugiyama-k
+    name: Keita Sugiyama
+    bio: Keita graduated from the Department of Integrated Information Technology,
+      College of Science and Engineering, Aoyama Gakuin University, in March 2018.
+      He is currently a Master Course Student in the Intelligence and Information
+      Course, Graduate School of Science and Engineering, Aoyama Gakuin University.
+      His main research interest is design and implementation of programming languages.
+    github_id: sugiyama-k
+    twitter_id: 
+    gravatar_hash: 2efd4b8371b9786bae58cb87084122dc
+  kn1kn1:
+    id: kn1kn1
+    name: Kenichi Kanai
+    bio: Member of SIAF LAB. Contributor/Translator of Sonic Pi. Software engineer
+      at Farmnote.
+    github_id: kn1kn1
+    twitter_id: kn1kn1
+    gravatar_hash: 6976cd10edb6e39b7ba66a284c96f8be
+  mrkn:
+    id: mrkn
+    name: Kenta Murata
+    bio: |-
+      A full-time CRuby committer at Speee Inc.
+      I'm currently focusing on making Ruby a data-science-ready programming language.
+    github_id: mrkn
+    twitter_id: mrkn
+    gravatar_hash: 819b3c0a25f9708fd32261b8ae2d23f6
+  mrkn2:
+    id: mrkn2
+    name: Kenta Murata
+    bio: |-
+      A full-time CRuby committer at Speee Inc.
+      I'm currently focusing on making Ruby a data-science-ready programming language.
+    github_id: 
+    twitter_id: mrkn2
+    gravatar_hash: 819b3c0a25f9708fd32261b8ae2d23f6
+  wyhaines:
+    id: wyhaines
+    name: Kirk Haines
+    bio: I started using Ruby back in the Ruby 1.6 days, and I have used it in my
+      daily professional life ever since. I'm fascinated by issues of application
+      design, distributed architecture, and making hard things easy. I was also the
+      last Ruby 1.8.6 maintainer. For entertainment, I read studies on exercise and
+      nutrition physiology, and I like to run and bicycle long distances. This year
+      will include my first 50k and 50m running races, and at least one 75 mile gravel
+      bike race.
+    github_id: wyhaines
+    twitter_id: wyhaines
+    gravatar_hash: ca8efd0ba834b02b9b7dd34b5c6c2721
+  koic:
+    id: koic
+    name: Koichi ITO
+    bio: Koichi ITO is an OSS Programmer, a committer of activerecord-oracle_enhanced-adapter,
+      Rails Contributors Top 100, and Senior Leader at Eiwa System Management, Inc.
+      He is a practitioner of Ruby/Rails application development with eXtreme Programming
+      for over 10 years.
+    github_id: koic
+    twitter_id: koic
+    gravatar_hash: 023b04c98f39cc041293d780352432ff
+  ko1:
+    id: ko1
+    name: Koichi Sasada
+    bio: Koichi Sasada is a programmer, mainly developing Ruby interpreter (CRuby/MRI).
+      He received Ph.D (Information Science and Technology) from the University of
+      Tokyo, 2007. He became a faculty of University of Tokyo (Assistant associate
+      2006-2008, Assistant professor 2008-2012). After the 13 years life in university,
+      he joined Heroku, Inc. Now he is a member of Cookpad Inc (2017-). He is also
+      a director of Ruby Association.
+    github_id: ko1
+    twitter_id: 
+    gravatar_hash: 990397e8b38d6f5f4ae8ff343e8b883a
+  ktou2:
+    id: ktou2
+    name: Kouhei Sutou
+    bio: 'He is a free software programmer and the president of ClearCode Inc. He
+      is also the namer of ClearCode Inc. The origin of the company name is "clear
+      code". We will be programmers that code clear code as our company name suggests.
+      He is interested in how to tell other programmers about how he codes clear code.
+
+'
+    github_id: 
+    twitter_id: ktou2
+    gravatar_hash: 2d9386b1504e581be390af978e05a8b9
+  maciejmensfeld:
+    id: maciejmensfeld
+    name: Maciej Mensfeld
+    bio: I'm a software architect and engineer working with Castle.io. I have experience
+      in a wide variety of business applications built using multiple Ruby frameworks.
+      I’m particularly interested in code quality assurance and the way it affects
+      the software development process. I’m an active OSS contributor and maintainer
+      of various projects including Karafka – Framework used to simplify Apache Kafka-based
+      Ruby applications development.
+    github_id: mensfeld
+    twitter_id: maciejmensfeld
+    gravatar_hash: c571205817eabfe7ae22de3b74ffe900
+  tric:
+    id: tric
+    name: mame & the judges
+    bio: ''
+    github_id: tric
+    twitter_id: 
+    gravatar_hash: e18ba65ac9d718d12645b32099e15c44
+  malafortune:
+    id: malafortune
+    name: Marc-André Lafortune
+    bio: |-
+      A freelance developper fond of refactoring, fixing things and reducing technical debt – ideally all at once.
+
+      He loves coding in Ruby and can't resist telling others how to do it properly – on Github, StackOverflow or at conferences around the world. This incontrollable desire to do things right led him into all sorts of trouble, including becoming a MRI committer.
+
+      He coauthored DeepCover for Ruby.
+    github_id: marcandre
+    twitter_id: malafortune
+    gravatar_hash: 4bc9e9d604b7711165a6793bd01264eb
+  duerst:
+    id: duerst
+    name: Martin J. Dürst
+    bio: Martin is a Professor of Computer Science at Aoyama Gakuin University in
+      Japan. He has been one of the main drivers of Internationalization (I18N) and
+      the use of Unicode on the Web and the Internet. He published the first proposals
+      for DNS I18N and for NFC character normalization, and is the main author of
+      the W3C Character Model and the IRI specification (RFC 3987). Since 2007, he
+      and his students have contributed to the implementation of Ruby, mostly in the
+      area of I18N.
+    github_id: duerst
+    twitter_id: 
+    gravatar_hash: f52e87b92cafb1e8c6d155076b56ecff
+  p_ck_:
+    id: p_ck_
+    name: Masataka Kuwabara
+    bio: Software Engineer at SideCI, Inc. / RuboCop core developer
+    github_id: pocke
+    twitter_id: p_ck_
+    gravatar_hash: 7f432d4a8aaadcea1ca77ec81a200121
+  m_seki:
+    id: m_seki
+    name: Masatoshi SEKI
+    bio: Masatoshi Seki is a Ruby committer and the author of several Ruby standard
+      libraries including dRuby, ERB, and Rinda. He’s an expert in object-oriented
+      programming, distributed systems, and eXtreme programming. He has been speaking
+      at RubyKaigi every year since 2006 when the Kaigi first started.
+    github_id: seki
+    twitter_id: m_seki
+    gravatar_hash: 40f4d1f2e77078955bd01e9fb4a503ba
+  matsumotory:
+    id: matsumotory
+    name: MATSUMOTO, Ryosuke
+    bio: I'm a chief engineer and chief researcher at Pepabo Research and Development
+      Institute, GMO Pepabo, Inc.
+    github_id: matsumotory
+    twitter_id: matsumotory
+    gravatar_hash: 2b692bd83f4418103142a053ecf5ff59
+  sonots:
+    id: sonots
+    name: Naotoshi Seo
+    bio: A CRuby and Fluentd committer working at DeNA. Recently working on development
+      of DNN framework.
+    github_id: sonots
+    twitter_id: sonots
+    gravatar_hash: aef92c3acc29ad8543e04135687fc4f1
+  nelhage:
+    id: nelhage
+    name: Nelson Elhage
+    bio: |-
+      Nelson is a software engineer who enjoys working and learning at any and all levels of the stack. He currently works on developer productivity at Stripe.
+
+      Previously, he's worked on live kernel patching at Ksplice, built super-fast code search for https://livegrep.com/, and generally dived deep into systems and the Linux kernel.
+    github_id: nelhage
+    twitter_id: nelhage
+    gravatar_hash: ae10295946402ccf3e7f7dd024cc2ab5
+  codefolio:
+    id: codefolio
+    name: Noah Gibbs
+    bio: Noah is a Ruby Fellow for AppFolio, working on Ruby performance and related
+      tooling. He wrote the book "Rebuilding Rails" about understanding Rails as just
+      Ruby metaprogramming.
+    github_id: noahgibbs
+    twitter_id: codefolio
+    gravatar_hash: 5e8107f48d4471a40de325151d589b6d
+  ptarjan:
+    id: ptarjan
+    name: Paul Tarjan
+    bio: Lifelong nerd and engineer. Nowadays he works at Stripe mostly on developer
+      productivity and infrastructural components like rate limiters, core abstractions,
+      large code refactors and language design. In the past he helped build HHVM and
+      Hack at Facebook, worked on the Open Graph and changed your search results to
+      not just be 10 blue links.
+    github_id: ptarjan
+    twitter_id: ptarjan
+    gravatar_hash: fb14493c56f049fbcadffc0f124a945f
+  piotr_murach:
+    id: piotr_murach
+    name: Piotr Murach
+    bio: 'Software engineer by day, open sourcer by night, mathematician by design
+      and human languages enthusiast by life, Piotr has released many open source
+      projects such as tty, finite_machine, github_api. In recent years, Piotr has
+      been obsessively thinking about optimising Ruby terminal applications development. '
+    github_id: piotrmurach
+    twitter_id: piotr_murach
+    gravatar_hash: fb249d5564a0f8c5a0b69e0d71d58949
+  prasun_anand:
+    id: prasun_anand
+    name: Prasun Anand
+    bio: Prasun is involved with different open-source projects aimed at super fast
+      Scientific Computing on Ruby and D. He worked with SciRuby as a GSoC student
+      in 2016, 2017 and a Ruby Grant recepient. He worked on JRuby port of NMatrix
+      and is currently work on creating GPGPU libraries for D and Ruby.  Currently
+      he is working with Genenetwork on softwares for high performance genome analysis
+      and RbCUDA gem.
+    github_id: prasunanand
+    twitter_id: prasun_anand
+    gravatar_hash: 8af24db99e50b7374d069904c1e196f7
+  v0dro:
+    id: v0dro
+    name: Sameer Deshmukh
+    bio: |-
+      Sameer is a Master's degree student at Tokyo Institute of Technology, Japan and a contributor to the Ruby Science Foundation, where he helps build scientific computation tools in Ruby. He is currently maintaining daru and rubex.
+
+      He enjoys spending spare time with friends, books and his bass guitar.
+    github_id: v0dro
+    twitter_id: v0dro
+    gravatar_hash: 5083e35c5075b75473919524286239b3
+  tagomoris:
+    id: tagomoris
+    name: Satoshi "moris" Tagomori
+    bio: |-
+      OSS developer/maintainer: Fluentd, Norikra, MessagePack-Ruby, Woothee and many others mainly about Web services, data collecting and distributed/streaming data processing.
+      Living in Tokyo, and day job is for Treasure Data.
+    github_id: tagomoris
+    twitter_id: tagomoris
+    gravatar_hash: 002525eada5741b7954ce22c1a066d32
+  shugomaeda:
+    id: shugomaeda
+    name: Shugo Maeda
+    bio: A Ruby committer, Director of Network Applied Communication Laboratory, and
+      Secretary general of the Ruby Association
+    github_id: shugo
+    twitter_id: shugomaeda
+    gravatar_hash: 18a797893e6768e048c1d15429f96bb4
+  soutaro:
+    id: soutaro
+    name: Soutaro Matsumoto
+    bio: Soutaro is CTO at SideCI, a code review automation service. The position
+      is ideal for him because it allows testing his analyzers with its customers
+      by adding new tool support.
+    github_id: soutaro
+    twitter_id: soutaro
+    gravatar_hash: 1fab9d01b25e99522f3dfd01e3d4cb51
+  _st0012:
+    id: _st0012
+    name: Stan Lo
+    bio: "Ruby/Rails developer, cat and boxing lover. Currently working at ticketsolve
+      (https://www.ticketsolve.com) as a Rails developer. And develop Goby language
+      (https://github.com/goby-lang/goby) after work \U0001F60E"
+    github_id: st0012
+    twitter_id: _st0012
+    gravatar_hash: 90eb4343c490d4fe855eec64e1b1eaa3
+  k0kubun:
+    id: k0kubun
+    name: Takashi Kokubun
+    bio: A Ruby committer working at Treasure Data, who is maintaining ERB, Haml and
+      Hamlit.
+    github_id: k0kubun
+    twitter_id: k0kubun
+    gravatar_hash: '08d5432a5bc31e6d9edec87b94cb1db1'
+  take-cheeze:
+    id: take-cheeze
+    name: Takeshi Watanabe
+    bio: |-
+      mruby pull-requester
+      Works at Fusic Co. Ltd
+    github_id: take-cheeze
+    twitter_id: 
+    gravatar_hash: 45dc52d638066d63276ec07ef806bf82
+  hone02:
+    id: hone02
+    name: Terence Lee
+    bio: 'Terence leads Heroku’s Ruby Task Force curating the Ruby experience on the
+      platform. He''s worked on some OSS projects such as Ruby (the language), mruby,
+      Bundler, Resque, as well as helping with the Rails Girls movement. When he’s
+      not going to an awesome Heroku or Ruby event, he lives in Austin, TX, the taco
+      capital of America. Terence loves Friday hugs, EVERY DAY OF THE WEEK! Give him
+      a big one when you see him! In addition to hugs, he believes in getting people
+      together for #rubykaraoke.'
+    github_id: hone
+    twitter_id: hone02
+    gravatar_hash: ac7f7f050ade421ee11b467c8570a3cd
+  scalone:
+    id: scalone
+    name: Thiago Scalone
+    bio: Scalone has 12 years of career 10 of them with Ruby and 7 of them with C
+      on payments. Ruby lover and active participant of Brazilian Ruby community.
+    github_id: scalone
+    twitter_id: scalone
+    gravatar_hash: e822acb0564c5632aae69fef35f85b3d
+  thibaut_barrere:
+    id: thibaut_barrere
+    name: Thibaut Barrère
+    bio: Rural coder. Author of Kiba ETL, a lightweight data processing framework
+      (http://www.kiba-etl.org).
+    github_id: thbar
+    twitter_id: thibaut_barrere
+    gravatar_hash: 91eb330fb36d1e03c856574dfb77d2bc
+  tom_enebo:
+    id: tom_enebo
+    name: Thomas E Enebo
+    bio: Thomas Enebo co-leads the JRuby project. He has been passionately working
+      on JRuby for many years. When not working on JRuby, he is writing Ruby applications,
+      playing with Java, and enjoying a decent beer.
+    github_id: enebo
+    twitter_id: tom_enebo
+    gravatar_hash: 13313ac2ec7ba7c43b1b952db034ff3b
+  udzura:
+    id: udzura
+    name: Uchio KONDO
+    bio: |-
+      A 10 y.o. Rubyist, Containers and cloud-native tech freak, system programming novice. One of the writers of books "Perfect Ruby" / "Perfect Ruby on Rails" (both in Japanese).
+      He lives in Fukuoka - the "coast" city of "west" Japan, works at GMO Pepabo, Inc. as SRE/R&D/Dev Productivity Engineer, and holds Fukuoka.rb local meetup. He also is an organizer of RailsGirls Fukuoka #1.
+    github_id: udzura
+    twitter_id: udzura
+    gravatar_hash: 2cf373725ded741824c50fd571eda6e1
+  palkan_tula:
+    id: palkan_tula
+    name: Vladimir Dementyev
+    bio: A mathematician found his happiness in programming Ruby and Erlang, contributing
+      to open source, mentoring Rails devs and being an Evil Martian. Author of AnyCable
+      and TestProf.
+    github_id: palkan
+    twitter_id: palkan_tula
+    gravatar_hash: 52cc8a838bf44a589d2572833b2dd1b9
+  vnmakarov:
+    id: vnmakarov
+    name: Vladimir Makarov
+    bio: Vladimir Makarov is a software developer. His major interests lay in algorithms,
+      programming languages, compilers and JITs. Vladimir finished Moscow Institute
+      of Physics and Technology and got his PhD in computer science in Russian Academy
+      of Sciences. Last 20 years he has been working on GCC in RedHat. Vladimir started
+      his work on Ruby MRI in 2015.  His MRI projects are new hash tables and ongoing
+      implementation of new VM instructions and MJIT. Vladimir lives in Toronto, Canada.
+    github_id: vnmakarov
+    twitter_id: 
+    gravatar_hash: 42979fbb3647ad7cd1ce86e5a1dc0e28
+  youchan:
+    id: youchan
+    name: Yoh Osaki
+    bio: |-
+      Software engineer at Retrieva, inc.
+      Author of Hyalite which is react like virtual DOM library.
+      Member of Asakusa.rb, Chidoriashi.rb
+    github_id: youchan
+    twitter_id: youchan
+    gravatar_hash: b54abc5e7463fe6470c379e97e3f2477
+  spikeolaf:
+    id: spikeolaf
+    name: Yuichiro Kaneko
+    bio: Ruby committer.
+    github_id: yui-knk
+    twitter_id: spikeolaf
+    gravatar_hash: b3ba3ccedfbf4d605f00bafd1a732529
+  yuri_at_earth:
+    id: yuri_at_earth
+    name: Yurie Yamane
+    bio: |-
+      "nora" mrubyist.
+      A member of Team Yamanekko.
+      A member of TOPPERS Project.
+    github_id: yurie
+    twitter_id: yuri_at_earth
+    gravatar_hash: 0607f2778a478327d55f9b4fb7954a60
+  hatappi:
+    id: hatappi
+    name: Yusaku Hatanaka
+    bio: "I'm working at Speee Inc.  \nRed Data Tools project member.  \nmy blog is
+      here => http://hatappi.hateblo.jp/"
+    github_id: hatappi
+    twitter_id: hatappi
+    gravatar_hash: ce42cf4d3452f73c3d4b046abdce1479
+  mametter:
+    id: mametter
+    name: Yusuke Endoh
+    bio: '''A full-time MRI committer at Cookpad, Inc.  He has been interested in
+      testing, analyzing, abusing of Ruby.  He is an advocate of "transcendental programming"
+      that creates a useless program like this bio. (`_`)''.yield_self{|s|eval(t=%q(puts"''#{s.sub(?_,?_+?_)}''.yield_self{|s|eval(t=%q(#{t}))}"))}'
+    github_id: mame
+    twitter_id: mametter
+    gravatar_hash: e73159002200b33d51b7a6a312f2440e
+  kurotaky:
+    id: kurotaky
+    name: Yuta Kurotaki
+    bio: |-
+      Senior Software Engineer at GMO Pepabo, Inc.
+      Interested in Human Information Processing, Human Computer Interaction, FinTech.
+    github_id: kurotaky
+    twitter_id: kurotaky
+    gravatar_hash: 0b2426ff15397042caa863cc7965c091

--- a/2019/data/presentations.yml
+++ b/2019/data/presentations.yml
@@ -1,0 +1,1076 @@
+---
+yukihiro_matz:
+  title: The Year of Concurrency
+  type: keynote
+  language: JA
+  description: The Matz keynote!
+  speakers:
+  - id: yukihiro_matz
+  video:
+    youtube_id: WZu-WVzbEOA
+matzbot:
+  title: Ruby 3 Progress Report
+  type: presentation
+  language: JA
+  description: Ruby 3 progress report
+  speakers:
+  - id: matzbot
+  video:
+    youtube_id: 1qEhEad5uPI
+k0kubun:
+  title: Performance Improvement of Ruby 2.7 JIT in Real World
+  type: presentation
+  language: JA
+  description: |-
+    Ruby 2.6's JIT was known to make a Rails application slower, while it achieved a good progress on some other benchmarks.
+
+    Will that be beneficial for your application in Ruby 2.7? How many times will it make Rails faster? How much additional memory will it consume? Come to the talk and figure it out.
+  speakers:
+  - id: k0kubun
+  materials:
+  - title: Performance Improvement of Ruby 2.7 JIT in Real World / RubyKaigi 2019
+    url: https://speakerdeck.com/k0kubun/rubykaigi-2019
+  video:
+    youtube_id: bz-sy5b2EXY
+maciejmensfeld:
+  title: How to take over a Ruby gem
+  type: presentation
+  language: EN
+  description: |-
+    Using Ruby gems is safe, right? We're a nice community of friendly beings that act towards the same goal: making Ruby better. But is that true? Can we just blindly use libraries, without making sure, that they are what they are supposed to be?
+
+    Come and learn how you can take over a gem, what you can do with it once you have it and what you can do to protect yourself against several types of attacks you're exposed to on a daily basis. Let's exploit the Ruby gems world, and its data together.
+  speakers:
+  - id: maciejmensfeld
+  materials:
+  - title: How to take over a Ruby gem
+    url: https://mensfeld.github.io/taking-over-a-gem/
+  video:
+    youtube_id: wePVhZeZTNM
+aycabta:
+  title: Terminal Editors For Ruby Core Toolchain
+  type: presentation
+  language: EN
+  description: |-
+    I implemented "Reline" that is a compatibility library with "readline" stdlib by pure Ruby and works correctly without GNU Readline and works on Windows too.
+
+    "Reidline" is authored for new IRB by keiju-san who is Ruby's grandfather, it behaves as a multiline editor like JavaScript console on browsers. It had many technical problems but I've already solved that when I implemented Reline. So I helped to complete Reidline.
+
+    These are highlights of Ruby 2.7. I'll talk about the technical problems of these and show a demo on Ruby 2.7.
+  speakers:
+  - id: aycabta
+  materials:
+  - title: 'IRB Reboot: Modernize Implementation and Features - ITOYANAGI Sakura'
+    url: https://slide.rabbit-shocker.org/authors/aycabta/rubykaigi-2019/
+  video:
+    youtube_id: 8l1ep4nN_KQ
+ota42y:
+  title: How to use OpenAPI3 for API developer
+  type: presentation
+  language: JA
+  description: |-
+    I'll talk about how to use OpenAPI 3 and another tools in production.
+
+    JSON is widely used in the current Web.
+    But the request / response format is not in the JSON specification, so we can't guarantee.
+
+    In the case of developing API servers for backend server and multiple servers like micro services,
+    guaranteeing the request / response format is improve for stability and development efficiency.
+    So the definition of schema is important.
+
+    OpenAPI 3 (formerly Swagger) is a specification for describing the interface of RESTful API.
+    We can define request / response parameters schema for the endpoint using it.
+
+    The committee is gem which validates request / response in rack layer.
+    I'm developing the function to perform validation using OpenAPI 3 in this gem.
+    And I shifted my application specification to OpenAPI3 from another schema specification called JSON Hyper-Schema.
+  speakers:
+  - id: ota42y
+  materials:
+  - title: How to use OpenAPI3 for API developer (RubyKaigi 2019)
+    url: https://speakerdeck.com/ota42y/how-to-use-openapi3-for-api-developer-rubykaigi-2019
+  video:
+    youtube_id: om1dgTbmXrw
+ko1:
+  title: Write a Ruby interpreter in Ruby for Ruby 3
+  type: presentation
+  language: EN
+  description: Ruby interpreter called MRI (Matz Ruby Interpreter) or CRuby is written
+    in C language. Writing an interpreter in C has several advantages, such as performance
+    at early development, extensibility in C language and so on. However, now we have
+    several issues because of writing MRI in C. To overcome this issue, I propose
+    to rewrite some part of MRI in Ruby language with C functions. It will be a base
+    of Ruby 3 (or Ruby 2.7). In this talk, I'll show the issues and how to solve them
+    with writing Ruby, how to write MRI internal in Ruby and how to build an interpreter
+    with Ruby code.
+  speakers:
+  - id: ko1
+  materials:
+  - title: Write a Ruby interpreter in Ruby for Ruby 3
+    url: http://www.atdot.net/~ko1/activities/2019_rubykaigi2019.pdf
+  video:
+    youtube_id: PZDhXPgt98U
+nateberkopec:
+  title: 'Determining Ruby Process Counts: Theory and Practice'
+  type: presentation
+  language: EN
+  description: You have a Ruby web application or service that takes a certain number
+    of requests per minute. How do you know how many Ruby processes you will need
+    to serve that load? The answer is actually very complex, and getting it wrong
+    can cost you a lot of money! In this talk, we'll go through the mathematics and
+    theory of queues, and then apply them to the configuration and provisioning of
+    Ruby services (web, background job, and otherwise). Finally, we'll discuss the
+    application of this theory in the real world, including multi-threading and the
+    GVL, "autoscaling", containers and deployment processes, and how Guilds may impact
+    this process in the future.
+  speakers:
+  - id: nateberkopec
+  materials:
+  - title: 'Determining Ruby Process Counts: Theory and Practice'
+    url: https://github.com/speedshop/rubykaigi2019/blob/master/presentation.pdf
+  video:
+    youtube_id: BE5C2ydN0y0
+giosakti:
+  title: Pathfinder - Building a Container Platform in Ruby Ecosystem
+  type: presentation
+  language: EN
+  description: |-
+    This session will discuss about an attempt to build container platform in ruby/mruby ecosystem, the current situation and lesson-learned that we can discern to improve it further.
+
+    Further on, for those whom are unfamiliar, this session will also touch a bit about container platform/orchestrator and the generic architecture behind it. So that as a developer, we understand the abstraction that it provides.
+  speakers:
+  - id: giosakti
+  materials:
+  - title: Pathfinder - Building a Container Platform in Ruby Ecosystem
+    url: https://speakerdeck.com/giosakti/pathfinder-building-a-container-platform-in-ruby-ecosystem
+  video:
+    youtube_id: AhBds1xGT94
+joker1007:
+  title: Pragmatic Monadic Programing in Ruby
+  type: presentation
+  language: JA
+  description: |-
+    Ruby is not only for Objective Oriented Programming style, but also for Functional Programming style.
+    I talk how ruby expresses important essences of Functional Programming.
+    For example, Functor, Applicative, Monad.
+
+    And Monadic syntax suger is very important to take advantage of Monad.
+    I also talk about Implementation of Monadic syntax suger that is inspired by Scala language.
+    I will show popular monad implementations like belows.
+    - Maybe
+    - Either
+    - State
+    - Future (like async syntax in JavaScript)
+    - Parser Combinator
+  speakers:
+  - id: joker1007
+  materials:
+  - title: Pragmatic Monadic Programming in Ruby
+    url: https://speakerdeck.com/joker1007/pragmatic-monadic-programming-in-ruby
+  video:
+    youtube_id: xUV2DvZ5L1A
+mametter:
+  title: A Type-level Ruby Interpreter for Testing and Understanding
+  type: presentation
+  language: JA
+  description: |-
+    We propose a type-level abstract interpreter for Ruby 3's static analysis.
+    This interpreter runs normal (i.e., non-type-annotated) Ruby programs in "type" level: each variable has only a type instead of a value.
+    It reports a possible type-error bug, e.g., attempting to call a unknown method or to pass an invalid type argument during the interpretation.
+    By recording all method definitions and calls, it also creates a summary of the program structure in type signature format.
+    This is useful to understand the code, and can be also used as a prototype of type definition for external type checkers.
+  speakers:
+  - id: mametter
+  materials:
+  - title: A Type-level Ruby Interpreter for Testing and Understanding
+    url: https://www.slideshare.net/mametter/a-typelevel-ruby-interpreter-for-testing-and-understanding
+  video:
+    youtube_id: 2oDBKrPYEu8
+alehander42:
+  title: Compiling Ruby to idiomatic code in static languages
+  type: presentation
+  language: EN
+  description: "Generating code and compiling code are very useful, but usually the
+    target is the machine: so the generated code is very unfriendly for programmers.
+    We will show two approaches with which we are able to compile Ruby to code in
+    statically typed languages and make it idiomatic and nice\n\npseudocode-like(where
+    we support small programs in a subset of Ruby, but we can generate correct statically
+    typed code in C++, C#, Go, Java) and \n\nrealcode-like, where we infer ruby types
+    on runtime and autotranslate more complicated codebase to Nim(rb2nim): the result
+    requires some manual work, but automates most of it."
+  speakers:
+  - id: alehander42
+  - id: zah
+  video:
+    youtube_id: hlWCp210IIY
+  materials:
+  - title: Compiling Ruby to idiomatic code in static languages
+    url: https://metacraft-labs.github.io/fast-rubocop/ruby-kaigi-2019/#/
+gsamokovarov:
+  title: Writing Debuggers in Plain Ruby! Fact or fiction?
+  type: presentation
+  language: EN
+  description: |-
+    In this talk, we'll build a simple byebug-like debugger in plain Ruby. We'll try to go all the way, but also explain what we cannot do without some C or Java code.
+
+    Let's imagine a Ruby future, where a debugger written in Ruby can be used in CRuby, JRuby and even TruffleRuby!
+  speakers:
+  - id: gsamokovarov
+  materials:
+  - title: Writing Debuggers in Plain Ruby! Fact or fiction?
+    url: http://kaigi-debuggers-in-ruby.herokuapp.com/
+  video:
+    youtube_id: vV_tZX7jooo
+youchan:
+  title: Ruby for NLP
+  type: presentation
+  language: JA
+  description: |-
+    There is no doubt that Deep Learning was the spark of the recent AI boom.
+    Deep Learning has been improving the field of image recognition and natural language processing.
+    In this presentation, I will explain how to deal with natural language processing in Ruby
+    In the first half I will explain the basic methodology of natural language processing and in the second half I will explain how to deal with Ruby.
+  speakers:
+  - id: youchan
+  materials:
+  - title: Ruby for NLP
+    url: http://youchan.org/RubyKaigi2019/
+  video:
+    youtube_id: nzPwSDRsv_0
+ioquatix:
+  title: Fibers Are the Right Solution
+  type: presentation
+  language: EN
+  description: The majority of performance improvements in modern processors are due
+    to increased core count rather than increased instruction execution frequency.
+    To maximise hardware utilization, applications need to use multiple processes
+    and threads. Servers that process discrete requests are a good candidate for both
+    parallelization and concurrency improvements. We discuss different ways in which
+    servers can improve processor utilization and how these different approaches affect
+    application code. We show that fibers require minimal changes to existing application
+    code and are thus a good approach for retrofitting existing systems.
+  speakers:
+  - id: ioquatix
+  materials:
+  - title: Fibers Are the Right Solution
+    url: https://www.codeotaku.com/journal/2018-11/fibers-are-the-right-solution/index
+  video:
+    youtube_id: qKQcUDEo-ZI
+_matthewd:
+  title: 'A Bundle of Joy: Rewriting for Performance'
+  type: presentation
+  language: EN
+  description: Local gem management is a key part of our modern workflow, but our
+    tools are layered on historical approaches and requirements. In this talk we explore
+    a ground-up rewrite of local gem management, and ask whether careful implementation
+    (and some feature-cutting) can produce a tool that meets most people's needs while
+    outperforming the current options. In the process, we'll look at specific design
+    choices that make common operations faster, and which might apply to your projects
+    too.
+  speakers:
+  - id: _matthewd
+  video:
+    youtube_id: fQBrWrJKPVU
+nusco:
+  title: A Deep Learning Adventure
+  type: presentation
+  language: EN
+  description: |-
+    Deep learning is the most exciting recent idea in software–but it's also intimidating. If you have no previous machine learning and deep learning experience, this talk is your entry ticket to the field.
+
+    We'll start from scratch, with a look at supervised learning. Then we'll see Ruby code that trains a neural network. Finally, we'll talk about deep neural networks, and explore a wonderful new concept that's changing the field of computer graphics: Generation Adversarial Networks. See how a deep learning program can invent imaginary animals!
+  speakers:
+  - id: nusco
+  video:
+    youtube_id: Uj-7X-9lkIg
+watson1978:
+  title: RMagick, migrate to ImageMagick 7
+  type: presentation
+  language: JA
+  description: |-
+    The currently RMagick has some problems about installing on macOS/Windows platform.
+    I will talk about RMagick that it will be migrated from ImageMagick 6 to 7 and it will be solved the problems.
+  speakers:
+  - id: watson1978
+  materials:
+  - title: 'RMagick, migrate to ImageMagick 7 #RubyKaigi #RubyKaigi2019'
+    url: https://speakerdeck.com/watson/rmagick-migrate-to-imagemagick-7-number-rubykaigi-number-rubykaigi2019
+  video:
+    youtube_id: Wt9eR8sj9s8
+k_tsj:
+  title: Pattern matching - New feature in Ruby 2.7
+  type: presentation
+  language: JA
+  description: Ruby core team plans to introduce pattern matching as an experimental
+    feature in Ruby 2.7. In this presentation, we will talk about the current proposed
+    syntax and its design policy.
+  speakers:
+  - id: k_tsj
+  materials:
+  - title: Pattern matching - New feature in Ruby 2.7
+    url: https://speakerdeck.com/k_tsj/pattern-matching-new-feature-in-ruby-2-dot-7
+  video:
+    youtube_id: paBlgsqoKk8
+alexwwood:
+  title: Building Serverless Applications in Ruby with AWS Lambda
+  type: presentation
+  language: EN
+  description: Come join us and learn about how you can build serverless applications
+    using Ruby on AWS Lambda! We will demonstrate how to create Ruby serverless functions
+    for web APIs as well as for event-driven applications, then build, test and deploy
+    them to production. We'll also discuss general best practices for developing serverless
+    applications.
+  speakers:
+  - id: alexwwood
+  video:
+    youtube_id: OA7jwECjvRY
+gao_shawnee:
+  title: 'GraphQL Migration: A Proper Use Case for Metaprogramming?'
+  type: presentation
+  language: EN
+  description: "When my team took the plunge to migrate Square’s largest Ruby app
+    to GraphQL, no way were we going to manually redefine over 200 objects. Implementing
+    a GraphQL layer includes repetitive and straightforward processes that can be
+    expedited with metaprogramming. \nI will start with some GraphQL basics, then
+    dig into process of metaprogramming a GraphQL layer from a demo ruby server. I
+    will explain the benefits of using this design pattern and how it improves developer
+    experience. At the end, I will demo the server handling a set diverse and complex
+    client calls! "
+  speakers:
+  - id: gao_shawnee
+  materials:
+  - title: 'GraphQL Migration: A Use Case for Metaprogramming?'
+    url: https://speakerdeck.com/shawneegao/ruby-kaigi-slides
+  video:
+    youtube_id: GKj4dipBEts
+tenderlove:
+  title: Compacting GC for MRI v2
+  type: presentation
+  language: JA
+  description: In this talk we will cover an implementation for a compacting GC in
+    MRI.  MRI's implementation presents unique challenges for implementing a compacting
+    GC.  In this talk, we will cover compactor implementation and algorithms, challenges
+    presented by MRI's implementation, compaction reference verification, and results
+    of compactor benchmarks.
+  speakers:
+  - id: tenderlove
+  materials:
+  - title: Compacting GC in MRI v2
+    url: https://speakerdeck.com/tenderlove/compacting-gc-in-mri-v2
+  video:
+    youtube_id: HgAZsg7D_Jo
+nagachika:
+  title: All bugfixes are incompatibilities
+  type: keynote
+  language: JA
+  description: Keynote
+  speakers:
+  - id: nagachika
+  materials:
+  - title: All bugfixes are incompatibilities
+    url: https://www.slideshare.net/nagachika/all-bugfixes-are-incompatibilities
+  video:
+    youtube_id: g_wPQzNlu9Q
+samphippen:
+  title: How RSpec works
+  type: presentation
+  language: EN
+  description: |-
+    RSpec is a much beloved series of libraries, currently holding spots 1, 2, 4, 5, and 6 in terms of most downloaded gems. Many of us use it every day, but the question is, how does it work?
+
+    In this talk, you will learn about how RSpec executes your tests, the anatomy of an `expect(...).to ...` expression, and how stubs and mocks work. You'll learn deeply about the behind the scenes architecture of RSpec. This talk is quite technical, and a fair amount of Ruby knowledge is assumed.
+  speakers:
+  - id: samphippen
+  materials:
+  - title: How RSpec Works
+    url: https://speakerdeck.com/penelope_zone/how-rspec-works
+  video:
+    youtube_id: B8yKlTNlY5E
+codefolio:
+  title: 'Six Years of Ruby Performance: A History'
+  type: presentation
+  language: EN
+  description: Ruby keeps getting faster. And people keep asking, "but how fast is
+    it for Rails?" Rails makes a great way to measure Ruby's speed, and how Ruby has
+    changed version-by-version. Let's look at six years of performance graphs for
+    apps big and small. How fast is 2.6.0? With JIT? How close is Ruby 3x3?
+  speakers:
+  - id: codefolio
+  materials:
+  - title: Six Years of Ruby Performance History
+    url: https://bit.ly/kaigi2019-gibbs
+  video:
+    youtube_id: iy4N7AtzZYc
+hasumikin:
+  title: Practical mruby/c firmware development with CRuby
+  type: presentation
+  language: EN
+  description: |-
+    Writing mruby/c firmware applications is like writing mrbgems. You need to make some C functions and mruby wrapper of them in order to handle peripherals like sensor, flash memory or BLE.
+    Easy to imagine it's hard to develop for a team in a situation of TIGHT COUPLING, right?
+    I will talk about some tools, mrubyc-test and mrubyc-debugger, which I made with CRuby for testing and debugging to keep our team slack coupling.
+  speakers:
+  - id: hasumikin
+  materials:
+  - title: Practical mruby/c firmware development with CRuby - HASUMI Hitoshi
+    url: https://slide.rabbit-shocker.org/authors/hasumikin/RubyKaigi-2019/
+  video:
+    youtube_id: rl0Nfiqs4e0
+ktou:
+  title: Better CSV processing with Ruby 2.6
+  type: presentation
+  language: JA
+  description: |-
+    csv, one of the standard libraries, in Ruby 2.6 has many improvements:
+
+      * Default gemified
+      * Faster CSV parsing
+      * Faster CSV writing
+      * Clean new CSV parser implementation for further improvements
+      * Reconstructed test suites for further improvements
+      * Benchmark suites for further performance improvements
+
+    These improvements are done without breaking backward compatibility.
+
+    This talk describes details of these improvements by a new csv maintainer.
+  speakers:
+  - id: ktou
+  - id: 284km
+  materials:
+  - title: Better CSV processing with Ruby 2.6 - Kouhei Sutou
+    url: https://slide.rabbit-shocker.org/authors/kou/rubykaigi-2019/
+  video:
+    youtube_id: z8yV3yEqxJY
+Hir0_IC:
+  title: intimate Chat with Matz and mruby developers about mruby
+  type: presentation
+  language: JA
+  description: 3 or 4 developers including overseas developer are going to talk about
+    mruby's development confidential stories, current situation, and future of mruby
+    with Yukihio "Matz" Matsumoto creator of the mruby programming language.
+  speakers:
+  - id: Hir0_IC
+  materials:
+  - title: Chat with Matz about mruby in Rubykaigi2019
+    url: https://www.slideshare.net/Hir0IC/chat-with-matz-about-mruby-in-rubykaigi2019
+  video:
+    youtube_id: Mf4v3u6tgOk
+fxn:
+  title: 'Zeitwerk: A new code loader'
+  type: presentation
+  language: EN
+  description: |
+    The talk presents Zeitwerk, a new code loader for gems and applications.
+
+    Zeitwerk is able to preload, lazy load, unload, and eager load the code of gems and applications with a compatible file structure without the need to write require calls.
+  speakers:
+  - id: fxn
+  materials:
+  - title: 'Zeitwerk: A new code loader'
+    url: https://speakerdeck.com/fxn/zeitwerk-a-new-code-loader
+  video:
+    youtube_id: YSc_GNQP6ts
+Envek:
+  title: 'Yabeda: Monitoring monogatari'
+  type: presentation
+  language: EN
+  description: |-
+    Developing large and high load application without monitoring is a hard and dangerous task, just like piloting an aircraft without gauges. Why it is so important to keep an eye on how application's “flight“ goes, what things you should care more, and how graphs may help to resolve occurring performance problems quickly.
+    On an example of Sidekiq, Prometheus, and Grafana, we will learn how to take metrics from the Ruby application, what can we see from their visualization, and I will tell a couple of sad tales about how it helps in everyday life (with happy-end!)
+  speakers:
+  - id: Envek
+  materials:
+  - title: 'RubyKaigi 2019: Yabeda: monitoring monogatari'
+    url: https://speakerdeck.com/envek/rubykaigi-2019-yabeda-monitoring-monogatari
+  video:
+    youtube_id: CvjefIat8yE
+yhara:
+  title: 'Ovto: Frontend web framework for Rubyists'
+  type: presentation
+  language: JA
+  description: |-
+    What framework do you use for creating single-page webapps? React, Vue, Angular, etc...
+    If you're tired of wirting JavaScript, Ovto may be a good choice.
+    In this talk, I will in introduce Ovto, a frontend framework which allows you to write single-page webapps all in Ruby.
+    https://github.com/yhara/ovto
+  speakers:
+  - id: yhara
+  video:
+    youtube_id: Vu2z8krSAYs
+  materials:
+  - title: 'Ovto: Frontend web framework for Rubyists'
+    url: https://speakerdeck.com/yhara/ovto-frontend-web-framework-for-rubyists
+jez:
+  title: 'State of Sorbet: A Type Checker for Ruby'
+  type: presentation
+  language: EN
+  description: |-
+    We have developed a typesystem for Ruby at Stripe with a goal of helping developers understand code better, write code with more confidence, and detect+prevent significant classes of bugs.
+
+    This talk shares experience of Stripe successfully adopting Sorbet in our codebase which had millions lines of code that were written before the typechecker had been conceived. The talk will describe:
+    - the process used to add typing to existing code;
+    - many tools developed to support this process;
+    - impact of this type system on safety and productivity at Stripe.
+
+    We also have some exciting announcements!
+
+    The talk does not require any previous knowledge of types and should be accessible to a broad audience.
+  speakers:
+  - id: jez
+  - id: ptarjan
+  materials:
+  - title: 'State of Sorbet: A Type Checker for Ruby'
+    url: https://sorbet.run/talks/RubyKaigi2019/
+  video:
+    youtube_id: odmlf_ezsBo
+grosser:
+  title: Actionable Code Coverage
+  type: presentation
+  language: EN
+  description: |-
+    No more external tools / unclear percentage scores / slow PR feedback.
+
+    Code coverage at your fingertips while developing, by having tests fail when newly added code is missing coverage, with minimal overhead and great visibility.
+
+     - how code coverage works in ruby (regular vs branch vs oneshot)
+     - how single_cov keeps things fast and simple
+     - onboarding for small and large codebases (automated onboarding + divide & conquer)
+     - how to hack forked code coverage with forking-test-runner
+     - wishlist for coverage.so
+  speakers:
+  - id: grosser
+  materials:
+  - title: Actionable Code Coverage
+    url: https://grosser.github.io/ruby-coverage-talk
+  video:
+    youtube_id: 01LYb28rMUQ
+mrkn_workshop:
+  title: RubyData Workshop
+  type: presentation
+  language: JA
+  description: |-
+    In this session, we'd like to introduce the current state of our data science ecosystems for Ruby.
+
+    This session consists of the following four parts.
+
+    1. In the first part, mrkn will talk about the whole summary.
+    2. In the second part, kou and people from Red Data Tools project will introduce this project and its current status.
+    3. In the third part, kozo2 will explain his achievements of RubyGrant 2018.
+    4. In the last part, Kazuma Furuhashi will explain his achievements of RubyGrant 2018.
+  speakers:
+  - id: mrkn
+  - id: 284km
+  - id: kozo2
+  - id: ktou
+  - id: znz
+  video:
+    youtube_id: PFcpmbRgB5A
+shugomaeda:
+  title: Terminal curses
+  type: presentation
+  language: JA
+  description: |-
+    Terminal programming with curses is useful and fun, but it sometimes brings terminal curses.
+
+    This talk shows basics of terminals (e.g., real text terminals, terminal emulators, the controlling terminal, /dev/tty and con, pty, control characters, escape sequences, termcap/terminfo, terminal mode), pros and cons of text-based user interfaces, an introduction to curses.gem, its applications, and issues you'll face when programming with curses.
+  speakers:
+  - id: shugomaeda
+  video:
+    youtube_id: 67M6Deo2aTw
+vnmakarov:
+  title: A light weight JIT compiler project for CRuby
+  type: presentation
+  language: EN
+  description: |2-
+      JITs based on GCC/LLVM as recently introduced CRuby MJIT might be heavy and slow for some environments and applications.  CRuby MJIT needs two tier compilation with a light weight compiler used as a tier 1 JIT compiler.
+
+      This talk will be about the light weight JIT compiler project for CRuby MJIT. The talk will cover the project motivations, current and future state of the project.
+  speakers:
+  - id: vnmakarov
+  materials:
+  - title: The light-weight-jit-compiler-project-for-c ruby
+    url: https://www.slideshare.net/VladimirMakarov13/the-lightweightjitcompilerprojectforc-ruby-141836482
+  video:
+    youtube_id: FdWLXKvZ6Gc
+amirrajan:
+  title: Building a game for the Nintendo Switch using Ruby
+  type: presentation
+  language: EN
+  description: Amir Rajan has done something insane. He released a Nintendo Switch
+    game written entirely in mRuby and C. Amir will share his journey with you from
+    the inception of A Dark Room Switch, it's integration with libSDL, all the way
+    to the submission to his publisher. Hopefully, Amir will inspire others to pursue
+    game development projects of their own using Ruby.
+  speakers:
+  - id: amirrajan
+  materials:
+  - title: Game Dev + Ruby = Happiness? Part II
+    url: http://slides.com/amirrajan/game-dev-ruby-happiness-part-2#/
+  video:
+    youtube_id: o0d4sjcUfCg
+p0deje:
+  title: 'Crystalball: predicting test failures'
+  type: presentation
+  language: EN
+  description: "Tests are often slow and are a bottleneck in development. We build
+    complex CI systems with heavy parallelization to reduce the amount of time it
+    takes to run all the tests, but we still tend to run all of them even for the
+    slightest change in code. What if instead, we could run only the tests that might
+    fail as a result of our changes? In a world of static languages, it's not hard,
+    but Ruby is very flexible and dynamic language so implementing this idea is tricky.
+    \n\nMeet [Crystalball](https://toptal.github.io/crystalball/) - a regression test
+    selection library we built in Toptal. I'll demonstrate how to use it with RSpec,
+    how it predicts what tests to run and how it can be extended."
+  speakers:
+  - id: p0deje
+  materials:
+  - title: 'Crystalball: predicting test failures'
+    url: https://speakerdeck.com/p0deje/crystalball-predicting-test-failures
+  video:
+    youtube_id: q2q-9Td71kE
+udzura:
+  title: The fastest way to bootstrap Ruby on Rails
+  type: presentation
+  language: EN
+  description: |-
+    Ruby on Rails applications sometimes take too long time in bootstrapping, especially when the application is complicated, monolithic or "legacy" one. This inhibits Kubernetes or other orchestrators to do smooth autoscaling.
+    There are tecnologies such as bootsnap to solve this problem. In addition to them, I propose new storategy - "checkpoint and restore".  I used CRIU(Checkpoint and Restore In Userspace) in Linux environment to make "ahead of time" process dump, and boot the application from image to reduce the bootstrap time. In my case, observed bootstrap time is reduced from about 2,500ms to 1,200ms.
+    I will describe what the CRIU is in the first place, use cases where CRIU is effective and some problems using CRIU.
+  speakers:
+  - id: udzura
+  materials:
+  - title: The fastest way to bootstrap Ruby on Rails
+    url: https://speakerdeck.com/udzura/the-fastest-way-to-bootstrap-ruby-on-rails
+  video:
+    youtube_id: pmlUq5fNkzA
+estolfo:
+  title: Benchmarking your code, inside and out
+  type: presentation
+  language: EN
+  description: |-
+    Benchmarking is an important component of writing applications, gems, Ruby implementations, and everything in between. There is never a perfect formula for how to measure the performance of your code, as the requirements vary from codebase to codebase.
+    Elastic has an entire team dedicated to measuring the performance of Elasticsearch and the clients team has worked with them to build a common benchmarking framework for itself. This talk will explore how the Elasticsearch Ruby Client is benchmarked and highlight key elements that are important for any benchmarking framework.
+  speakers:
+  - id: estolfo
+  materials:
+  - title: Benchmarking the Elasticsearch clients
+    url: https://drive.google.com/open?id=1n2wPr_hqqEGZVts1s2yQ5pGbUoC-ohdX
+  video:
+    youtube_id: WOnxe6qWtzY
+nirvdrum:
+  title: 'Beyond `puts`: TruffleRuby’s Modern Debugger Using Chrome'
+  type: presentation
+  language: EN
+  description: |-
+    We all write bugs. How quickly we can identify & understand them depends on the quality of our tools.
+
+    In this talk you'll be introduced to TruffleRuby's modern debugger, based on the Chrome browser's DevTools Protocol. TruffleRuby's uniquely powerful set of tools let you debug, profile, and inspect the memory usage of Ruby code, native extensions, and other embedded languages all at the same time. Support for those tools is zero-overhead so you can have them always enabled. I'll show you how it all works and how it lets you step through Ruby code, inspect local variables, evaluate expressions, and more.
+  speakers:
+  - id: nirvdrum
+  materials:
+  - title: 'Beyond `puts`: TruffleRuby’s Modern Debugger Using Chrome'
+    url: https://speakerdeck.com/nirvdrum/beyond-puts-trufflerubys-modern-debugger-using-chrome
+  video:
+    youtube_id: pe28r1VSBdU
+MikeMcQuaid:
+  title: 'Building Homebrew in Ruby: The Good, Bad and Ugly'
+  type: presentation
+  language: EN
+  description: Homebrew is a popular macOS package manager in the Ruby community and
+    is also written in Ruby. As Homebrew isn't a web application and doesn't provide
+    a Ruby library, the Ruby ecosystem works great for us in some ways and less great
+    in others. Learn about things we love, hate and struggle with because Homebrew
+    is built in Ruby.
+  speakers:
+  - id: MikeMcQuaid
+  video:
+    youtube_id: m1P_06bjjCs
+  materials:
+  - title: Building Homebrew in Ruby
+    url: https://speakerdeck.com/mikemcquaid/building-homebrew-in-ruby
+tanaka_akr:
+  title: What is Domain Specific Language?
+  type: presentation
+  language: JA
+  description: |-
+    Ruby is known as a good language for DSL (Domain Specific Language).
+    However, it is unclear what differentiate internal DSL and normal library.
+    This presentation tries to explain the difference.
+    Both DSL and normal library solves part of programmers task.
+    They tries to make programming easier.
+    However, DSL tends to use some kind of black magic unlike normal library.
+    The black magic is used to realize succinct and easy-to-read program for
+    many applications in the domain.
+    I hope this presentation makes programmers aware to design good library.
+  speakers:
+  - id: tanaka_akr
+  video:
+    youtube_id: 9S6RK0AGzng
+rubylangorg:
+  title: Ruby Committers vs the World
+  type: discussion
+  language: JA
+  description: 'Ruby core committers on stage!
+
+    '
+  speakers:
+  - id: rubylangorg
+  video:
+    youtube_id: 5eAXAUTtNYU
+yuri_at_earth:
+  title: "(partially) Non-volatile mruby"
+  type: presentation
+  language: JA
+  description: |-
+    In RubyKaigi 2018, I talked about basic idea of putting mruby on ROM.
+    But there’s still some objects consuming RAM, such as IREP structure and libraries defined in Ruby.
+    In this session, I will give another solution for the problem to put more structures into ROM.
+    Moreover, I will explain about the change of implementation of instance variables and Hash class in mruby 2.0, and the effect of memory consumption.
+  speakers:
+  - id: yuri_at_earth
+  - id: takahashim
+  materials:
+  - title: "(partially) Non-volatile mruby"
+    url: https://speakerdeck.com/yamanekko/partially-non-volatile-mruby
+  video:
+    youtube_id: N-TGgiNp5u0
+zelivans:
+  title: Fuzzing native Ruby code with Kisaten
+  type: presentation
+  language: EN
+  description: |-
+    Fuzzing is a common technique used to discover bugs and vulnerabilities in code. In order to fuzz native Ruby code, I've built [Kisaten](https://github.com/twistlock/kisaten), a Ruby extension for MRI that uses the magic of one of the best fuzzers of the time, `american fuzzy lop`. With Kisaten I found bugs in the Ruby standard library (in rdoc and rexml) and in popular gems like mail, asciidoctor and rubyzip. And there is still much more to fuzz!
+
+    I plan to walk through its development process from a Rubyist point of view, and present how it can be used so you can fuzz your own code.
+  speakers:
+  - id: zelivans
+  materials:
+  - title: Fuzzing native Ruby code with Kisaten
+    url: https://www.twistlock.com/wp-content/uploads/2019/04/RubyKaigi2019.pdf
+searls:
+  title: The Selfish Programmer
+  type: presentation
+  language: EN
+  description: |-
+    Using Ruby at work is great… but sometimes it feels like a job!
+
+    This year, I rediscovered the joy of writing Ruby apps for nobody but myself—and you can, too! Solo development is a great way to learn skills, to find inspiration, and to distill what matters most about programming.
+
+    Building an entire app by yourself can be overwhelming, but this talk will make it easier. We'll start with a minimal toolset that one person can maintain. You'll learn how many "bad" coding practices can actually reduce complexity. You may be surprised how selfish coding can make you a better team member, too!
+  speakers:
+  - id: searls
+  materials:
+  - title: The Selfish Programmer on Vimeo
+    url: https://vimeo.com/331528433/88176d4f3c
+  video:
+    youtube_id: LVe0g91yZ84
+riseshia:
+  title: Cleaning up a huge ruby application
+  type: presentation
+  language: JA
+  description: |-
+    (JA)
+    プロジェクトに顕在している未使用のコードを消すのは難しいです。
+    その理由としては特定コードを消していいのか確信を持ちづらいこと、そして実際削除可能なコードを探す作業は作業効率が悪いということなどが上げられます。
+    クックパッドでも未使用コードを削除しているのですが、上記のような問題がありこれらを解決するためにコードの修正履歴を利用したコード監視や、本番環境の実行履歴からの未使用コード探すなど仕組みを導入しています。
+
+    この発表ではコード削除業の意義や面倒さを説明し、そして1年で現行のサービスのクローズなしで5万行以上のコードを消せた経験を共有します。
+
+    (EN)
+    Deleting unused code from a huge project is hard.
+    Because it's difficult to:
+
+    - get confidence whether we could delete it or not.
+    - find potential unused codes is cost-inefficient task.
+
+    We has cleaned up unused codes, and introduced the stuffs such as logging code execution on the production environment, monitoring the code changes for solving these problems.
+
+    In this talk, I will explain why cleaning up codes is needed, why it's troublesome, and describe our experience how we deleting more than 50,000 lines codes without closing any services.
+  speakers:
+  - id: riseshia
+  materials:
+  - title: Cleaning up a huge ruby application
+    url: https://speakerdeck.com/riseshia/cleaning-up-a-huge-ruby-application
+  video:
+    youtube_id: 4akNWMKVZQU
+soutaro:
+  title: The challenges behind Ruby type checking
+  type: presentation
+  language: JA
+  description: |-
+    Static type checking for Ruby is challenging because the language is dynamically typed. What exactly is the source of the difficulty? You might think of *duck typing* or `defime_method`? Totally! But not only them are the reason. In fact, only a few lines of typical and innocent looking Ruby code can make type checking much more complicated than you assume.
+
+    This talk is about the difficulties and type system extensions to make the type checking possible. Static type checking is not easy and requires unfamiliar type system features, but we can do that.
+  speakers:
+  - id: soutaro
+  materials:
+  - title: The challenges behind Ruby type checking
+    url: https://speakerdeck.com/soutaro/the-challenges-behind-ruby-type-checking
+  video:
+    youtube_id: 7N-QOx6cVI4
+headius:
+  title: 'JRuby: The Road to Ruby 2.6 and Rails 6'
+  type: presentation
+  language: EN
+  description: 'Over the past six months, the JRuby team has been working on filling
+    in edges: getting refinements working well, porting C extensions, and getting
+    well-known applications running. At the same time, we always try to push forward
+    on performance and general compatibility. In this talk, we''ll cover recent work
+    to support Rails 6 and Ruby 2.6. We''ll show off a major Rails application running
+    on JRuby. And we''ll show you how you can help us keep JRuby moving forward.'
+  speakers:
+  - id: headius
+  - id: tom_enebo
+  materials:
+  - title: 'JRuby: The Road to Ruby 2.6 and Rails 6'
+    url: https://speakerdeck.com/headius/jruby-the-road-to-ruby-2-dot-6-and-rails-6
+  video:
+    youtube_id: vPy5KO4uHuA
+PeterQuines:
+  title: Running Ruby On The Apple II
+  type: presentation
+  language: EN
+  description: |-
+    An 8-bit CPU running at 1 megahertz. Kilobytes of RAM. The Apple II was released in the 1970's and many people first learned to program on it using the built in BASIC. Surely it is impossible to fit a language as complicated as Ruby on such a limited machine… right?
+
+    Come see Ruby running where it has never run before, and learn how such a rich language can be squeezed down to fit on the humble Apple II.
+  speakers:
+  - id: PeterQuines
+  materials:
+  - title: Running Ruby On The Apple ][
+    url: https://github.com/justcolin/conference_talks/blob/master/ruby_on_the_apple_ii__rubykaigi_2019/README.md
+  video:
+    youtube_id: qiwpWHfyXpM
+sue445:
+  title: Best practices in web API client development
+  type: presentation
+  language: JA
+  description: |-
+    How many did you make web API clients?
+
+    I have made web API clients as OSS, but I have made more private web API clients (not OSS) than that. (total 10+ gems)
+
+    Everyone should have used an external web service web API to create something.
+
+    Sometimes, you may need to create a client to use private web APIs that are not publicly exposed.
+
+    I would like to introduce the best practices of making web API clients.
+
+     I think that designing a good API client will lead to a good gem design, so I believe that my talk is beneficial not only for API client developers but also gem developers.
+  speakers:
+  - id: sue445
+  materials:
+  - title: 'Best practices in web API client development #RubyKaigi'
+    url: https://speakerdeck.com/sue445/best-practices-in-web-api-client-development-number-rubykaigi
+  video:
+    youtube_id: Ry0uQeTCHHs
+hsbt:
+  title: The future of the Bundled Bundler with RubyGems
+  type: presentation
+  language: JA
+  description: |-
+    I did merge Bundler into Ruby core repository and shipped bundler as standard library on Ruby 2.6. It helps to preparation of the fresh Ruby install and easy to use gem and bundle commands.
+
+    In background, we have a lot of issues until done to merge bundler into ruby core. This presentation show the some of issues of it works that are test suite, rubygems integration and library ecosystem like heroku. You can understand the internal of library management by rubygems and bundler.
+
+    Finally, I'm going to show the integration plan of RubyGems and Bundler and the part of  its implements. Also I will show the issues of the current status. You can resolve them after my talk.
+  speakers:
+  - id: hsbt
+  materials:
+  - title: The Future of Bundled Bundler
+    url: https://www.slideshare.net/hsbt/the-future-of-bundled-bundler
+  video:
+    youtube_id: H4rsTfJw9A4
+kddeisz:
+  title: Pre-evaluation in Ruby
+  type: presentation
+  language: EN
+  description: |-
+    Ruby is historically difficult to optimize due to features that improve flexibility and productivity at the cost of performance. Techniques like Ruby's new JIT compiler and deoptimization code help, but still are limited by techniques like monkey-patching and binding inspection.
+
+    Pre-evaluation is another optimization technique that works based on user-defined contracts and assumptions. Users can opt in to optimizations by limiting their use of Ruby's features and thereby allowing further compiler work.
+
+    In this talk we'll look at how pre-evaluation works, and what benefits it enables.
+  speakers:
+  - id: kddeisz
+  materials:
+  - title: Pre-evaluation in Ruby
+    url: https://speakerdeck.com/kddnewton/pre-evaluation-in-ruby
+  video:
+    youtube_id: q3i5pYpxP-s
+m_seki:
+  title: dRuby 20th anniversary hands-on workshop
+  type: presentation
+  language: JA
+  description: |-
+    dRuby (distributed ruby) is a cool library bone in the 20th century.
+
+    In this session, we will learn the basics of dRuby. Experience distributed objects on your PC.
+
+    Please download (or print) the document. (V0.7)
+    → http://www.druby.org/fukuoka2019.pdf
+  speakers:
+  - id: m_seki
+  video:
+    youtube_id: 6BJLGr_M30g
+frsyuki:
+  title: Performance Optimization Techniques of MessagePack-Ruby
+  type: presentation
+  language: JA
+  description: |-
+    MessagePack is known as one of the world's fastest object serialization formats available with compatibility to JSON. MessagePack is fast not just because of its binary format but also because of VERY optimized implementations crafted by enthusiasts for each programming languages.
+    To be the fastest serialization library for Ruby, MessagePack-Ruby implements various performance optimization techniques. This session explains the techniques with numbers and discusses further possible optimizations.
+  speakers:
+  - id: frsyuki
+  video:
+    youtube_id: yn5mEH8dUIY
+mrkn:
+  title: Reducing ActiveRecord memory consumption using Apache Arrow
+  type: presentation
+  language: JA
+  description: |-
+    The `pluck` method provided in ActiveRecord is a platform to obtain one or few field values as an array or arrays from a database.  The `pluck` method, compared with finder methods, can considerably reduce memory consumption because it does not generate model instances.
+
+    In this talk, I would like to introduce my new approach to reduce the memory consumption of ActiveRecord.  This approach employs Apache Arrow as the internal data representation of an `ActiveRecord::Result` object.  This approach can achieve a remarkable reduction of the memory consumption of the `pluck` method; it is 2-12x efficient than the original implementation.
+  speakers:
+  - id: mrkn
+  materials:
+  - title: Reducing ActiveRecord memory consumption using Apache Arrow
+    url: https://speakerdeck.com/mrkn/reducing-activerecord-memory-consumption-using-apache-arrow
+  video:
+    youtube_id: c1Y5o4tgblQ
+tongueroo:
+  title: Ruby Serverless Framework
+  type: presentation
+  language: EN
+  description: Learn how to run Ruby applications on AWS Lambda with a Serverless
+    Framework specifically designed with Ruby.  Demo is provided. We deploy it to
+    AWS Lambda with a single command.
+  speakers:
+  - id: tongueroo
+  video:
+    youtube_id: a0VKbrgzKso
+ujm:
+  title: Play with local vars
+  type: presentation
+  language: EN
+  description: |-
+    This 40min talk is only about Ruby's local variables. I'm not going to talk about anything else.
+
+    I'll demonstrate, or more precisely, play with Ruby local variables, including a discussion about the following common pitfall:
+
+    ```ruby
+    eval 'a = 1'
+    eval 'p a' #=> NameError!
+    ```
+
+    Ruby has multiple different types of variables: global vars, instance vars, class vars, constants, local vars, and pseudo vars such as self. Identifiers without sigils such as @ are considered either local vars, methods, method arguments, block parameters, pseudo variables, or other reserved words. Particularly important aspect I believe is that Ruby intentionally tries to make local vars and methods indistinguishable for human. This talk focuses only on local vars among other variables or methods.
+
+    * Keywords: parse.y, binding, yarv iseq, continuation, flip-flop operator, regular expression, and gdb
+
+    Oh by the way, the whole presentation is likely going to be done inside my Vim.
+  speakers:
+  - id: ujm
+  materials:
+  - title: Play with local vars
+    url: https://gist.github.com/ujihisa/bf0c24f8200533d89300a67be217ee39
+  video:
+    youtube_id: oNJyBZ5OAMw
+n0kada:
+  title: Timezone API
+  type: presentation
+  language: JA
+  description: |-
+    The Time, a core class, supports timezone since Ruby 2.6.
+    This talk will give what the API is, and how it is determined to cooperate with existing external libraries.
+  speakers:
+  - id: n0kada
+  video:
+    youtube_id: AjQUCWeh9sQ
+shyouhei:
+  title: The send-pop optimisation
+  type: presentation
+  language: JA
+  description: '"Sending a method to an object, then discarding its return value immediately"
+    is one of the most frequent operations that ruby does.  By eliminating such wastes
+    of time and memory, ruby execution could be much more efficient.  I will share
+    you some stories and outcomes of my journey trying to optimise that part.'
+  speakers:
+  - id: shyouhei
+  materials:
+  - title: The send-pop optimisation
+    url: https://speakerdeck.com/shyouhei/the-send-pop-optimisation
+  video:
+    youtube_id: rH81nlm1lcE
+pitr_ch:
+  title: 'TruffleRuby: Wrapping up compatibility for C extensions'
+  type: presentation
+  language: EN
+  description: |-
+    We think it is crucial that any alternative Ruby implementation aiming to be fully compatible with MRI runs the C extensions. TruffleRuby's compatibility was recently significantly improved, with much better support that almost completely removes the need to patch C extensions.
+
+    In this talk you will hear and see: how the old approach to C extensions worked and where and why it was failing short; how does the new approach work and how much closer it brings TruffleRuby to its goal to be a drop-in replacement for MRI.
+
+    We have been interpreting the C extensions (and JITing together with Ruby code) for a while, however we have been passing the Ruby objects directly into the C code which had lead to problems. We now have a new innovative technique which no longer requires patches in almost all cases. The objects are wrapped for greater compatibility and there is a virtual GC marking phase to avoid memory leaks.
+  speakers:
+  - id: pitr_ch
+  materials:
+  - title: 'TruffleRuby: Wrapping up compatibility for C extensions'
+    url: https://speakerdeck.com/pitr_ch/truffleruby-wrapping-up-compatibility-for-c-extensions
+  video:
+    youtube_id: R-vInXwpPPg
+oceanicpanda:
+  title: Working towards Bundler 3
+  type: presentation
+  language: EN
+  description: "Bundler hit a big milestone this year with the release of Bundler
+    2 \U0001F389, but not without its bumps and hurdles. We'll look into the problems
+    that some of our users have been experiencing after the Bundler 2 release, what
+    the core team has been doing to fix these issues and what we've since learned.
+    Afterwards, We'll look at the upcoming Bundler 2.1 and Bundler 3 releases."
+  speakers:
+  - id: oceanicpanda
+  materials:
+  - title: Working towards Bundler 3
+    url: https://speakerdeck.com/colby/working-towards-bundler-3
+  video:
+    youtube_id: m_KTuPuEmQ0
+sonots:
+  title: 'Red Chainer and Cumo: Practical Deep Learning in Ruby'
+  type: presentation
+  language: JA
+  description: |-
+    We will introduce Red Chainer which is a deep learning framework purely written in Ruby and Cumo which is GPU aware fast numerical library for Ruby, and talk about their evolutions.
+
+    In this talk, we describe:
+
+    * Current status about Deep Learning and Scientific Computing in Ruby.
+    * Introduction about [Red Chainer](https://github.com/red-data-tools/red-chainer) project.
+    * Introduction of the ONNX data format, and automatic generation of Ruby codes by supporting ONNX with Red Chainer.
+    * Introduction about [Cumo](https://github.com/sonots/cumo) project, and its support in Red Chainer.
+    * Recent updates about supporting Fast Convolutional Neural Networks in Red Chainer.
+
+    Also, @sonots talks about [ChainerX](https://chainer.org/announcement/2018/12/03/chainerx.html) and a plan to make a further faster deep learning with its ruby bindings.
+  speakers:
+  - id: sonots
+  - id: hatappi
+  materials:
+  - title: 'Red Chainer and Cumo: Practical Deep Learning in Ruby at RubyKaigi 2019'
+    url: https://speakerdeck.com/sonots/red-chainer-and-cumo-practical-deep-learning-in-ruby-at-rubykaigi-2019
+  video:
+    youtube_id: PdHcIn51B7Y
+jeremyevans0:
+  title: Optimization Techniques Used by the Benchmark Winners
+  type: keynote
+  language: EN
+  description: Sequel and Roda have dominated TechEmpower's independent benchmarks
+    for Ruby web frameworks for years.  This presentation will discuss optimizations
+    that Sequel and Roda use, and how to use similar approaches to improve the performance
+    of your own code.
+  speakers:
+  - id: jeremyevans0
+  materials:
+  - title: Optimization Techniques Used by the Benchmark Winners
+    url: http://code.jeremyevans.net/presentations/rubykaigi2019/index.html
+  video:
+    youtube_id: RuGZCcEL2F8

--- a/2019/data/schedule.yml
+++ b/2019/data/schedule.yml
@@ -1,0 +1,204 @@
+---
+apr18:
+  events:
+  - type: break
+    begin: '09:00'
+    end: '10:00'
+    name: Registration
+  - type: keynote
+    begin: '10:00'
+    end: '11:10'
+    talks:
+      Main Hall (3F): yukihiro_matz
+  - type: talk
+    begin: '11:20'
+    end: '12:00'
+    talks:
+      Main Hall (3F): matzbot
+  - type: break
+    begin: '12:00'
+    end: '13:30'
+    name: "Lunch \U0001F35C"
+  - type: talk
+    begin: '13:30'
+    end: '14:10'
+    talks:
+      Main Hall (3F): k0kubun
+      Multi-purpose Hall (2F): maciejmensfeld
+      409 + 410 (4F): aycabta
+      International Conference Room (5F): ota42y
+  - type: talk
+    begin: '14:20'
+    end: '15:00'
+    talks:
+      Main Hall (3F): ko1
+      Multi-purpose Hall (2F): nateberkopec
+      409 + 410 (4F): giosakti
+      International Conference Room (5F): joker1007
+  - type: break
+    begin: '15:00'
+    end: '15:40'
+    name: Afternoon Break
+  - type: talk
+    begin: '15:40'
+    end: '16:20'
+    talks:
+      Main Hall (3F): mametter
+      Multi-purpose Hall (2F): alehander42
+      409 + 410 (4F): gsamokovarov
+      International Conference Room (5F): youchan
+  - type: talk
+    begin: '16:30'
+    end: '17:10'
+    talks:
+      Main Hall (3F): ioquatix
+      Multi-purpose Hall (2F): _matthewd
+      409 + 410 (4F): nusco
+      International Conference Room (5F): watson1978
+  - type: talk
+    begin: '17:20'
+    end: '18:00'
+    talks:
+      Main Hall (3F): k_tsj
+      Multi-purpose Hall (2F): alexwwood
+      409 + 410 (4F): gao_shawnee
+      International Conference Room (5F): tenderlove
+apr19:
+  events:
+  - type: break
+    begin: '08:30'
+    end: '10:00'
+    name: Breakfast
+  - type: keynote
+    begin: '10:00'
+    end: '11:10'
+    talks:
+      Main Hall (3F): nagachika
+  - type: talk
+    begin: '11:20'
+    end: '12:00'
+    talks:
+      Main Hall (3F): samphippen
+      Multi-purpose Hall (2F): codefolio
+      409 + 410 (4F): hasumikin
+      International Conference Room (5F): ktou
+  - type: break
+    begin: '12:00'
+    end: '13:30'
+    name: "Lunch \U0001F35C"
+  - type: talk
+    begin: '13:30'
+    end: '14:10'
+    talks:
+      Main Hall (3F): Hir0_IC
+      Multi-purpose Hall (2F): fxn
+      409 + 410 (4F): Envek
+      International Conference Room (5F): yhara
+  - type: talk
+    begin: '14:20'
+    end: '15:00'
+    talks:
+      Main Hall (3F): jez
+      Multi-purpose Hall (2F): grosser
+      International Conference Room (5F): shugomaeda
+  - type: talk
+    begin: '14:20'
+    end: '15:30'
+    talks:
+      409 + 410 (4F): mrkn_workshop
+  - type: break
+    begin: '15:00'
+    end: '15:40'
+    name: Afternoon Break
+  - type: talk
+    begin: '15:40'
+    end: '16:20'
+    talks:
+      Main Hall (3F): vnmakarov
+      Multi-purpose Hall (2F): amirrajan
+      409 + 410 (4F): p0deje
+      International Conference Room (5F): udzura
+  - type: talk
+    begin: '16:30'
+    end: '17:10'
+    talks:
+      Main Hall (3F): estolfo
+      Multi-purpose Hall (2F): nirvdrum
+      409 + 410 (4F): MikeMcQuaid
+      International Conference Room (5F): tanaka_akr
+  - type: lt
+    begin: '17:20'
+    end: '18:20'
+    name: Lightning Talks
+apr20:
+  events:
+  - type: break
+    begin: '08:30'
+    end: '10:00'
+    name: Breakfast
+  - type: talk
+    begin: '10:00'
+    end: '11:10'
+    talks:
+      Main Hall (3F): rubylangorg
+  - type: talk
+    begin: '11:20'
+    end: '12:00'
+    talks:
+      Main Hall (3F): yuri_at_earth
+      Multi-purpose Hall (2F): zelivans
+      409 + 410 (4F): searls
+      International Conference Room (5F): riseshia
+  - type: break
+    begin: '12:00'
+    end: '13:30'
+    name: "Lunch \U0001F35C"
+  - type: talk
+    begin: '13:30'
+    end: '14:10'
+    talks:
+      Main Hall (3F): soutaro
+      Multi-purpose Hall (2F): headius
+      409 + 410 (4F): PeterQuines
+      International Conference Room (5F): sue445
+  - type: talk
+    begin: '14:20'
+    end: '15:00'
+    talks:
+      Main Hall (3F): hsbt
+      Multi-purpose Hall (2F): kddeisz
+      International Conference Room (5F): frsyuki
+  - type: talk
+    begin: '14:20'
+    end: '15:30'
+    talks:
+      409 + 410 (4F): m_seki
+  - type: break
+    begin: '15:00'
+    end: '15:40'
+    name: Afternoon Break
+  - type: talk
+    begin: '15:40'
+    end: '16:20'
+    talks:
+      Main Hall (3F): mrkn
+      Multi-purpose Hall (2F): tongueroo
+      409 + 410 (4F): ujm
+      International Conference Room (5F): n0kada
+  - type: talk
+    begin: '16:30'
+    end: '17:10'
+    talks:
+      Main Hall (3F): shyouhei
+      Multi-purpose Hall (2F): pitr_ch
+      409 + 410 (4F): oceanicpanda
+      International Conference Room (5F): sonots
+  - type: keynote
+    begin: '17:20'
+    end: '18:30'
+    talks:
+      Main Hall (3F): jeremyevans0
+  - type: break
+    begin: '18:30'
+    end: '18:45'
+    name: Closing

--- a/2019/data/speakers.yml
+++ b/2019/data/speakers.yml
@@ -1,0 +1,664 @@
+---
+keynotes:
+  yukihiro_matz:
+    id: yukihiro_matz
+    name: Yukihiro "Matz" Matsumoto
+    bio: The Creator of Ruby
+    github_id: matz
+    twitter_id: yukihiro_matz
+    gravatar_hash: 0ec4920185b657a03edf01fff96b4e9b
+  nagachika:
+    id: nagachika
+    name: nagachika
+    bio: |-
+      CRuby Commiter
+      CRuby stable branch maintainer.
+    github_id: nagachika
+    twitter_id: nagachika
+    gravatar_hash: 250aeda838f8596050901d8f7db3ef31
+  jeremyevans0:
+    id: jeremyevans0
+    name: Jeremy Evans
+    bio: Jeremy Evans is the lead developer of the Sequel database library, the Roda
+      web toolkit, the Rodauth authentication framework, and many other Ruby libraries.
+      He has contributed to CRuby and JRuby, as well as many popular Ruby libraries.
+      He is the maintainer of Ruby ports for the OpenBSD operating system.
+    github_id: jeremyevans
+    twitter_id: jeremyevans0
+    gravatar_hash: f183bcc4176b308c9edabe79299e448f
+speakers:
+  tenderlove:
+    id: tenderlove
+    name: Aaron Patterson
+    bio: Aaron is on the Ruby core team, the Rails core team, and the team that takes
+      care of his cat, Gorby puff.   Someday he will find the perfect safety gear
+      to wear while extreme programming.
+    github_id: tenderlove
+    twitter_id: tenderlove
+    gravatar_hash: f29327647a9cff5c69618bae420792ea
+  p0deje:
+    id: p0deje
+    name: Alex Rodionov
+    bio: I have been doing software testing for more than 12 years. For the last 5
+      years, I help to improve the quality in Toptal, the largest fully distributed
+      high-skilled workforce in the world. Contributor to Mozilla. A developer of
+      Watir. Selenium committer and maintainer of selenium-webdriver gem.
+    github_id: p0deje
+    twitter_id: p0deje
+    gravatar_hash: d049f551aa71e6326c74002ac8e6788a
+  alexwwood:
+    id: alexwwood
+    name: Alex Wood
+    bio: Author of the Ruby runtime for AWS Lambda. Maintainer of the AWS SDK for
+      Ruby.
+    github_id: 
+    twitter_id: alexwwood
+    gravatar_hash: fceb24dfe052368eec601f5a0934fa42
+  alehander42:
+    id: alehander42
+    name: Alexander Ivanov
+    bio: 'A programmer with interest in language development: worked as a web developer,
+      loves open source, currently works on development tools. Loves language design
+      and compilers, contributed to Elixir, currently contributing to Nim. '
+    github_id: alehander42
+    twitter_id: 
+    gravatar_hash: 3113f7634e4f7215a132bc0d453ac19e
+  amirrajan:
+    id: amirrajan
+    name: Amir Rajan
+    bio: "Amir Rajan is a pretty decent dev and is constantly trying to improve in
+      his craft. He’s a jack of all trades, being comfortable with a number of platforms
+      and languages. \n\nLast but certainly not least, Amir is the creator of A Dark
+      Room iOS. This RPG conquered the world and took the #1 spot in the App Store
+      and placed in the top #10 paid apps across 70 countries. It has been downloaded
+      over 2.5 millions times and is a staple game in the App Store with over 25,000
+      five star reviews."
+    github_id: amirrajan
+    twitter_id: amirrajan
+    gravatar_hash: 433d6daba7a9f7e563b793c0890ef906
+  Envek:
+    id: Envek
+    name: Andrey Novikov
+    bio: |-
+      Brings a lot of Ruby applications to the devastating lands of production and enforcing them work for the all humanity benefit and causing happiness among users.
+
+      Currently conquer the Earth together with all the Evil Martians forces. Resistance is futile!
+    github_id: Envek
+    twitter_id: Envek
+    gravatar_hash: d0e95abdd0aed671ebd0920c16d393d4
+  zelivans:
+    id: zelivans
+    name: Ariel Zelivansky
+    bio: I am the head of security research at Twistlock. I do security with a special
+      affection for the Ruby language.
+    github_id: zelivans
+    twitter_id: 
+    gravatar_hash: 64bab50c0521821f24007f4d12b257c3
+  headius:
+    id: headius
+    name: Charles Nutter
+    bio: Charles works on JVM languages at Red Hat.
+    github_id: headius
+    twitter_id: headius
+    gravatar_hash: f1d37642fdaa1662ff46e4c65731e9ab
+  oceanicpanda:
+    id: oceanicpanda
+    name: Colby Swandale
+    bio: Maintainer of RubyGems and Bundler.
+    github_id: colby-swandale
+    twitter_id: oceanicpanda
+    gravatar_hash: 81faf651bd1a239298307c7fd6efe944
+  PeterQuines:
+    id: PeterQuines
+    name: Colin Fulton
+    bio: Colin Fulton is a frontend developer and web accessibility specialist for
+      Duo Security, a division of Cisco in Ann Arbor, Michigan. Colin is amazed and
+      amused that it took significantly more character to write this simple bio than
+      it did to implement Conway's "Game of Life" in Ruby.
+    github_id: justcolin
+    twitter_id: PeterQuines
+    gravatar_hash: bb90145b3852488aef3e2f2d6d2b0d2f
+  rubylangorg:
+    id: rubylangorg
+    name: CRuby Committers
+    bio: ''
+    github_id: 
+    twitter_id: rubylangorg
+    gravatar_hash: ce6d997265cefede13ee7e7e2a2cf9b2
+  estolfo:
+    id: estolfo
+    name: Emily Stolfo
+    bio: Emily works at Elastic where she maintains the Ruby client and the Rails
+      integrations gems. She is also an adjunct faculty of Columbia University and
+      has taught courses on databases and web development. Although originally from
+      New York, Emily currently lives in Berlin where she likes running long distances
+      and making ceramics.
+    github_id: estolfo
+    twitter_id: 
+    gravatar_hash: 672b94bc900f25ed4392787236ec4140
+  gsamokovarov:
+    id: gsamokovarov
+    name: Genadi Samokovarov
+    bio: Genadi is a Ruby developer from Sofia, Bulgaria. Ruby on Rails contributor
+      and the maintainer of the web-console gem.
+    github_id: gsamokovarov
+    twitter_id: 
+    gravatar_hash: 1ac5a00efa41cd58c421d3cd98dda7b9
+  giosakti:
+    id: giosakti
+    name: Giovanni Sakti
+    bio: |-
+      Gio comes from Jakarta whom currently works for GO-JEK as systems engineer. GO-JEK is a hyperlocal startup from Indonesia that listed in Fortune as company that are changing the world (http://fortune.com/change-the-world/2017/go-jek/).
+
+      Gio organizes some meetups in Jakarta, including ruby.id and jakartajs.org. He also loves to take part as mentor in bootcamps or workshops. His interest includes programming languages and developer automation.
+    github_id: giosakti
+    twitter_id: giosakti
+    gravatar_hash: 03d1338a972b823306c07f7a16fbae86
+  sue445:
+    id: sue445
+    name: Go Sueyoshi
+    bio: "I was born and raised in Fukuoka. My body is made of Tonkotsu-Ramen \U0001F35C\n\nI'm
+      a maintainer of rubicure, Itamae, chatwork-ruby and many many OSS.\n\nI'm engineer
+      of pixiv.inc. I'm working as like a SRE (web application, infrastructure and
+      CI engineer).\n\nPretty Cure is my life, and Cure Peace is my wife\U0001F49B"
+    github_id: sue445
+    twitter_id: sue445
+    gravatar_hash: 2b680c5f22146e764e2998dd4595ec93
+  Hir0_IC:
+    id: Hir0_IC
+    name: Hiromasa Ishii
+    bio: |-
+      an assistant general manager of mruby Forum.
+      an embedded system division manager of SCSK Kyushu corp.
+      Hiromasa Ishii ,  mruby contributor ,has been working with Matz from the begging of the mruby itself development,and now is focusing on spreading mruby through NPO activities.
+    github_id: Hir0
+    twitter_id: Hir0_IC
+    gravatar_hash: 6f6ce55512ae31423d28ad10b909bcfc
+  hsbt:
+    id: hsbt
+    name: Hiroshi SHIBATA
+    bio: "A member of Ruby core team. He maintains RubyGems, Rake, rdoc, psych, ruby-build,
+      etc. and He is an administrator of ruby-lang.org and supports to develop the
+      environment of Ruby language.\n\nHe is also Executive Officer in GMO Pepabo,
+      Inc. His most interest things are “Productivity”  He believes, there's business
+      value in fun. The team member happiness can make valuable products. "
+    github_id: hsbt
+    twitter_id: hsbt
+    gravatar_hash: eabad423977cfc6873b8f5df62b848a6
+  hasumikin:
+    id: hasumikin
+    name: Hitoshi HASUMI
+    bio: A programmer of Monstar Lab at Matsue (AKA Ruby City) office
+    github_id: hasumikin
+    twitter_id: hasumikin
+    gravatar_hash: d62b18efd2549587e712cebf6403861a
+  aycabta:
+    id: aycabta
+    name: ITOYANAGI Sakura
+    bio: ''
+    github_id: aycabta
+    twitter_id: 
+    gravatar_hash: 43da97eeeac8fafd2bf196db1f19c534
+  jez:
+    id: jez
+    name: Jake Zimmerman
+    bio: A self proclaimed "types enthusiast," Jake enjoys learning how type systems
+      can help bring clarity and focus to large codebases. He works on the Sorbet
+      core team at Stripe where he brings his experience with types and programming
+      languages to help make engineers more productive every day.
+    github_id: jez
+    twitter_id: 
+    gravatar_hash: 5b09dc310b18fe8f18120e5761e65176
+  joker1007:
+    id: joker1007
+    name: joker1007
+    bio: |-
+      Repro inc. CTO
+      Ruby/Rails Programmer
+    github_id: joker1007
+    twitter_id: joker1007
+    gravatar_hash: a5e5ee2fb9e4ce3c728ed9e3ef6e916f
+  searls:
+    id: searls
+    name: Justin Searls
+    bio: Justin Searls is on a mission to find the root causes that have led to most
+      software being buggy, unpleasant to use, and hard to maintain. He cofounded
+      Test Double, an agency of like-minded consultants who join client teams to write
+      great code while making software better for everyone.
+    github_id: searls
+    twitter_id: searls
+    gravatar_hash: 4fdf06ef4b312b864accf921af6c2f79
+  znz:
+    id: znz
+    name: Kazuhiro NISHIYAMA
+    bio: CRuby Committer
+    github_id: znz
+    twitter_id: znz
+    gravatar_hash: 2c28563e5258a37b8e664caf991130b4
+  k_tsj:
+    id: k_tsj
+    name: Kazuki Tsujimoto
+    bio: Kazuki Tsujimoto is an infrastructure engineer at Nomura Research Institute,
+      Ltd. He is also a CRuby committer.
+    github_id: k-tsj
+    twitter_id: k_tsj
+    gravatar_hash: 303dd57f37d64288bb4f0336332a8882
+  284km:
+    id: 284km
+    name: Kazuma Furuhashi
+    bio: Kazuma Furuhashi is a programmer and the author of Charty, a visualization
+      library for Ruby. A member of Asakusa.rb, Red Data Tools and working at Speee
+      Inc.
+    github_id: 284km
+    twitter_id: 284km
+    gravatar_hash: 7ef4ab70ee295c821f8b77fab3aa87cf
+  mrkn:
+    id: mrkn
+    name: Kenta Murata
+    bio: |-
+      A full-time CRuby committer at Speee Inc.
+      I'm currently focusing on making Ruby a data-science-ready programming language.
+    github_id: mrkn
+    twitter_id: mrkn
+    gravatar_hash: 819b3c0a25f9708fd32261b8ae2d23f6
+  kddeisz:
+    id: kddeisz
+    name: Kevin Deisz
+    bio: Kevin is a software developer living in Boston. He is currently serving as
+      the CTO of CultureHQ, a startup in Boston based on making workplace community
+      better. In his spare time he plays music, breaks the Ruby virtual machine, and
+      drinks good New England beer.
+    github_id: kddeisz
+    twitter_id: kddeisz
+    gravatar_hash: 8a66c2a7197be751b21ebd35319ec797
+  nirvdrum:
+    id: nirvdrum
+    name: Kevin Menard
+    bio: Kevin is a researcher at Oracle Labs where he works as part of a team developing
+      TruffleRuby, a high performance Ruby implementation. He’s been involved with
+      the Ruby community since 2008 and has been doing open source in some capacity
+      since 1999. In his spare time he’s a father of two and enjoys playing drums.
+    github_id: nirvdrum
+    twitter_id: nirvdrum
+    gravatar_hash: 303aae3354beb438eaa44000b1f2f3fd
+  ko1:
+    id: ko1
+    name: Koichi Sasada
+    bio: Koichi Sasada is a programmer, mainly developing Ruby interpreter (CRuby/MRI).
+      He received Ph.D (Information Science and Technology) from the University of
+      Tokyo, 2007.  Now he is still working on MRI development at Cookpad Inc. He
+      is also a director of Ruby Association.
+    github_id: ko1
+    twitter_id: 
+    gravatar_hash: 990397e8b38d6f5f4ae8ff343e8b883a
+  ktou:
+    id: ktou
+    name: Kouhei Sutou
+    bio: 'He is a free software programmer and the president of ClearCode Inc. He
+      is also the namer of ClearCode Inc. The origin of the company name is "clear
+      code". We will be programmers that code clear code as our company name suggests.
+      He is interested in how to tell other programmers about how he codes clear code.
+
+'
+    github_id: kou
+    twitter_id: ktou
+    gravatar_hash: 2d9386b1504e581be390af978e05a8b9
+  kozo2:
+    id: kozo2
+    name: Kozo Nishida
+    bio: A Ruby newbie
+    github_id: kozo2
+    twitter_id: kozo2
+    gravatar_hash: 3388725ae095a3504e66e3f0374b2739
+  maciejmensfeld:
+    id: maciejmensfeld
+    name: Maciej Mensfeld
+    bio: I'm a software architect and engineer working with Castle.io. I have experience
+      in a wide variety of business applications built using multiple Ruby frameworks.
+      I’m particularly interested in code quality assurance and the way it affects
+      the software development process. I’m an active OSS contributor and maintainer
+      of various projects including Karafka – Framework used to simplify Apache Kafka-based
+      Ruby applications development.
+    github_id: mensfeld
+    twitter_id: maciejmensfeld
+    gravatar_hash: c571205817eabfe7ae22de3b74ffe900
+  m_seki:
+    id: m_seki
+    name: Masatoshi SEKI
+    bio: Masatoshi Seki is a Ruby committer and the author of several Ruby standard
+      libraries including dRuby, ERB, and Rinda. He’s an expert in object-oriented
+      programming, distributed systems, and eXtreme programming. He has been speaking
+      at RubyKaigi every year since 2006 when the Kaigi first started.
+    github_id: seki
+    twitter_id: m_seki
+    gravatar_hash: 40f4d1f2e77078955bd01e9fb4a503ba
+  takahashim:
+    id: takahashim
+    name: Masayoshi Takahashi
+    bio: Masayoshi Takahashi is an old-time Rubyist and the founder of Nihon Ruby
+      no Kai, a non-profit Ruby community in Japan. He is also the founder of Tatsu-Zine
+      Publising, the e-book publisher for IT engineers in Japan.
+    github_id: takahashim
+    twitter_id: 
+    gravatar_hash: 21a4b941766d805333e11c5766be43b4
+  _matthewd:
+    id: _matthewd
+    name: Matthew Draper
+    bio: By day a Rails developer for Buildkite, a CI service that executes your tests
+      on your own machines, by night, Matthew is a Rails Developer -- a member of
+      Rails Core since 2015, with light fingerprints throughout the framework.
+    github_id: matthewd
+    twitter_id: _matthewd
+    gravatar_hash: e55df1cc7d5fdb4ae9bc2afcb9afe7e4
+  matzbot:
+    id: matzbot
+    name: Matz & the Ruby Core Team
+    bio: ''
+    github_id: matzbot
+    twitter_id: 
+    gravatar_hash: e24c49d64733324769ec858cadd34920
+  grosser:
+    id: grosser
+    name: Michael Grosser
+    bio: |-
+      Mostly Ruby/Rails hacker that tries to OS everything.
+      Maintaining about 100 gems and involved in many more repos, working with ruby professionally since 2007. Senior staff engineer at Zendesk.
+    github_id: grosser
+    twitter_id: grosser
+    gravatar_hash: 9e57f24b9d4603e9d0fdd9d669c85a2c
+  MikeMcQuaid:
+    id: MikeMcQuaid
+    name: Mike McQuaid
+    bio: |-
+      Mike McQuaid is a senior engineer at GitHub where he works from home in Edinburgh. At GitHub he works on improving the quality of internal and external software whilst attempting to automate himself out of the job.
+
+      Outside of work, he is the lead maintainer of the Homebrew package manager for macOS, author of Git in Practice (published with Manning) and has contributed to a wide array of other open source projects including KDE and the Linux kernel.
+    github_id: MikeMcQuaid
+    twitter_id: MikeMcQuaid
+    gravatar_hash: 215e0166d4d8265395c5d9076da73c70
+  sonots:
+    id: sonots
+    name: Naotoshi Seo
+    bio: 'The author of Cumo, CUDA aware numerical library for Ruby. CRuby, Fluentd,
+      and Chainer committer working at ZOZO Technologies, Inc. '
+    github_id: sonots
+    twitter_id: sonots
+    gravatar_hash: aef92c3acc29ad8543e04135687fc4f1
+  nateberkopec:
+    id: nateberkopec
+    name: Nate Berkopec
+    bio: "Nate is the owner of Speedshop, a Ruby on Rails performance consultancy,
+      and the author of The Complete Guide to Rails Performance. Nate has taught Ruby
+      and Rails performance skills in workshops all over the world, and is a contributor
+      to several open source projects, such as Ruby on Rails, Puma and Sentry.\L His
+      favorite Japanese musical artists are 山下 達郎, 角松 敏生 and カシオペア."
+    github_id: nateberkopec
+    twitter_id: nateberkopec
+    gravatar_hash: 360db81fc4d83de5f6b6a13a398d4cb3
+  codefolio:
+    id: codefolio
+    name: Noah Gibbs
+    bio: Noah is a Ruby Fellow for AppFolio, working on Ruby performance and related
+      tooling. He wrote the book "Rebuilding Rails" about understanding Rails as "really
+      just Ruby."
+    github_id: noahgibbs
+    twitter_id: codefolio
+    gravatar_hash: 5e8107f48d4471a40de325151d589b6d
+  n0kada:
+    id: n0kada
+    name: nobu
+    bio: A Ruby committer
+    github_id: nobu
+    twitter_id: n0kada
+    gravatar_hash: f1d6cc2b735bfd82c8773172da2aeab9
+  ota42y:
+    id: ota42y
+    name: ota42y
+    bio: ruby on rails engineer
+    github_id: ota42y
+    twitter_id: ota42y
+    gravatar_hash: b13a6d260cc92e406fc0b8a2facbc312
+  nusco:
+    id: nusco
+    name: Paolo Perrotta
+    bio: 'Paolo is the author of two books for the Pragmatic Programmers: Metaprogramming
+      Ruby, and the upcoming Programming Machine Learning. He’s been a developer for
+      a long time, ranging from embedded to enterprise software, computer games, and
+      web applications. He''s got a base camp in Bologna, Italy.'
+    github_id: nusco
+    twitter_id: nusco
+    gravatar_hash: 0d509031a015eb9e28228723963e2628
+  ptarjan:
+    id: ptarjan
+    name: Paul Tarjan
+    bio: Lifelong nerd and engineer. Nowadays he works at Stripe mostly on developer
+      productivity and infrastructural components like rate limiters, core abstractions,
+      large code refactors and language design. In the past he helped build HHVM and
+      Hack at Facebook, worked on the Open Graph and changed your search results to
+      not just be 10 blue links.
+    github_id: ptarjan
+    twitter_id: ptarjan
+    gravatar_hash: fb14493c56f049fbcadffc0f124a945f
+  pitr_ch:
+    id: pitr_ch
+    name: Petr Chalupa
+    bio: Petr is a researcher at Oracle Labs where he works as part of a team developing
+      a high performance Ruby implementation called TruffleRuby. He is the maintainer
+      of concurrent-ruby, a tool-box of concurrency abstractions for Ruby, a 60th
+      most downloaded gem. He is a happy Ruby user for 10 years.
+    github_id: pitr-ch
+    twitter_id: pitr_ch
+    gravatar_hash: 95bcc8d80c505fda705d5c33098f0136
+  frsyuki:
+    id: frsyuki
+    name: Sadayuki Furuhashi
+    bio: 'Founder & Software Architect at Treasure Data, Inc. "Sada" is an enthusiast
+      for open-source software design that helps adoption of distributed systems in
+      production. His software list includes MessagePack, Fluentd, Embulk, and Digdag.
+      GitHub: https://github.com/frsyuki'
+    github_id: frsyuki
+    twitter_id: frsyuki
+    gravatar_hash: aba3c1870b6cea67493617e5a343b586
+  samphippen:
+    id: samphippen
+    name: Sam Phippen
+    bio: Sam Phippen is a lead maintainer of the RSpec testing framework. He's been
+      writing Ruby for just about a decade, and still remembers 1.8.6. He's sad that
+      he can't hug every cat.
+    github_id: 
+    twitter_id: samphippen
+    gravatar_hash: 8ca3202a7c4591caa91e66cf4ad4b116
+  ioquatix:
+    id: ioquatix
+    name: Samuel Williams
+    bio: I am a software engineer, and I am motivated by the beauty I uncover when
+      building complex systems.
+    github_id: ioquatix
+    twitter_id: ioquatix
+    gravatar_hash: 1373435a1059a97614969ab154c5b224
+  riseshia:
+    id: riseshia
+    name: Sangyong Sim
+    bio: Software engineer at Cookpad Inc.
+    github_id: riseshia
+    twitter_id: riseshia
+    gravatar_hash: 0f54aa7d6df3dbcbde91a02d0e2f75d5
+  gao_shawnee:
+    id: gao_shawnee
+    name: Shawnee Gao
+    bio: 'Full Stack Software Engineer at Square Inc. living in San Francisco. I am
+      passionate about software that delivers both great customer and developer experience.
+      Outside of work I am a coffee enthusiast and painter. '
+    github_id: shawneegao
+    twitter_id: gao_shawnee
+    gravatar_hash: fba080a087394e1860c8688e8db9458d
+  watson1978:
+    id: watson1978
+    name: Shizuo Fujita
+    bio: Engineer at Ubiregi, Inc.
+    github_id: Watson1978
+    twitter_id: watson1978
+    gravatar_hash: 6e8aca910e7ee095397d3b90acb25f6c
+  shugomaeda:
+    id: shugomaeda
+    name: Shugo Maeda
+    bio: The Creator of Textbringer, a Ruby committer, Director of Network Applied
+      Communication Laboratory, and Secretary general of the Ruby Association
+    github_id: shugo
+    twitter_id: shugomaeda
+    gravatar_hash: 18a797893e6768e048c1d15429f96bb4
+  soutaro:
+    id: soutaro
+    name: Soutaro Matsumoto
+    bio: Soutaro is a software engineer working for Sider, using his time to develop
+      program analysis for code review automation.
+    github_id: soutaro
+    twitter_id: soutaro
+    gravatar_hash: 1fab9d01b25e99522f3dfd01e3d4cb51
+  k0kubun:
+    id: k0kubun
+    name: Takashi Kokubun
+    bio: Optimizing Ruby's JIT compiler and maintaining Haml and ERB. Senior Software
+      Engineer at Arm Treasure Data.
+    github_id: k0kubun
+    twitter_id: k0kubun
+    gravatar_hash: '08d5432a5bc31e6d9edec87b94cb1db1'
+  tanaka_akr:
+    id: tanaka_akr
+    name: Tanaka Akira
+    bio: |-
+      Ruby committer,
+      Researcher of National Institute of Advanced Industrial Science and Technology (AIST)
+    github_id: 
+    twitter_id: tanaka_akr
+    gravatar_hash: b11f10c4cd9d53970e7be20caa43f940
+  ujm:
+    id: ujm
+    name: Tatsuhiro Ujihisa
+    bio: Vim
+    github_id: ujihisa
+    twitter_id: ujm
+    gravatar_hash: d9d0ceb387e3b6de5c4562af78e8a910
+  tom_enebo:
+    id: tom_enebo
+    name: Thomas E Enebo
+    bio: 'Thomas Enebo co-leads the JRuby project. He has been passionately working
+      on JRuby for many years. When not working on JRuby, he is writing Ruby applications,
+      playing with Java, and enjoying a decent beer. '
+    github_id: enebo
+    twitter_id: tom_enebo
+    gravatar_hash: 13313ac2ec7ba7c43b1b952db034ff3b
+  tongueroo:
+    id: tongueroo
+    name: Tung Nguyen
+    bio: |-
+      I run BoltOps, a consultancy focused on software and infrastructure on AWS. Have a few open source tools:
+
+      * Jets: Ruby Serverless Framework http://rubyonjets.com/
+      * UFO: ECS Deployment tool http://ufoships.com/
+      * Lono: CloudFormation Framework http://lono.cloud/
+      * Sonic: Swiss army knife tool http://sonic-screwdriver.cloud/
+
+      Been lucky enough to been recognized as an AWS Hero. Here's my LinkedIn: https://www.linkedin.com/in/tongueroo
+
+      Ultimately, I'm a Ruby developer at heart.
+    github_id: tongueroo
+    twitter_id: 
+    gravatar_hash: 3b665e30662d48a0da4cd78569b396df
+  udzura:
+    id: udzura
+    name: Uchio KONDO
+    bio: |-
+      Rubyist, containers enthusiast, system programming novice. One of the writers of books "Perfect Ruby" / "Perfect Ruby on Rails" (both in Japanese).
+      He lives in Fukuoka - the "coast" city of "west" Japan, works at GMO Pepabo, Inc. as R&D/Dev Productivity Engineer, and holds Fukuoka.rb local meetup. He also is a organizer of RailsGirls Fukuoka #1 and Fukuoka RubyKaigi 02.
+    github_id: udzura
+    twitter_id: udzura
+    gravatar_hash: 2cf373725ded741824c50fd571eda6e1
+  shyouhei:
+    id: shyouhei
+    name: Urabe, Shyouhei
+    bio: Money Forward, Inc. hire Shyouhei, a long-time ruby-core committer, to contribute
+      to the whole ruby ecosystem. Being a full-time ruby-core developer, his current
+      interest is to speed up ruby execution by modifying its internals. Doing so
+      is not straight-forward because of ruby's highly dynamic nature. To tackle this
+      problem he is implementing a variety of optimisation techniques that are yet
+      to be applied to it.
+    github_id: shyouhei
+    twitter_id: shyouhei
+    gravatar_hash: 9d2f78236e45a335301ba1195026105d
+  vnmakarov:
+    id: vnmakarov
+    name: Vladimir Makarov
+    bio: Vladimir Makarov is a software developer. His major interests lay in algorithms,
+      programming languages, compilers and JITs. Vladimir finished Moscow Institute
+      of Physics and Technology and got his PhD in computer science in Russian Academy
+      of Sciences. Last 20 years he has been working on GCC in RedHat. Vladimir started
+      his work on Ruby MRI in 2015.  His MRI projects are new hash tables and ongoing
+      implementation of new VM instructions and JIT. Vladimir lives in Toronto, Canada.
+    github_id: vnmakarov
+    twitter_id: 
+    gravatar_hash: 42979fbb3647ad7cd1ce86e5a1dc0e28
+  fxn:
+    id: fxn
+    name: Xavier Noria
+    bio: Everlasting student · Rails Core Team · Ruby Hero · Freelance · Live lover
+    github_id: fxn
+    twitter_id: 
+    gravatar_hash: 7223c62b7310e164eb79c740188abbda
+  youchan:
+    id: youchan
+    name: Yoh Osaki
+    bio: |-
+      Software engineer at Retrieva inc.
+      Author of Hyalite which is react like virtual DOM library.
+      Member of Asakusa.rb, Chidoriashi.rb
+    github_id: youchan
+    twitter_id: youchan
+    gravatar_hash: b54abc5e7463fe6470c379e97e3f2477
+  yuri_at_earth:
+    id: yuri_at_earth
+    name: Yurie Yamane(team yamanekko)
+    bio: |-
+      "nora" mrubyist.
+      A member of Team Yamanekko.
+      A member of TOPPERS Project.
+    github_id: yurie
+    twitter_id: yuri_at_earth
+    gravatar_hash: 0607f2778a478327d55f9b4fb7954a60
+  hatappi:
+    id: hatappi
+    name: Yusaku Hatanaka
+    bio: "The author of Red Chainer.\nI'm working at Mercuri Inc.  \nRed Data Tools
+      project member.  "
+    github_id: hatappi
+    twitter_id: hatappi
+    gravatar_hash: c582b722e015633f7900083f8ea75732
+  mametter:
+    id: mametter
+    name: Yusuke Endoh
+    bio: '''A full-time MRI committer at Cookpad, Inc.  He has been interested in
+      testing, analyzing, abusing of Ruby.  He is an advocate of "transcendental programming"
+      that creates a useless program like this bio. (`_`)''.then{|s|eval(t=%q(puts"''#{s.sub(?_,?_+?_)}''.then{|s|eval(t=%q(#{t}))}"))}'
+    github_id: mame
+    twitter_id: mametter
+    gravatar_hash: e73159002200b33d51b7a6a312f2440e
+  yhara:
+    id: yhara
+    name: Yutaka HARA
+    bio: A Ruby programmer from Shimane, Japan. Designer of Enumerable#lazy. Author
+      of 『Rubyでつくる奇妙なプログラミング言語』("Making Esoteric Programming Languages with Ruby").
+    github_id: yhara
+    twitter_id: yhara
+    gravatar_hash: 26e1ba9a02729b2d6013604135221aae
+  zah:
+    id: zah
+    name: Zahary Karadjov
+    bio: 'Zahary is member of the core compiler team of the Nim programming language.
+      He joined the project 7 years ago, hoping that one day Nim will surpass C++
+      in usage and popularity. His career started as a game engine developer, where
+      he learned how to push the modern hardware to its limits, but eventually he
+      went to become the first Nim hire at Status.im, where his team is building Nimbus:
+      an Ethereum 2.0 Sharding Client for Resource-Restricted Devices.'
+    github_id: zah
+    twitter_id: 
+    gravatar_hash: e85951a8fe600d5b6d2772c2b0ae9b15

--- a/2020-takeout/data/presentations.yml
+++ b/2020-takeout/data/presentations.yml
@@ -1,0 +1,381 @@
+---
+yukihiro_matz:
+  title: Matz Keynote
+  type: keynote
+  language: JA
+  description: ''
+  speakers:
+  - id: yukihiro_matz
+  video:
+    youtube_id: wVrJZReHlM8
+mametter:
+  title: 'Type Profiler: a Progress Report of a Ruby 3 Type Analyzer'
+  type: presentation
+  language: JA
+  description: Type Profiler is a type inference tool for plain Ruby code. It analyzes
+    Ruby code that has no type information and guesses a type of the modules and methods
+    in the code. The output will serve as a signature for external type checkers like
+    Sorbet and Steep. Since 2019, we have been developing the tool as one of the key
+    features for Ruby 3 static analysis, and now it works with some practical applications.
+    In this talk, we briefly explain what and how Type Profiler works, present a roadmap
+    and progress of the development, and discuss how useful it is for practical applications
+    with some demos.
+  materials:
+    - title: "Type Profiler: Ambitious Type Inference for Ruby 3"
+      url: https://www.slideshare.net/mametter/type-profiler-ambitious-type-inference-for-ruby-3-238384550
+  speakers:
+  - id: mametter
+  video:
+    youtube_id: 6KcFdQWp8W0
+etagwerker:
+  title: 'RubyMem: The Leaky Gems Database for Bundler'
+  type: presentation
+  language: EN
+  description: "Out of memory errors are quite tricky. Our first reaction is always
+    the same: \"It can't be my code, it must be one of my dependencies!\" What if
+    you could quickly check that with bundler? \n\nIn this talk you will learn about
+    memory leaks, out of memory errors, and leaky dependencies. You will learn how
+    to use `bundler-leak`, a community-driven, open source tool that will make your
+    life easier when debugging memory leaks."
+  speakers:
+  - id: etagwerker
+jeremyevans0:
+  title: 'Keyword Arguments: Past, Present, and Future'
+  type: presentation
+  language: EN
+  description: Ruby 3 will separate keyword arguments from positional arguments, which
+    causes the biggest backwards compatibility issues in Ruby since Ruby 1.9.  This
+    presentation will discuss the history of keyword arguments, how keyword arguments
+    are handled internally, how keyword arguments were separated from positional arguments
+    internally, and possible future improvements in the handling of keyword arguments.
+  speakers:
+  - id: jeremyevans0
+  video:
+    youtube_id: rxJRrccXRfg
+kishima:
+  title: Now is the time to create your own (m)Ruby computer
+  type: presentation
+  language: EN
+  description: mruby has been known as a good tool for supporting server applications
+    and embedded softwares like an IoT application on a small CPU whose resource is
+    limited. Now times are changing. mruby gets more power from recent micro processors.
+    I believe now Ruby engineers can create their own computer as per their wish.
+    Basic process and essential technique how to create an original (m)Ruby computer
+    will be shown in the talk with a live demonstration of the computer.
+  speakers:
+  - id: kishima
+  video:
+    youtube_id: N24gfQJMXfs
+paracycle:
+  title: Reflecting on Ruby Reflection for Rendering RBIs
+  type: presentation
+  language: EN
+  description: |-
+    As part of our adoption process of Sorbet at Shopify, we needed an automated way to teach Sorbet about our ~400 gem dependencies. We decided to tackle this problem by generating interface files (RBI) for each gem via runtime reflection.
+
+    However, this turns out to not be as simple as it sounds; the flexible nature of Ruby allows gem authors to do many wild things that make this Hard. Come and hear about all the lessons that we learnt about runtime reflection in Ruby while building `tapioca`.
+  speakers:
+  - id: paracycle
+  video:
+    youtube_id: OJRQAn6BfpE
+yuji_yokoo:
+  title: Developing your Dreamcast apps and games with mruby
+  type: presentation
+  language: EN
+  description: |-
+    What would you make, if you can run your Ruby code on Dreamcast?
+
+    Well, now you can! I have been working on my development setup for running mruby code on Dreamcast. I would like to show you what I have developed so far and how you can get started. I would also like to tell you why development on Dreamcast is a great idea and share a few things I learned along the way.
+  speakers:
+  - id: yuji_yokoo
+  video:
+    youtube_id: oqBTlYUkGXk
+shyouhei:
+  title: On sending methods
+  type: presentation
+  language: JA
+  description: As you have noticed 2.7 is faster than older ruby versions.  One of
+    the main reason for this is my optimisation around method invocations.  Let me
+    share what was suboptimal, and how was that fixed.
+  speakers:
+  - id: shyouhei
+  video:
+    youtube_id: IAkrGf9XJi0
+johnlinvc:
+  title: 'mruby-rr: Time Traveling Debugger For mruby Using rr'
+  type: presentation
+  language: EN
+  description: |-
+    Debugging bugs that don't happen every time is painful. It needs both technique and luck.
+    When dealing with these, a mistyped `continue` command is irreversible and will take us a whole afternoon just to reproduce the issue again.
+
+    [mruby-rr](https://github.com/johnlinvc/mruby-rr) comes to rescue! It's a Time Traveling Debugger for mruby that based on Mozilla's rr. `mruby-rr` supports record and replay of mruby program execution. We can record the tough bug using mruby-rr for just once. Afterwards we can playback the execution as many times as we want. `mruby-rr` can also do time traveling operations like `reverse-next` and evaluating expressions.
+  speakers:
+  - id: johnlinvc
+  video:
+    youtube_id: E5ifh9yZCKk
+ko1:
+  title: Ractor report
+  type: presentation
+  language: JA
+  description: |-
+    This talk will introduce Ractor, the concurrency system for Ruby 3 based on actual implementation.
+
+    At RubyKaigi 2016, I proposed Guild ([A proposal of new concurrency model for Ruby 3](http://rubykaigi.org/2016/presentations/ko1.html)) and at RubyKaigi 2018, I introduced prototype of it ([Guild Prototype - RubyKaigi 2018](https://rubykaigi.org/2018/presentations/ko1.html)). For Ruby 3, we renamed Guild to Ractor and finished the first implementation. This talk will introduce Ractor API with current implementation.
+  speakers:
+  - id: ko1
+  video:
+    youtube_id: 40t8EPpnujg
+jonatas:
+  title: 'Live coding: Grepping Ruby code like a boss'
+  type: presentation
+  language: EN
+  description: |-
+    Our favorite language allows us to implement the same code in a few different ways. Because of that, it becomes tough to search and find the target code only with regular expressions.
+
+    I'd like to present fast, a searching DSL that can help you build complex
+    searches directly in the AST nodes as regexes does for plain strings.
+
+    The presentation will be a live coding tour of how to use the tool and create your searching patterns.
+
+    I'll also show how to manipulate the code in the target AST nodes,
+    allowing us to refactor the source code in an automated way.
+    I'll share a few funny stories about how I refactored thousands of files in a week.
+  speakers:
+  - id: jonatas
+  video:
+    youtube_id: YczrZQC9aP8
+hasumikin:
+  title: 'mruby machine: An Operating System for Microcontoller'
+  type: presentation
+  language: EN
+  description: |-
+    There are different approaches to make an operating system.
+
+    I take an approach which takes advantage of mruby/c's VM then makes my own mruby compiler and shell program.
+
+    Though my purpose is making an useful and effective development platform for microcontroller with Ruby, I will also share some universal knowledge on how to make an OS with you.
+  speakers:
+  - id: hasumikin
+  video:
+    youtube_id: kDOf_tZKlLU
+shugomaeda:
+  title: Magic is organizing chaos
+  type: presentation
+  language: JA
+  description: |-
+    The power of Law (e.g., type signatures, type checkers, type profilers) is growing toward Ruby 3.
+    We need the power of Chaos for the Cosmic Balance.
+
+    In this talk, I propose Proc#using to extend area where Refinements can be used.
+  speakers:
+  - id: shugomaeda
+  video:
+    youtube_id: QKiQiK7gSHQ
+youchan:
+  title: Asynchronous Opal
+  type: presentation
+  language: JA
+  description: |-
+    Opal is a compiler convert from Ruby to JavaScript. JavaScript has async/await syntax for asynchronous processing.
+    But Opal hasn't implemented it yet.
+    The Opal community had been discussed mapping `Fiber` semantics to JavaScript async/await. The conclusion was it is impossible to map coroutine such as `Fiber` because async/await is just a syntax sugar that expresses nested callbacks into flat statements.
+    I'm going to talk about the idea I'm trying to incorporate easy-to-use asynchronous processing into Opal.
+  speakers:
+  - id: youchan
+  video:
+    youtube_id: yDUmMuPdSUA
+elct9620:
+  title: Is it time run Ruby on Web via WebAssembly?
+  type: presentation
+  language: EN
+  description: The W3C is starting to recommend to use WebAssembly, and we can compile
+    mruby to WebAssembly very easy in now day. But we have Opal and it works well,
+    we really need to use WebAssembly? Let me share my experience about trying to
+    add mruby to HTML5 game, and discuss the pros and cons when we use Ruby in WebAssembly
+    way in Web.
+  speakers:
+  - id: elct9620
+  video:
+    youtube_id: PJLWoz6K7w4
+jimlock:
+  title: 'msgraph: Microsoft Graph API Client with Ruby'
+  type: presentation
+  language: JA
+  description: |-
+    [msgraph](https://github.com/jinroq/msgraph) is the unofficial Microsoft Graph API Client with Ruby.
+    The official Microsoft Graph Client Library for Ruby is [microsoft_graph](https://rubygems.org/gems/microsoft_graph). However, since its release on August 1, 2016, the preview version has been continued and has not been maintained. So, I created an API client that I can maintain on my own.
+
+    In this talk, I will talk about why I created the unofficial API Client.
+  speakers:
+  - id: jimlock
+  video:
+    youtube_id: TrVhnrTPtoI
+m_seki:
+  title: Rinda in the real-world embedded systems.
+  type: presentation
+  language: JA
+  description: |-
+    Okayama Astrophysical Observatory Wide-Field Camera (OAOWFC), is an autonomous wide-field near-infrared camera and has been in operation since 2015. A distributed control system is operated via control software using Rinda.
+    I report the implementation of the robot telescope 🤖🔭.
+  speakers:
+  - id: m_seki
+  video:
+    youtube_id: qwe6qmtxHbk
+eregontp:
+  title: Running Rack and Rails Faster with TruffleRuby
+  type: presentation
+  language: EN
+  description: |-
+    Optimizing Rack and Rails applications with a just-in-time (JIT) compiler is a challenge. For example, MJIT does not speed up Rails currently.
+    TruffleRuby tackles this challenge. We have been running the Rails Simpler Benchmarks with TruffleRuby and now achieve higher performance than any other Ruby implementation.
+
+    In this talk we’ll show how we got there and what TruffleRuby optimizations are useful for Rack and Rails applications.
+    TruffleRuby is getting ready to speed up your applications, will you try it?
+  speakers:
+  - id: eregontp
+  video:
+    youtube_id: 281YdMYRAsk
+koic:
+  title: Road to RuboCop 1.0
+  type: presentation
+  language: JA
+  description: "RuboCop 1.0 is coming soon.\n\nRuboCop 1.0 introduces several new
+    features and breaking changes to go to the stable major version 1.0!\nIn this
+    presentation, I will talk about how the milestones for RuboCop 1.0 has been implemented. For
+    examples, gemified departments, safe annotate, new cop status, and others. \n\nRuboCop
+    1.0 will provide the safest static analysis in the all‐time previous releases.
+    The pragmatic meaning of them has emerged during the implementation process. This
+    talk will help you ride on RuboCop 1.0."
+  speakers:
+  - id: koic
+  video:
+    youtube_id: jkY7J9k6mHs
+tenderlove:
+  title: Don't @ me!  Instance Variable Performance in Ruby
+  type: presentation
+  language: JA
+  description: 'How do instance variables work?  We''ve all used instance variables
+    in our programs, but how do they actually work?  In this presentation we''ll look
+    at how instance variables are implemented in Ruby.  We''ll start with a very strange
+    benchmark, then dive in to Ruby internals to understand why the code behaves the
+    way it does.  Once we''ve figured out this strange behavior, we''ll follow up
+    with a patch to increase instance variable performance.  Be prepared for a deep
+    dive in to a weird area of Ruby, and remember: don''t @ me!'
+  speakers:
+  - id: tenderlove
+  video:
+    youtube_id: 4ysxA8DDplQ
+rubylangorg:
+  title: Ruby Committers vs the World
+  type: discussion
+  language: JA
+  description: Ruby core all stars on stage!
+  speakers:
+  - id: rubylangorg
+palkan_tula:
+  title: The whys and hows of transpiling Ruby
+  type: presentation
+  language: EN
+  description: |-
+    Transpiling is a source-to-source compiling. Why might we need it in Ruby? Compatibility and experiments.
+
+    Ruby is evolving fast nowadays. The latest MRI release introduced, for example, the pattern matching syntax. Unfortunately, not everyone is ready to use it yet: gems authors have to support older versions, Ruby implementations are lagging. And it's still experimental, which raises the question: how to evaluate proposals? By backporting them to older Rubies!
+
+    I want to discuss these problems and share the story of the Ruby transpiler — Ruby Next. A decent amount of Ruby hackery is guaranteed.
+  speakers:
+  - id: palkan_tula
+  video:
+    youtube_id: zLInIisYlDo
+kddeisz:
+  title: Prettier Ruby
+  type: presentation
+  language: EN
+  description: |-
+    Prettier was created in 2017 and has since seen a meteoric rise within the JavaScript community. It differentiated itself from other code formatters and linters by supporting minimal configuration, eliminating the need for long discussions and arguments by enforcing an opinionated style on its users. That enforcement ended up resonating well, as it allowed developers to get back to work on the more important aspects of their job.
+
+    Since then, it has expanded to support other languages and markup, including Ruby. The Ruby plugin is now in use in dozens of applications around the world, and better formatting is being worked on daily. This talk will give you a high-level overview of prettier and how to wield it in your project. It will also dive into the nitty gritty, showing how the plugin was made and how you can help contribute to its growth. You’ll come away with a better understanding of Ruby syntax, knowledge of a new tool and how it can be used to help your team.
+  speakers:
+  - id: kddeisz
+  video:
+    youtube_id: 3945FmGGHhw
+ioquatix:
+  title: Don't Wait For Me! Scalable Concurrency for Ruby 3!
+  type: presentation
+  language: EN
+  description: We have proven that fibers are useful for building scalable systems.
+    In order to develop this further, we need to add hooks into the various Ruby VMs
+    so that we can improve the concurrency of existing code without changes. There
+    is an outstanding PR for this work, but additional effort is required to bring
+    this to completion and show its effectiveness in real world situations. We will
+    discuss the implementation of this PR, the implementation of the corresponding
+    Async Scheduler, and how they work together to improve the scalability of Ruby
+    applications.
+  speakers:
+  - id: ioquatix
+  video:
+    youtube_id: Y29SSOS4UOc
+ktou:
+  title: Goodbye fat gem
+  type: presentation
+  language: JA
+  description: Fat gem mechanism is useful to install extension library without any
+    compiler. Fat gem mechanism is especially helpful for Windows rubyists because
+    Windows rubyists don't have compiler. But there are some downsides. For example,
+    fat gem users can't use Ruby 2.7 (the latest Ruby) until fat gem developers release
+    a new gem for Ruby 2.7. As of 2020, pros of fat gem mechanism is decreasing and
+    cons of it is increasing. This talk describes the details of pros and cons of
+    it then says thanks and goodbye to fat gem.
+  speakers:
+  - id: ktou
+  video:
+    youtube_id: tGZiCqyMU_g
+hsbt:
+  title: Dependency Resolution with Standard Libraries
+  type: presentation
+  language: JA
+  description: "I maintain the RubyGems, Bundler and the standard libraries of the
+    Ruby language. So, I have a plan to make all of the standard libraries to default
+    gems at Ruby 3. In the past, I described the detail of default gems and bundled
+    gems at RubyKaigi and the Ruby conferences in the world. But the users still confused
+    the differences standard libraries and default/bundled gems.\n\nAfter releasing
+    Ruby 3, We need to learn about the dependency is not only \"Versioning\" with
+    default gems. It caused by the between library and library over the versioning.
+    For that reason, I need to describe the motivation of \"Promoting/Demoting the
+    Default Gems or Bundle Gems\" continuously. You will learn the resolution mechanism
+    on RubyGems/Bundler and the standard libraries of the Ruby language with my talk. "
+  speakers:
+  - id: hsbt
+  video:
+    youtube_id: wvayhyTEL_k
+miura1729:
+  title: Ruby to C Translator by AI
+  type: presentation
+  language: JA
+  description: |-
+    I am developing Ruby to C Translator  "MMC". This uses AI (i.e. Abstract Interpretation) for Type Profiling and Escape Analysis. MMC generates very efficient C code  by AI. For example , MMC gains about 50 times faster than CRuby for ao-bench  (faster than C version).
+    I will presentation the technical detail of MMC especially escape analysis.
+  speakers:
+  - id: miura1729
+  video:
+    youtube_id: kr2RXLoiLNA
+aycabta:
+  title: The Complex Nightmare of the Asian Cultural Area
+  type: presentation
+  language: EN
+  description: |-
+    There are many different cultures in Asia that seem odd to the rest of the world. This session introduces the complexities of the current situation and the various technologies that have been created to achieve their goals.
+  speakers:
+  - id: aycabta
+  video:
+    youtube_id: s7Zc7VJMBv8
+soutaro:
+  title: The State of Ruby 3 Typing
+  type: presentation
+  language: EN
+  description: |-
+    Ruby 3 will ship with a new feature for type checking, RBS. It provides a language to describe types of Ruby programs, the type declarations for standard library classes, and a set of features to support using and developing type checkers. In this talk, I will introduce the feature and how the Ruby programming will be with RBS.
+  speakers:
+  - id: soutaro
+  video:
+    youtube_id: PvkpW1OEaP8

--- a/2020-takeout/data/schedule.yml
+++ b/2020-takeout/data/schedule.yml
@@ -1,0 +1,124 @@
+---
+sep04:
+  events:
+  - type: break
+    begin: '10:00'
+    end: '10:15'
+    name: Opening
+  - type: talk
+    begin: '10:15'
+    end: '10:40'
+    talks:
+      A: ko1
+  - type: talk
+    begin: '10:45'
+    end: '11:10'
+    talks:
+      A: mametter
+      B: kddeisz
+  - type: talk
+    begin: '11:15'
+    end: '11:40'
+    talks:
+      A: shyouhei
+      B: etagwerker
+  - type: talk
+    begin: '11:45'
+    end: '12:10'
+    talks:
+      A: youchan
+      B: paracycle
+  - type: break
+    begin: '12:10'
+    end: '13:00'
+    name: Lunch Break
+  - type: talk
+    begin: '13:00'
+    end: '13:25'
+    talks:
+      A: ktou
+      B: palkan_tula
+  - type: talk
+    begin: '13:30'
+    end: '13:55'
+    talks:
+      A: ioquatix
+      B: hasumikin
+  - type: talk
+    begin: '14:00'
+    end: '14:25'
+    talks:
+      A: koic
+      B: soutaro
+  - type: talk
+    begin: '14:30'
+    end: '14:50'
+    talks:
+      A: m_seki
+      B: eregontp
+  - type: talk
+    begin: '15:00'
+    end: '15:30'
+    talks:
+      A: rubylangorg
+
+sep05:
+  events:
+  - type: break
+    begin: '10:00'
+    end: '10:05'
+    name: Opening
+  - type: talk
+    begin: '10:05'
+    end: '10:45'
+    talks:
+      A: rubylangorg
+  - type: talk
+    begin: '10:50'
+    end: '11:10'
+    talks:
+      A: shugomaeda
+      B: yuji_yokoo
+  - type: talk
+    begin: '11:15'
+    end: '11:40'
+    talks:
+      A: jimlock
+      B: elct9620
+  - type: talk
+    begin: '11:45'
+    end: '12:10'
+    talks:
+      A: tenderlove
+      B: johnlinvc
+  - type: break
+    begin: '12:10'
+    end: '13:00'
+    name: Lunch Break
+  - type: talk
+    begin: '13:00'
+    end: '13:25'
+    talks:
+      A: hsbt
+      B: jonatas
+  - type: talk
+    begin: '13:30'
+    end: '13:55'
+    talks:
+      A: aycabta
+      B: kishima
+  - type: talk
+    begin: '14:00'
+    end: '14:25'
+    talks:
+      A: miura1729
+      B: jeremyevans0
+  - type: keynote
+    begin: '14:30'
+    end: '15:05'
+    talks:
+      A: yukihiro_matz
+  - type: break
+    begin: '15:05'
+    end: '15:20'
+    name: Closing

--- a/2020-takeout/data/speakers.yml
+++ b/2020-takeout/data/speakers.yml
@@ -1,0 +1,259 @@
+---
+keynotes:
+  yukihiro_matz:
+    id: yukihiro_matz
+    name: Yukihiro "Matz" Matsumoto
+    bio: The Creator of Ruby
+    github_id: matz
+    twitter_id: yukihiro_matz
+    gravatar_hash: 0ec4920185b657a03edf01fff96b4e9b
+speakers:
+  tenderlove:
+    id: tenderlove
+    name: Aaron Patterson
+    bio: Aaron is on the Ruby core team, the Rails core team, and the team that takes
+      care of his cat, Gorby puff.   Someday he will find the perfect safety gear
+      to wear while extreme programming.
+    github_id: tenderlove
+    twitter_id: tenderlove
+    gravatar_hash: f29327647a9cff5c69618bae420792ea
+  eregontp:
+    id: eregontp
+    name: Benoit Daloze
+    bio: Benoit Daloze is the lead of TruffleRuby at Oracle Labs. He did a PhD on
+      concurrency in Ruby with TruffleRuby. He has contributed to many Ruby implementations,
+      including TruffleRuby, MRI and JRuby. He is the maintainer of ruby/spec, a test
+      suite for the behavior of the Ruby programming language.
+    github_id: eregon
+    twitter_id: eregontp
+    gravatar_hash: 0ea7f61aec8fee539be0cf39b7bab77c
+  rubylangorg:
+    id: rubylangorg
+    name: CRuby Committers
+    bio: ''
+    github_id: 
+    twitter_id: rubylangorg
+    gravatar_hash: ce6d997265cefede13ee7e7e2a2cf9b2
+  etagwerker:
+    id: etagwerker
+    name: Ernesto Tagwerker
+    bio: Ernesto is the Founder of Ombu Labs, a small software development company
+      dedicated to building lean code. When he is not obsessively playing table tennis
+      or chess, he likes to maintain a few Ruby gems including `database_cleaner`
+      and `email-spec`. He is passionate about writing less code, launching minimal
+      products, coaching entrepreneurs, contributing to open source, and eating empanadas.
+    github_id: etagwerker
+    twitter_id: 
+    gravatar_hash: eceef9c09ab1fb1bd8a997551777a66d
+  miura1729:
+    id: miura1729
+    name: Hideki Miura
+    bio: I am a plumber.
+    github_id: miura1729
+    twitter_id: 
+    gravatar_hash: 360c8e3a4839819090e66e6ddf4b99ad
+  hsbt:
+    id: hsbt
+    name: Hiroshi SHIBATA
+    bio: |-
+      A member of Ruby core team. He maintains RubyGems, Rake, rdoc, psych, ruby-build, etc. and He is an administrator of ruby-lang.org and supports to develop the environment of Ruby language.
+
+      He is also Executive Officer in GMO Pepabo, Inc. His most interest things are “Productivity”  He believes, there's business value in fun. The team member happiness can make valuable products.
+    github_id: hsbt
+    twitter_id: hsbt
+    gravatar_hash: eabad423977cfc6873b8f5df62b848a6
+  hasumikin:
+    id: hasumikin
+    name: Hitoshi HASUMI
+    bio: A programmer of Monstar Lab at Shimane office
+    github_id: hasumikin
+    twitter_id: hasumikin
+    gravatar_hash: d62b18efd2549587e712cebf6403861a
+  aycabta:
+    id: aycabta
+    name: ITOYANAGI Sakura
+    bio: ''
+    github_id: aycabta
+    twitter_id: 
+    gravatar_hash: 43da97eeeac8fafd2bf196db1f19c534
+  jeremyevans0:
+    id: jeremyevans0
+    name: Jeremy Evans
+    bio: Jeremy Evans is a Ruby committer.  He is the maintainer of Ruby ports for
+      the OpenBSD operating system.  He is also the lead developer of the Sequel database
+      library, the Roda web toolkit, the Rodauth authentication framework, and many
+      other Ruby libraries.
+    github_id: jeremyevans
+    twitter_id: jeremyevans0
+    gravatar_hash: f183bcc4176b308c9edabe79299e448f
+  jonatas:
+    id: jonatas
+    name: Jônatas Davi Paganini
+    bio: |-
+      My work is onboard people in a large Ruby codebase, and most of the time, I'm showing code or hunting for some code examples.
+
+      While developing some educational RuboCop cops, I found the RuboCop node pattern very useful to target code offenses. Then, I developed a similar tool to search and allow refactoring code based on node pattern concept.
+    github_id: jonatas
+    twitter_id: 
+    gravatar_hash: faae82c588349e1b51d9ff9b5431e10c
+  kishima:
+    id: kishima
+    name: Katsuhiko Kageyama
+    bio: "Embedded software engineer in a manufacturing company. \nOrganizing a mruby
+      community \"mruby meetup\".\nPersonally, producing technical books about mruby
+      and original devices in TechBookFest, Comic Market and Maker Faire(2020 Tsukuba)."
+    github_id: kishima
+    twitter_id: 
+    gravatar_hash: 30b735d887bdd9c0b0b9ff466ba887d0
+  kddeisz:
+    id: kddeisz
+    name: Kevin Deisz
+    bio: I am a Staff Production Engineer of Shopify, based out of Boston, Massachusetts.
+      I'm passionate about music, accessibility, and open-source software.
+    github_id: kddeisz
+    twitter_id: kddeisz
+    gravatar_hash: 8a66c2a7197be751b21ebd35319ec797
+  koic:
+    id: koic
+    name: Koichi ITO
+    bio: Koichi ITO is a member of RuboCop's core developers team. He is a practitioner
+      of Ruby/Rails application development with eXtreme Programming. He works at
+      ESM, Inc.
+    github_id: koic
+    twitter_id: koic
+    gravatar_hash: 023b04c98f39cc041293d780352432ff
+  ko1:
+    id: ko1
+    name: Koichi Sasada
+    bio: Koichi Sasada is a programmer, mainly developing Ruby interpreter (CRuby/MRI).
+      He received Ph.D (Information Science and Technology) from the University of
+      Tokyo, 2007. Now he is still working on MRI development at Cookpad Inc. He is
+      also a director of Ruby Association.
+    github_id: ko1
+    twitter_id: 
+    gravatar_hash: 990397e8b38d6f5f4ae8ff343e8b883a
+  johnlinvc:
+    id: johnlinvc
+    name: Lin Yu Hsiang
+    bio: Cloud Platform Engineer at Exosite. Ruby lover. Full-stack developer. Organizer
+      of Swift Taipei.  iOS developer. FP lover.
+    github_id: johnlinvc
+    twitter_id: johnlinvc
+    gravatar_hash: 3f7d9611fc919c98512b779cde637dfc
+  m_seki:
+    id: m_seki
+    name: Masatoshi SEKI
+    bio: Masatoshi Seki is a Ruby committer and the author of several Ruby standard
+      libraries including dRuby, ERB, and Rinda. He’s an expert in object-oriented
+      programming, distributed systems, and eXtreme programming. He has been speaking
+      at RubyKaigi every year since 2006 when the Kaigi first started.
+    github_id: seki
+    twitter_id: m_seki
+    gravatar_hash: 40f4d1f2e77078955bd01e9fb4a503ba
+  jimlock:
+    id: jimlock
+    name: ODA Hirohito
+    bio: ";)"
+    github_id: jinroq
+    twitter_id: jimlock
+    gravatar_hash: 72e4a8bf47620de5381ff20f3deda977
+  ioquatix:
+    id: ioquatix
+    name: Samuel Williams
+    bio: I am a software engineer, and I am motivated by the beauty I uncover when
+      building complex systems.
+    github_id: ioquatix
+    twitter_id: ioquatix
+    gravatar_hash: 1373435a1059a97614969ab154c5b224
+  soutaro:
+    id: soutaro
+    name: Soutaro Matsumoto
+    bio: Software engineer at Square.
+    github_id: soutaro
+    twitter_id: soutaro
+    gravatar_hash: 1fab9d01b25e99522f3dfd01e3d4cb51
+  shugomaeda:
+    id: shugomaeda
+    name: Shugo Maeda
+    bio: The Creator of Textbringer, a Ruby committer, Director of Network Applied
+      Communication Laboratory, and Secretary general of the Ruby Association
+    github_id: shugo
+    twitter_id: shugomaeda
+    gravatar_hash: 18a797893e6768e048c1d15429f96bb4
+  ktou:
+    id: ktou
+    name: Sutou Kouhei
+    bio: He is a free software programmer and the president of ClearCode Inc. He is
+      also the namer of ClearCode Inc. The origin of the company name is "clear code".
+      We will be programmers that code clear code as our company name suggests. He
+      is a maintainer of [rake-compiler](https://github.com/rake-compiler/rake-compiler/)
+      gem that helps fat gem developers. He was  maintain [Ruby-GNOME](https://github.com/ruby-gnome/ruby-gnome/)
+      that had many fat gems.
+    github_id: kou
+    twitter_id: ktou
+    gravatar_hash: 2d9386b1504e581be390af978e05a8b9
+  paracycle:
+    id: paracycle
+    name: Ufuk Kayserilioglu
+    bio: Ufuk is the Production Engineering Manager of the Ruby Infrastructure team at Shopify. He has over 20 years of experience working with statically and dynamically typed languages ranging from low-level communication programming to web development. He brings that experience to Shopify for the adoption of better Ruby tooling and practices. He currently works remotely from Cyprus where he lives with his beloved wife and wonderful daughter.
+    github_id: paracycle
+    twitter_id: paracycle
+    gravatar_hash: 2bb923c57a1fdc3a2eb484bb8d565fd2
+  shyouhei:
+    id: shyouhei
+    name: Urabe, Shyouhei
+    bio: Money Forward, Inc. hire Shyouhei, a long-time ruby-core committer, to contribute
+      to the whole ruby ecosystem. Being a full-time ruby-core developer, his current
+      interest is to speed up ruby execution by modifying its internals. Doing so
+      is not straight-forward because of ruby's highly dynamic nature. To tackle this
+      problem he is implementing a variety of optimisation techniques that are yet
+      to be applied to it.
+    github_id: shyouhei
+    twitter_id: shyouhei
+    gravatar_hash: 9d2f78236e45a335301ba1195026105d
+  palkan_tula:
+    id: palkan_tula
+    name: Vladimir Dementyev
+    bio: Vladimir is a mathematician who found his happiness in programming Ruby and
+      Erlang, contributing to open source and being an Evil Martian. Author of AnyCable,
+      TestProf and many yet unknown ukulele melodies.
+    github_id: palkan
+    twitter_id: palkan_tula
+    gravatar_hash: 52cc8a838bf44a589d2572833b2dd1b9
+  youchan:
+    id: youchan
+    name: Yoh Osaki
+    bio: |-
+      Software engineer at Retrieva inc.
+      Author of Hyalite which is react like virtual DOM library.
+      Member of Asakusa.rb, Chidoriashi.rb
+    github_id: youchan
+    twitter_id: youchan
+    gravatar_hash: b54abc5e7463fe6470c379e97e3f2477
+  yuji_yokoo:
+    id: yuji_yokoo
+    name: Yuji Yokoo
+    bio: Yuji is a software developer based in Adelaide, South Australia. He was born
+      and raised in Tokyo, Japan. He used to be a Windows desktop application developer
+      until he discovered Ruby. He enjoys console video gaming, programming, and especially
+      mixing both of them together.
+    github_id: 
+    twitter_id: 
+    gravatar_hash: b87628a711b78598dcd409da186cd633
+  mametter:
+    id: mametter
+    name: Yusuke Endoh
+    bio: '''A full-time MRI committer at Cookpad, Inc.  He has been interested in
+      testing, analyzing, abusing of Ruby.  He is an advocate of "transcendental programming"
+      that creates a useless program like this bio. (`_`)''.yield_self{|s|eval(t=%q(puts"''#{s.sub(?_,?_+?_)}''.yield_self{|s|eval(t=%q(#{t}))}"))}'
+    github_id: mame
+    twitter_id: mametter
+    gravatar_hash: e73159002200b33d51b7a6a312f2440e
+  elct9620:
+    id: elct9620
+    name: 蒼時弦也
+    bio: Game Developer / 5xruby's Rails Developer. Enjoy trying anything that can
+      work with Ruby in Game, IoT or anything else.
+    github_id: elct9620
+    twitter_id: elct9620
+    gravatar_hash: 888339de9e7a88688b6acb30d33e66cd

--- a/2020/data/presentations.yml
+++ b/2020/data/presentations.yml
@@ -1,0 +1,658 @@
+---
+yukihiro_matz:
+  title: Matz Keynote
+  type: keynote
+  language: JA
+  description: Matz in Matsumoto!
+  speakers:
+  - id: yukihiro_matz
+mametter:
+  title: 'Type Profiler: a Progress Report of a Ruby 3 Type Analyzer'
+  type: presentation
+  language: JA
+  description: Type Profiler is a type inference tool for plain Ruby code. It analyzes
+    Ruby code that has no type information and guesses a type of the modules and methods
+    in the code. The output will serve as a signature for external type checkers like
+    Sorbet and Steep. Since 2019, we have been developing the tool as one of the key
+    features for Ruby 3 static analysis, and now it works with some practical applications.
+    In this talk, we briefly explain what and how Type Profiler works, present a roadmap
+    and progress of the development, and discuss how useful it is for practical applications
+    with some demos.
+  speakers:
+  - id: mametter
+shashank_date:
+  title: Controlling multiple drones using mruby
+  type: presentation
+  language: EN
+  description: |-
+    mruby is a lightweight implementation of the Ruby language. In this talk we will see how the mruby build system works, how to optimize its configuration for controlling drones, and use it to control a certain class (Tello) of programmable drones. It will include code for:
+    - flight control (using UDP sockets)
+    - camera control (using OpenCV)
+    - multiple drone control (using Fibers)
+    The talk will end with a live demo of multi-drone acrobatics followed by a group activity involving crowd coding.
+  speakers:
+  - id: shashank_date
+etagwerker:
+  title: 'RubyMem: The Leaky Gems Database for Bundler'
+  type: presentation
+  language: EN
+  description: "Out of memory errors are quite tricky. Our first reaction is always
+    the same: \"It can't be my code, it must be one of my dependencies!\" What if
+    you could quickly check that with bundler? \n\nIn this talk you will learn about
+    memory leaks, out of memory errors, and leaky dependencies. You will learn how
+    to use `bundler-leak`, a community-driven, open source tool that will make your
+    life easier when debugging memory leaks."
+  speakers:
+  - id: etagwerker
+jeremyevans0:
+  title: 'Keyword Arguments: Past, Present, and Future'
+  type: presentation
+  language: EN
+  description: Ruby 3 will separate keyword arguments from positional arguments, which
+    causes the biggest backwards compatibility issues in Ruby since Ruby 1.9.  This
+    presentation will discuss the history of keyword arguments, how keyword arguments
+    are handled internally, how keyword arguments were separated from positional arguments
+    internally, and possible future improvements in the handling of keyword arguments.
+  speakers:
+  - id: jeremyevans0
+tetiana_chupryna:
+  title: Graphics programming with Ruby and OpenGL
+  type: presentation
+  language: EN
+  description: 'Ruby is commonly considered as a backend language. We''ll try to go
+    beyond this thesis and explore how Ruby can be applicable to something different
+    like creating graphics. We''ll focus on OpenGL, explore its tools for controlling
+    the scene and drawing objects: from primitive to triangle meshes and more. Graphics
+    programming is such a fun activity and Ruby is such a beautiful language, let’s
+    see how good are they together!'
+  speakers:
+  - id: tetiana_chupryna
+kishima:
+  title: Now is the time to create your own (m)Ruby computer
+  type: presentation
+  language: EN
+  description: mruby has been known as a good tool for supporting server applications
+    and embedded softwares like an IoT application on a small CPU whose resource is
+    limited. Now times are changing. mruby gets more power from recent micro processors.
+    I believe now Ruby engineers can create their own computer as per their wish.
+    Basic process and essential technique how to create an original (m)Ruby computer
+    will be shown in the talk with a live demonstration of the computer.
+  speakers:
+  - id: kishima
+k0kubun:
+  title: Hacking Ruby's Performance for Production
+  type: presentation
+  language: JA
+  description: |-
+    Sometimes production Ruby applications get mysterious performance problems.
+    Your customers complain about it. Your company loses money. You start to hate operating your Ruby application.
+
+    However, once you get the power to demystify and solve the difficult problems, optimizing your Ruby application will become full of joy.
+    In this talk, you'll learn techniques to debug and solve Ruby performance problems from system levels to pure Ruby layers.
+    Welcome to the art of performance optimization.
+  speakers:
+  - id: k0kubun
+paracycle:
+  title: Reflecting on Ruby Reflection for Rendering RBIs
+  type: presentation
+  language: EN
+  description: |-
+    As part of our adoption process of Sorbet at Shopify, we needed an automated way to teach Sorbet about our ~400 gem dependencies. We decided to tackle this problem by generating interface files (RBI) for each gem via runtime reflection.
+
+    However, this turns out to not be as simple as it sounds; the flexible nature of Ruby allows gem authors to do many wild things that make this Hard. Come and hear about all the lessons that we learnt about runtime reflection in Ruby while building `tapioca`.
+  speakers:
+  - id: paracycle
+yuji_yokoo:
+  title: Developing your Dreamcast apps and games with mruby
+  type: presentation
+  language: EN
+  description: |-
+    What would you make, if you can run your Ruby code on Dreamcast?
+
+    Well, now you can! I have been working on my development setup for running mruby code on Dreamcast. I would like to show you what I have developed so far and how you can get started. I would also like to tell you why development on Dreamcast is a great idea and share a few things I learned along the way.
+  speakers:
+  - id: yuji_yokoo
+shyouhei:
+  title: On sending methods
+  type: presentation
+  language: JA
+  description: As you have noticed 2.7 is faster than older ruby versions.  One of
+    the main reason for this is my optimisation around method invocations.  Let me
+    share what was suboptimal, and how was that fixed.
+  speakers:
+  - id: shyouhei
+lara:
+  title: Benchmarking 9 Flavors of Ruby
+  type: presentation
+  language: EN
+  description: We benchmarked 9 alternative Ruby implementations for the same compute-heavy
+    algorithm that is easy to migrate to from an existing Ruby codebase. Our comparison
+    looks at ease-of-use, gotchas, performance, and memory usage of JRuby, Crystal,
+    Rust, Ruby-to-WebAssembly, C-extensions, MRuby, CRuby JIT, and Goby. Each implementation
+    provides Dockerfiles to play with.
+  speakers:
+  - id: lara
+  - id: grosser
+johnlinvc:
+  title: 'mruby-rr: Time Traveling Debugger For mruby Using rr'
+  type: presentation
+  language: EN
+  description: |-
+    Debugging bugs that don't happen every time is painful. It needs both technique and luck.
+    When dealing with these, a mistyped `continue` command is irreversible and will take us a whole afternoon just to reproduce the issue again.
+
+    [mruby-rr](https://github.com/johnlinvc/mruby-rr) comes to rescue! It's a Time Traveling Debugger for mruby that based on Mozilla's rr. `mruby-rr` supports record and replay of mruby program execution. We can record the tough bug using mruby-rr for just once. Afterwards we can playback the execution as many times as we want. `mruby-rr` can also do time traveling operations like `reverse-next` and evaluating expressions.
+  speakers:
+  - id: johnlinvc
+ko1:
+  title: Guild Implementation
+  type: presentation
+  language: EN
+  description: |-
+    This talk will introduce the design and implementation of Guild, the concurrency system for Ruby 3 based on actual implementation.
+
+    One of big goals of Ruby 3 is better concurrency support. At RubyKaigi 2016, I proposed Guild to achieve better concurrent programming on parallel computers ([A proposal of new concurrency model for Ruby 3](http://rubykaigi.org/2016/presentations/ko1.html)). At RubyKaigi 2018, I introduced prototype of Guild system ([Guild Prototype - RubyKaigi 2018](https://rubykaigi.org/2018/presentations/ko1.html)). However, only a few code are working on the prototype.
+
+    Guild achieves easier concurrent program and utilize parallel computers by the idea (mostly) no implicit object sharing. To develop Guild system, we need to introduce many hacks to achieve both thread-safty and good performance. In this talk, I will introduce the design of Guild system and the implementation techniques on the actual implementation.
+  speakers:
+  - id: ko1
+jonatas:
+  title: 'Live coding: Grepping Ruby code like a boss'
+  type: presentation
+  language: EN
+  description: |-
+    Our favorite language allows us to implement the same code in a few different ways. Because of that, it becomes tough to search and find the target code only with regular expressions.
+
+    I'd like to present fast, a searching DSL that can help you build complex
+    searches directly in the AST nodes as regexes does for plain strings.
+
+    The presentation will be a live coding tour of how to use the tool and create your searching patterns.
+
+    I'll also show how to manipulate the code in the target AST nodes,
+    allowing us to refactor the source code in an automated way.
+    I'll share a few funny stories about how I refactored thousands of files in a week.
+  speakers:
+  - id: jonatas
+hasumikin:
+  title: 'mruby machine: An Operating System for Microcontoller'
+  type: presentation
+  language: JA
+  description: |-
+    There are different approaches to make an operating system.
+
+    I take an approach which takes advantage of mruby/c's VM then makes my own mruby compiler and shell program.
+
+    Though my purpose is making an useful and effective development platform for microcontroller with Ruby, I will also share some universal knowledge on how to make an OS with you.
+  speakers:
+  - id: hasumikin
+shugomaeda:
+  title: Magic is organizing chaos
+  type: presentation
+  language: JA
+  description: |-
+    The power of Law (e.g., type signatures, type checkers, type profilers) is growing toward Ruby 3.
+    We need the power of Chaos for the Cosmic Balance.
+
+    In this talk, I propose Proc#using to extend area where Refinements can be used.
+  speakers:
+  - id: shugomaeda
+jhawthorn:
+  title: Parsing and Rewriting ERB
+  type: presentation
+  language: EN
+  description: ERB templates are compiled into Ruby, and we have parsers for Ruby.
+    We can use this to determine their hierarchy, eager load them, make them faster,
+    or even replace some of Ruby's fundamentals.
+  speakers:
+  - id: jhawthorn
+youchan:
+  title: Asynchronous Opal
+  type: presentation
+  language: JA
+  description: |-
+    Opal is a compiler convert from Ruby to JavaScript. JavaScript has async/await syntax for asynchronous processing.
+    But Opal hasn't implemented it yet.
+    The Opal community had been discussed mapping `Fiber` semantics to JavaScript async/await. The conclusion was it is impossible to map coroutine such as `Fiber` because async/await is just a syntax sugar that expresses nested callbacks into flat statements.
+    I'm going to talk about the idea I'm trying to incorporate easy-to-use asynchronous processing into Opal.
+  speakers:
+  - id: youchan
+alanwusx:
+  title: Optimizing CRuby bytecode dispatch for modern CPUs
+  type: keynote
+  language: EN
+  description: Since CRuby spends a lot of its time jumping between bytecode handlers,
+    reducing overhead in this area can be very profitable. Join me on a trip to explore
+    techniques that help modern CPUs dispatch bytecode efficiently. Everyone is welcome;
+    you don’t need to be a chip design wizard to attend this session.
+  speakers:
+  - id: alanwusx
+DarkDimius:
+  title: Moving fast and fixing things with Sorbet
+  type: presentation
+  language: EN
+  description: "In June 2019 we open sourced Sorbet at RubyKaigi. \n\nWe’ve built
+    quality editor tools like jump-to-def and seen many contributions from a growing
+    community. Within Stripe, we've used Sorbet to drive code quality via measurable,
+    concrete indicators. \nThis talk will show how to use Sorbet and Sorbet features
+    to speedup your iteration time and fix bugs in legacy codebases.\n\nWe’ll also
+    share these improvements and give an update on our collaboration with Matz and
+    the Ruby 3 Types working group. Suitable for anyone using Ruby—no familiarity
+    with Sorbet needed! Come follow in the footsteps of the many companies already
+    using Sorbet."
+  speakers:
+  - id: DarkDimius
+ChrisBr:
+  title: Digesting MRI by Studying Alternative Ruby Implementations
+  type: presentation
+  language: EN
+  description: |-
+    Pointers, managing memory and static typing - writing C code is hard! However, most programming languages, including Matz's Ruby Interpreter (MRI), are implemented in a low level programming language. So you think without knowing these concepts, you can not contribute to Ruby? Wrong! Although MRI is implemented in C, fortunately there are Ruby's in Java, Rust and even Ruby itself.
+
+    If you ever wanted to learn about Ruby internals without being a C expert, this talk is for you. Join me on my journey of re-implementing hash maps in JRuby, breaking bundler and actually learn to write (some) C code.
+  speakers:
+  - id: ChrisBr
+elct9620:
+  title: Is it time run Ruby on Web via WebAssembly?
+  type: presentation
+  language: EN
+  description: The W3C is starting to recommend to use WebAssembly, and we can compile
+    mruby to WebAssembly very easy in now day. But we have Opal and it works well,
+    we really need to use WebAssembly? Let me share my experience about trying to
+    add mruby to HTML5 game, and discuss the pros and cons when we use Ruby in WebAssembly
+    way in Web.
+  speakers:
+  - id: elct9620
+spikeolaf:
+  title: What is expected?
+  type: presentation
+  language: JA
+  description: |-
+    CRuby uses Bison to generate its parser. The parser is called LALR(1) parser in which we can determine what should do (shift/reduce/accept/error) next based on current state and next input token.
+
+    But current CRuby does not have "expected_tokens" method because it is more difficult than expected. Then I will talk what is difficulty and how to implement it.
+  speakers:
+  - id: spikeolaf
+Prakriti-nith:
+  title: All-in-one interactive plotting using daru-view
+  type: presentation
+  language: EN
+  description: Why only other languages have web app/Jupyter notebook plotting libraries?
+    Need interactive plotting? No JavaScript code again, please! With daru-view,  you
+    get to plot Google charts, Highcharts, HighMaps, HighStock, Datatables, D3.js
+    and compare them using only a few lines of Ruby. Amazing, Right?
+  speakers:
+  - id: Prakriti-nith
+sue445:
+  title: Ruby on CI
+  type: presentation
+  language: JA
+  description: |-
+    I'm a CI nerd.
+
+    I have made many apps and gems so far and have used many CIs. (e.g. Jenkins, Travis CI, Wercker, CircleCI, GitLab CI, GitHub Actions...)
+
+    Which CI should we use? How do we solve the slow build?
+
+    I'll talk about followings.
+
+    * History of CI
+    * Which CI should we use when ruby app and gem development
+    * How/What we should do CI when ruby app and gem development
+    * vs Slow build
+    * and more!
+  speakers:
+  - id: sue445
+keystonelemur:
+  title: Pattern Matching in Practice
+  type: presentation
+  language: EN
+  description: Ruby 2.7 introduces the new Pattern Matching syntax, but to some this
+    may be a very foreign concept. We'll be exploring ways to use Pattern Matching
+    in your code today to solve real-world problems and help build an understanding
+    for when and where you can use it.
+  speakers:
+  - id: keystonelemur
+jashmatthews:
+  title: Experiments in Building a Tracing JIT for CRuby
+  type: presentation
+  language: EN
+  description: How would we build an optimizing compiler for CRuby? What optimizations
+    work on generated C code with a traditional compiler? What doesn't work and needs
+    a high level Intermediate Representation and Ruby-specific optimizations?
+  speakers:
+  - id: jashmatthews
+jimlock:
+  title: 'msgraph: Microsoft Graph API Client with Ruby'
+  type: presentation
+  language: JA
+  description: |-
+    [msgraph](https://github.com/jinroq/msgraph) is the unofficial Microsoft Graph API Client with Ruby.
+    The official Microsoft Graph Client Library for Ruby is [microsoft_graph](https://rubygems.org/gems/microsoft_graph). However, since its release on August 1, 2016, the preview version has been continued and has not been maintained. So, I created an API client that I can maintain on my own.
+
+    In this talk, I will talk about why I created the unofficial API Client.
+  speakers:
+  - id: jimlock
+m_seki:
+  title: Rinda in the real-world embedded systems.
+  type: presentation
+  language: JA
+  description: |-
+    組み込み／ハードウェア制御分野におけるCRuby／dRuby周辺技術の応用事例を二つ紹介する。
+    一つは国立天文台岡山観測所にある91㎝望遠鏡をロボット望遠鏡に改造した事例である。
+    非常に多くのサブシステムで構成されるロボット望遠鏡はRindaのタプルスペースを利用して制御されている。
+    LindaにはないRinda独自の機能である、時限つきタプルを利用して実用的なシステムを構築している。
+    もう一つは小さな組み込み計測装置の事例である。GUIはSPAのWebアプリケーションである。
+    WEBrickにServer Sent Eventsを組み込み、ユーザー操作と計測装置からのイベントを処理している。
+    SSEのために新たに作成した同期メカニズムを紹介する。
+  speakers:
+  - id: m_seki
+jvilk-stripe:
+  title: Ruby IDE Features Powered by Sorbet Static Types
+  type: presentation
+  language: EN
+  description: |-
+    Many languages benefit from smart Integrated Development Environments (IDEs) and many devs have grown to like them. Unfortunately, existing Ruby IDEs weren’t good for Stripe: they lack features, use imprecise heuristics, and are too slow on our codebase.
+
+    This talk presents how we implemented IDE features for Ruby and how they make writing Ruby even more fun. Features include:
+
+    - error squiggles
+    - go to definition
+    - autocomplete
+    - docs on hover
+    - and more!
+
+    We also have an exciting announcement!
+
+    The talk does not require prior knowledge of types and will be accessible to a broad audience.
+  speakers:
+  - id: jvilk-stripe
+eregontp:
+  title: Running Rack and Rails Faster with TruffleRuby
+  type: presentation
+  language: EN
+  description: |-
+    Optimizing Rack and Rails applications with a just-in-time (JIT) compiler is a challenge. For example, MJIT does not speed up Rails currently.
+    TruffleRuby tackles this challenge. We have been running the Rails Simpler Benchmarks with TruffleRuby and now achieve higher performance than any other Ruby implementation.
+
+    In this talk we’ll show how we got there and what TruffleRuby optimizations are useful for Rack and Rails applications.
+    TruffleRuby is getting ready to speed up your applications, will you try it?
+  speakers:
+  - id: eregontp
+knu:
+  title: Language Choices Between Flexibility and Restriction
+  type: presentation
+  language: JA
+  description: |-
+    Programmers will love and value flexibility and mightiness in languages they use, not to speak of Ruby programmers who know more than well that a powerful language can do a lot more with much less effort.
+
+    However, there are many situations where less is more.  Good constraints and restrictions can make some sorts of things work better, where human errors must be avoided, security concern minimized, or future extensibility reserved.
+
+    In this talk will be discussed with real examples what are the trade-offs an implementer should consider, to help the audience make the right choice in their API and product feature design.
+  speakers:
+  - id: knu
+_st0012:
+  title: Optimize your debugging workflow with tapping_device
+  type: presentation
+  language: EN
+  description: |-
+    Have you ever examined your debugging process before? Do you know how efficient/inefficient your debugging strategy is? If the answers are “no”, this talk is for you.
+
+    In this talk, I will explain the way most of us debug programs, and why is it an O(log n) operation. And then, I will introduce a concept called “Object-Oriented Tracing” along with my tool: [tapping_device](https://github.com/st0012/tapping_device). By adopting the concept and with the help of my tool, I’ve been able to make debugging an O(1) operation. Here’s an [example](http://bit.ly/object-oriented-tracing) that I used this strategy to debug a Rails issue.
+
+    Of course, I’m not saying I’ve found a silver bullet for debugging, so I will also show you its limitation and where it suits best.
+  speakers:
+  - id: _st0012
+koic:
+  title: Ride on RuboCop 1.0 for safe static analysis
+  type: presentation
+  language: JA
+  description: "RuboCop 1.0 is coming soon.\n\nRuboCop 1.0 introduces several new
+    features and breaking changes to go to the stable major version 1.0!\nIn this
+    presentation, we will talk about how the milestones for RuboCop 1.0 has been implemented. For
+    examples, gemified departments, safe annotate, new cop status, and others. \n\nRuboCop
+    1.0 will provide the safest static analysis in the all‐time previous releases.
+    The pragmatic meaning of them has emerged during the implementation process. This
+    talk will help you ride on RuboCop 1.0.\n\nAnd, we will show you a new RuboCop
+    plugin that integrates RuboCop and the Ruby 3 Static Types."
+  speakers:
+  - id: koic
+  - id: p_ck_
+mrkn:
+  title: Data visualization and machine learning using Ruby
+  type: presentation
+  language: JA
+  description: |-
+    Ruby finally had ready-to-use visualization and machine learning libraries. They are Charty and Rumale.
+    I'd like to introduce them and demonstrate how to use them.
+
+    Using Charty, you get cool visualization results of your data by the smallest amount of code. The code amount is about 1 line in almost cases because Charty supports different types of data structures to visualize. You no longer need a conversion for visualization.
+
+    Rumale is a machine learning framework like scikit-learn. Rumale supports a lot of machine learning models. Rumale is written in Ruby so you don't need pycall.rb and Python environment to use machine learning models. If you want to do machine learning in your Ruby script, you must know how to use Rumale.
+
+    I'd like to realize the usefulness of Charty and Rumale by demonstration. You will realize that Ruby is no longer a programming language that cannot be used for data science.
+  speakers:
+  - id: mrkn
+bovi:
+  title: Ruby-defined Hardware
+  type: presentation
+  language: EN
+  description: |-
+    A common conception of most people is that hardware is a hard-problem. Few people approach due to that the challenge to develop new hardware systems.
+
+    What if we could simplify the development of hardware and make it more like software development? What if we could generate hardware directly out of software?
+
+    This talk will propose the concept of Ruby-defined Hardware where Ruby code is the input for a hardware development system.
+  speakers:
+  - id: bovi
+tenderlove:
+  title: Don't @ me!  Instance Variable Performance in Ruby
+  type: presentation
+  language: JA
+  description: 'How do instance variables work?  We''ve all used instance variables
+    in our programs, but how do they actually work?  In this presentation we''ll look
+    at how instance variables are implemented in Ruby.  We''ll start with a very strange
+    benchmark, then dive in to Ruby internals to understand why the code behaves the
+    way it does.  Once we''ve figured out this strange behavior, we''ll follow up
+    with a patch to increase instance variable performance.  Be prepared for a deep
+    dive in to a weird area of Ruby, and remember: don''t @ me!'
+  speakers:
+  - id: tenderlove
+rubylangorg:
+  title: Ruby Committers vs the World
+  type: discussion
+  language: JA
+  description: Ruby core all starts on stage!
+  speakers:
+  - id: rubylangorg
+palkan_tula:
+  title: The whys and hows of transpiling Ruby
+  type: presentation
+  language: EN
+  description: |-
+    Transpiling is a source-to-source compiling. Why might we need it in Ruby? Compatibility and experiments.
+
+    Ruby is evolving fast nowadays. The latest MRI release introduced, for example, the pattern matching syntax. Unfortunately, not everyone is ready to use it yet: gems authors have to support older versions, Ruby implementations are lagging. And it's still experimental, which raises the question: how to evaluate proposals? By backporting them to older Rubies!
+
+    I want to discuss these problems and share the story of the Ruby transpiler — Ruby Next. A decent amount of Ruby hackery is guaranteed.
+  speakers:
+  - id: palkan_tula
+kddeisz:
+  title: Prettier Ruby
+  type: presentation
+  language: EN
+  description: |-
+    Prettier was created in 2017 and has since seen a meteoric rise within the JavaScript community. It differentiated itself from other code formatters and linters by supporting minimal configuration, eliminating the need for long discussions and arguments by enforcing an opinionated style on its users. That enforcement ended up resonating well, as it allowed developers to get back to work on the more important aspects of their job.
+
+    Since then, it has expanded to support other languages and markup, including Ruby. The Ruby plugin is now in use in dozens of applications around the world, and better formatting is being worked on daily. This talk will give you a high-level overview of prettier and how to wield it in your project. It will also dive into the nitty gritty, showing how the plugin was made and how you can help contribute to its growth. You’ll come away with a better understanding of Ruby syntax, knowledge of a new tool and how it can be used to help your team.
+  speakers:
+  - id: kddeisz
+yuri_at_earth:
+  title: Writing mruby bytecode by yourself
+  type: presentation
+  language: JA
+  description: |-
+    Unlike MRI, mruby uses a binary bytecode format file "*.mrb".  When we build the mruby processor, we compile the standard Ruby libraries with the mrbc bytecode compiler.
+
+    On the other hand, there are few tools to support this bytecode format. This presentation proposes an assembly language for bytecode, and introduce an assembler for converting assembly language to bytecode and a disassembler for converting bytecode to assembly language. Then try editing the bytecode directly using them.
+  speakers:
+  - id: yuri_at_earth
+  - id: takahashim
+ioquatix:
+  title: Don't Wait For Me! Scalable Concurrency for Ruby 3!
+  type: presentation
+  language: EN
+  description: We have proven that fibers are useful for building scalable systems.
+    In order to develop this further, we need to add hooks into the various Ruby VMs
+    so that we can improve the concurrency of existing code without changes. There
+    is an outstanding PR for this work, but additional effort is required to bring
+    this to completion and show its effectiveness in real world situations. We will
+    discuss the implementation of this PR, the implementation of the corresponding
+    Async Scheduler, and how they work together to improve the scalability of Ruby
+    applications.
+  speakers:
+  - id: ioquatix
+anton_davydov:
+  title: How to visualize a ruby project
+  type: presentation
+  language: EN
+  description: |-
+    Code visualization is an important part of coding. Usually, we use our imagination but what will happen if we ask ruby to do this work?
+
+    In my talk, I'll show a tool that we build in dry-rb and which exists only in the ruby ecosystem. This tool will help us to see all project component associations on the one page. I'll explain why other tools work terribly and how to visualize important things. Also, I'll explain how this visualization can help with onboarding new developers, find "god" objects in the system and use a heatmap of dependency usage for finding unused parts of the project.
+  speakers:
+  - id: anton_davydov
+ktou:
+  title: Goodbye fat gem
+  type: presentation
+  language: JA
+  description: Fat gem mechanism is useful to install extension library without any
+    compiler. Fat gem mechanism is especially helpful for Windows rubyists because
+    Windows rubyists don't have compiler. But there are some downsides. For example,
+    fat gem users can't use Ruby 2.7 (the latest Ruby) until fat gem developers release
+    a new gem for Ruby 2.7. As of 2020, pros of fat gem mechanism is decreasing and
+    cons of it is increasing. This talk describes the details of pros and cons of
+    it then says thanks and goodbye to fat gem.
+  speakers:
+  - id: ktou
+hsbt:
+  title: Dependency Resolution with Standard Libraries
+  type: presentation
+  language: JA
+  description: "I maintain the RubyGems, Bundler and the standard libraries of the
+    Ruby language. So, I have a plan to make all of the standard libraries to default
+    gems at Ruby 3. In the past, I described the detail of default gems and bundled
+    gems at RubyKaigi and the Ruby conferences in the world. But the users still confused
+    the differences standard libraries and default/bundled gems.\n\nAfter releasing
+    Ruby 3, We need to learn about the dependency is not only \"Versioning\" with
+    default gems. It caused by the between library and library over the versioning.
+    For that reason, I need to describe the motivation of \"Promoting/Demoting the
+    Default Gems or Bundle Gems\" continuously. You will learn the resolution mechanism
+    on RubyGems/Bundler and the standard libraries of the Ruby language with my talk. "
+  speakers:
+  - id: hsbt
+chrisseaton:
+  title: Towards TruffleRuby in Production at Scale
+  type: presentation
+  language: EN
+  description: Shopify is looking at what it takes to put the TruffleRuby optimising
+    implementation of Ruby into production at scale. TruffleRuby builds on sophisticated
+    just-in-time compiler technology and shows extremely strong results on benchmarks,
+    but what does it take to get those results on a application at the scale of Shopify?
+    We have been building tools to understand how TruffleRuby optimizes, building
+    compatibility with the Shopify technology stack, and improving the performance
+    of TruffleRuby for real applications. We’ll pass on what we’ve achieved and learned
+    so far.
+  speakers:
+  - id: chrisseaton
+ohrdev:
+  title: dRuby in the Serverless World
+  type: presentation
+  language: JA
+  description: |-
+    AWS Lambda's support for Ruby Runtime makes Serverless programming using Ruby easy.
+    Distributed programming with Ruby is possible by using dRuby, Combined AWS Lambda, large-scale distributed processing can be easily implemented.
+    In this session, we explain Serverless Programming and Serverless architecture using AWS Lambda and dRuby as examples, and introduce implementation of large-scale distributede processing using dRuby.
+    This session is for the following Rubyist.
+
+    * Rubyist who wants to know about Serverless
+    * Rubyist who wants to know about distributed processing
+    * Rubyist who wants to use dRuby more
+  speakers:
+  - id: ohrdev
+headius:
+  title: 'JRuby in 2020: Faster, Smaller, More Compatible'
+  type: presentation
+  language: EN
+  description: |-
+    JRuby 9.3 is out with support for Ruby 2.6 features! Meanwhile we've been working hard to improve JRuby's usability and to improve the JRuby ecosystem. This talk will cover our recent work to clean up the "rough edges" of JRuby:
+
+    * Startup time improvements across various JVM versions
+    * Reduced memory consumption at boot and during execution
+    * Better peak performance across many Ruby features, utilizing state-of-the-art JVM optimizations
+    * Expanding support for mainstream Ruby libraries and frameworks
+  speakers:
+  - id: headius
+  - id: tom_enebo
+maciejmensfeld:
+  title: A complete guide to Ruby gems security
+  type: presentation
+  language: EN
+  description: |-
+    Ruby gems aren't fundamentally safe. Several gems were infected last year, and constant attempts are being made to do the same with others.  It's not only the execution that is a problem but the installation process as well.
+
+    Are there any ways for OSS users to regain control over what is being executed on their machines and their servers? Are there any ways for libraries maintainers to provide higher transparency over what they ship? Come, find out and let's exploit the Ruby gems world together!
+  speakers:
+  - id: maciejmensfeld
+kurotaky:
+  title: 'Ethereum.rb: Library for linking Ruby and Blockchain'
+  type: presentation
+  language: EN
+  description: Ethereum.rb is a library that can be easily connected to the Ethereum
+    blockchain from Ruby. In this talk, we will explain the basic mechanism of blockchain
+    and learn how to create blockchain applications (DApps) using Ruby. I will explain
+    how to process inside Ethereum.rb. And also the latest updates. By listening to
+    this talk, anyone will be able to create a blockchain application using Ruby.
+  speakers:
+  - id: kurotaky
+miura1729:
+  title: Ruby to C Translator by AI
+  type: presentation
+  language: JA
+  description: |-
+    I am developing Ruby to C Translator  "MMC". This uses AI (i.e. Abstract Interpretation) for Type Profiling and Escape Analysis. MMC generates very efficient C code  by AI. For example , MMC gains about 50 times faster than CRuby for ao-bench  (faster than C version).
+    I will presentation the technical detail of MMC especially escape analysis.　Further, I will talk about Ruby extension of MMC for Low Level Programming.
+  speakers:
+  - id: miura1729
+schneems:
+  title: The Life-Changing Magic of Tidying Active Record Allocations
+  type: presentation
+  language: EN
+  description: Your app is slow. It does not spark joy. In this talk, we will use
+    memory allocation profiling tools to discover performance hotspots, even when
+    they're coming from inside a library. We will use this technique with a real-world
+    application to identify a piece of optimizable code in Active Record that ultimately
+    leads to a patch with a substantial impact on page speed.
+  speakers:
+  - id: schneems
+aycabta:
+  title: Alpine Programming - Talk to You About Terminal Nightmare
+  type: presentation
+  language: EN
+  description: |-
+    I lost all I need to develop because I started to try radically new. There ware no conventional ways to move forward. There ware no methods to look ahead clearly. I had to create an entirely new style to go little by little.
+
+    At Christmas, 2019, Ruby 2.7 was released with the brand-new IRB what I improved. Last 2 years, other Ruby committers always said to me, "Good luck. But you'll not be able to complete it". I think this is a kind of Alpinism.
+
+    In Japan, Alpinism is being done in the mountains of the Japanese Alps around Matsumoto, it is to climb higher and more difficult. There are no conventional ways to move forward. There are no methods to look ahead clearly. I'll talk to you about Alpine Programming in Ruby 2.7.
+  speakers:
+  - id: aycabta
+soutaro:
+  title: Ruby3 Typing, 2020
+  type: keynote
+  language: EN
+  description: |-
+    Recall the Matz's keynote in 2016, *Ruby3 Typing*. It was three years ago and everything started. We build a team. We had a lot of discussions and wrote code. We discovered things that changed the original plan. Now we have a set of conclusions for type checking in Ruby3.
+
+    It's time to see how our effort lands.
+  speakers:
+  - id: soutaro

--- a/2020/data/schedule.yml
+++ b/2020/data/schedule.yml
@@ -1,0 +1,190 @@
+---
+sep03:
+  events:
+  - type: break
+    begin: '09:00'
+    end: '10:00'
+    name: Registration
+  - type: keynote
+    begin: '10:00'
+    end: '11:00'
+    talks:
+      Main Hall: yukihiro_matz
+  - type: talk
+    begin: '11:10'
+    end: '11:50'
+    talks:
+      Main Hall: mametter
+      Small Hall: shashank_date
+      Open Studio: etagwerker
+  - type: break
+    begin: '11:50'
+    end: '13:30'
+    name: Lunch Break
+  - type: talk
+    begin: '13:30'
+    end: '14:10'
+    talks:
+      Main Hall: jeremyevans0
+      Small Hall: tetiana_chupryna
+      Open Studio: kishima
+  - type: talk
+    begin: '14:20'
+    end: '15:00'
+    talks:
+      Main Hall: k0kubun
+      Small Hall: paracycle
+      Open Studio: yuji_yokoo
+  - type: break
+    begin: '15:00'
+    end: '15:40'
+    name: Afternoon Break
+  - type: talk
+    begin: '15:40'
+    end: '16:20'
+    talks:
+      Main Hall: shyouhei
+      Small Hall: lara
+      Open Studio: johnlinvc
+  - type: talk
+    begin: '16:30'
+    end: '17:10'
+    talks:
+      Main Hall: ko1
+      Small Hall: jonatas
+      Open Studio: hasumikin
+  - type: talk
+    begin: '17:20'
+    end: '18:00'
+    talks:
+      Main Hall: shugomaeda
+      Small Hall: jhawthorn
+      Open Studio: youchan
+  - type: lt
+    begin: '18:10'
+    end: '19:10'
+    name: Lightning Talks
+sep04:
+  events:
+  - type: break
+    begin: '09:00'
+    end: '10:00'
+    name: Door Open
+  - type: keynote
+    begin: '10:00'
+    end: '11:00'
+    talks:
+      Main Hall: alanwusx
+  - type: talk
+    begin: '11:10'
+    end: '11:50'
+    talks:
+      Main Hall: DarkDimius
+      Small Hall: ChrisBr
+      Open Studio: elct9620
+  - type: break
+    begin: '11:50'
+    end: '13:30'
+    name: Lunch break
+  - type: talk
+    begin: '13:30'
+    end: '14:10'
+    talks:
+      Main Hall: spikeolaf
+      Small Hall: Prakriti-nith
+      Open Studio: sue445
+  - type: talk
+    begin: '14:20'
+    end: '15:00'
+    talks:
+      Main Hall: keystonelemur
+      Small Hall: jashmatthews
+      Open Studio: jimlock
+  - type: break
+    begin: '15:00'
+    end: '15:40'
+    name: Afternoon Break
+  - type: talk
+    begin: '15:40'
+    end: '16:20'
+    talks:
+      Main Hall: m_seki
+      Small Hall: jvilk-stripe
+      Open Studio: eregontp
+  - type: talk
+    begin: '16:30'
+    end: '17:10'
+    talks:
+      Main Hall: knu
+      Small Hall: _st0012
+      Open Studio: koic
+  - type: talk
+    begin: '17:20'
+    end: '18:00'
+    talks:
+      Main Hall: mrkn
+      Small Hall: bovi
+      Open Studio: tenderlove
+sep05:
+  events:
+  - type: break
+    begin: '09:00'
+    end: '10:00'
+    name: Door Open
+  - type: talk
+    begin: '10:00'
+    end: '11:00'
+    talks:
+      Main Hall: rubylangorg
+  - type: talk
+    begin: '11:10'
+    end: '11:50'
+    talks:
+      Main Hall: palkan_tula
+      Small Hall: kddeisz
+      Open Studio: yuri_at_earth
+  - type: break
+    begin: '11:50'
+    end: '13:30'
+    name: Lunch Break
+  - type: talk
+    begin: '13:30'
+    end: '14:10'
+    talks:
+      Main Hall: ioquatix
+      Small Hall: anton_davydov
+      Open Studio: ktou
+  - type: talk
+    begin: '14:20'
+    end: '15:00'
+    talks:
+      Main Hall: hsbt
+      Small Hall: chrisseaton
+      Open Studio: ohrdev
+  - type: break
+    begin: '15:00'
+    end: '15:40'
+    name: Afternoon Break
+  - type: talk
+    begin: '15:40'
+    end: '16:20'
+    talks:
+      Main Hall: headius
+      Small Hall: maciejmensfeld
+      Open Studio: kurotaky
+  - type: talk
+    begin: '16:30'
+    end: '17:10'
+    talks:
+      Main Hall: miura1729
+      Small Hall: schneems
+      Open Studio: aycabta
+  - type: keynote
+    begin: '17:20'
+    end: '18:20'
+    talks:
+      Main Hall: soutaro
+  - type: break
+    begin: '18:20'
+    end: '18:35'
+    name: Closing

--- a/2020/data/speakers.yml
+++ b/2020/data/speakers.yml
@@ -1,0 +1,543 @@
+---
+keynotes:
+  yukihiro_matz:
+    id: yukihiro_matz
+    name: Yukihiro "Matz" Matsumoto
+    bio: The Creator of Ruby
+    github_id: matz
+    twitter_id: yukihiro_matz
+    gravatar_hash: 0ec4920185b657a03edf01fff96b4e9b
+  alanwusx:
+    id: alanwusx
+    name: Alan Wu
+    bio: Alan tries his best to extract efficiency out of modern hardware. He works
+      on the Ruby and Rails infrastructure team at Shopify and is a member of the
+      Ruby core team. While Alan studied Japanese in university, he gives talks in
+      English.
+    github_id: 
+    twitter_id: alanwusx
+    gravatar_hash: f6383a0bd54548033e7add59afaef528
+  soutaro:
+    id: soutaro
+    name: Soutaro Matsumoto
+    bio: Software engineer at Square.
+    github_id: soutaro
+    twitter_id: soutaro
+    gravatar_hash: 1fab9d01b25e99522f3dfd01e3d4cb51
+speakers:
+  tenderlove:
+    id: tenderlove
+    name: Aaron Patterson
+    bio: Aaron is on the Ruby core team, the Rails core team, and the team that takes
+      care of his cat, Gorby puff.   Someday he will find the perfect safety gear
+      to wear while extreme programming.
+    github_id: tenderlove
+    twitter_id: tenderlove
+    gravatar_hash: f29327647a9cff5c69618bae420792ea
+  knu:
+    id: knu
+    name: Akinori MUSHA
+    bio: A FOSS hacker, Ruby committer, Rails dev, father of two; working at Machimachi.com
+    github_id: knu
+    twitter_id: 
+    gravatar_hash: 74f896b312b786ee75a18073941e2457
+  anton_davydov:
+    id: anton_davydov
+    name: Anton Davydov
+    bio: I'm a backend architect from toptal, Hanami core developer and an indie developer
+      from Moscow. I work on different open source projects and builds Space-Rocket
+      ships at night.
+    github_id: davydovanton
+    twitter_id: anton_davydov
+    gravatar_hash: 4c206cf12d71775464e20c58dfa4148b
+  eregontp:
+    id: eregontp
+    name: Benoit Daloze
+    bio: Benoit Daloze is the lead of TruffleRuby at Oracle Labs. He did a PhD on
+      concurrency in Ruby with TruffleRuby. He has contributed to many Ruby implementations,
+      including TruffleRuby, MRI and JRuby. He is the maintainer of ruby/spec, a test
+      suite for the behavior of the Ruby programming language.
+    github_id: eregon
+    twitter_id: eregontp
+    gravatar_hash: 0ea7f61aec8fee539be0cf39b7bab77c
+  keystonelemur:
+    id: keystonelemur
+    name: Brandon Weaver
+    bio: Brandon is a Ruby Architect at Square working on the Frameworks team, defining
+      standards for Ruby across the company. He's an artist who turned programmer
+      who had a crazy idea to teach programming with cartoon lemurs and whimsy.
+    github_id: baweaver
+    twitter_id: keystonelemur
+    gravatar_hash: f555402e879ef6ad937e41bbaedb465b
+  headius:
+    id: headius
+    name: Charles Nutter
+    bio: Charles works on JVM languages at Red Hat.
+    github_id: headius
+    twitter_id: headius
+    gravatar_hash: f1d37642fdaa1662ff46e4c65731e9ab
+  chrisseaton:
+    id: chrisseaton
+    name: Chris Seaton
+    bio: Chris Seaton is a Researcher at Shopify, where he works on the Ruby programming
+      Language, and a Visitor at the University of Manchester. He was formerly a Research
+      Manager at the Oracle Labs Virtual Machine Research Group, where he led the
+      TruffleRuby implementation of Ruby, and worked on other language and virtual
+      machine projects. Before this he completed a PhD at Manchester.
+    github_id: chrisseaton
+    twitter_id: 
+    gravatar_hash: d0b0965afa66f2cabf76a8128b39e7c6
+  ChrisBr:
+    id: ChrisBr
+    name: Christian Bruckmayer
+    bio: |-
+      Christian Bruckmayer originally from Nuremberg, Germany, but just recently migrated to the south west of England. In his day job, he makes everyday cooking fun at Cookpad, the best place to find and share home cooked recipes. Since 2014 he is an avid open source contributor hacking for instance on JRuby, openSUSE Linux or various gems.
+
+      If he's not hacking Ruby, he's out doing what 'young' people do: traveling the world, skiing in the alps or going to concerts of his favorite band.
+    github_id: ChrisBr
+    twitter_id: 
+    gravatar_hash: 365b5cbcdc3c4d50ed52c4a4825a0de5
+  rubylangorg:
+    id: rubylangorg
+    name: CRuby Committers
+    bio: ''
+    github_id: 
+    twitter_id: rubylangorg
+    gravatar_hash: ce6d997265cefede13ee7e7e2a2cf9b2
+  bovi:
+    id: bovi
+    name: Daniel Bovensiepen
+    bio: Daniel is a Senior Research Scientist for a large industrial company. He
+      is researching in the area of communication, manufacturing and automation. He
+      uses Ruby over 20 years in areas nobody expects it. He is also a core committer
+      of mruby.
+    github_id: bovi
+    twitter_id: 
+    gravatar_hash: 49d6f762505615af259534deed94bc54
+  DarkDimius:
+    id: DarkDimius
+    name: Dmitry Petrashko
+    bio: |-
+      Dmitry works on developer productivity at Stripe, Making it easy to confidently write maintainable, fast, and reliable code at Stripe by improving language, core abstractions, tools and educational materials.
+
+      Before this, Dmitry co-architected Dotty, the compiler slated to become Scala3.
+    github_id: DarkDimius
+    twitter_id: 
+    gravatar_hash: 6ede4f43de82d33e6946486e509e5302
+  etagwerker:
+    id: etagwerker
+    name: Ernesto Tagwerker
+    bio: Ernesto is the Founder of Ombu Labs, a small software development company
+      dedicated to building lean code. When he is not obsessively playing table tennis
+      or chess, he likes to maintain a few Ruby gems including `database_cleaner`
+      and `email-spec`. He is passionate about writing less code, launching minimal
+      products, coaching entrepreneurs, contributing to open source, and eating empanadas.
+    github_id: etagwerker
+    twitter_id: 
+    gravatar_hash: eceef9c09ab1fb1bd8a997551777a66d
+  sue445:
+    id: sue445
+    name: Go Sueyoshi
+    bio: "I was born and raised in Fukuoka. My body is made of Tonkotsu-Ramen \U0001F35C\n\nI'm
+      a maintainer of rubicure, Itamae, chatwork-ruby and many many OSS.\n\nI'm engineer
+      of pixiv.inc. I'm working as like a SRE (web application, infrastructure and
+      CI engineer).\n\nPretty Cure is my life, and Cure Peace is my wife\U0001F49B"
+    github_id: sue445
+    twitter_id: sue445
+    gravatar_hash: 2b680c5f22146e764e2998dd4595ec93
+  miura1729:
+    id: miura1729
+    name: Hideki Miura
+    bio: I am a plumber.
+    github_id: miura1729
+    twitter_id: 
+    gravatar_hash: 360c8e3a4839819090e66e6ddf4b99ad
+  hsbt:
+    id: hsbt
+    name: Hiroshi SHIBATA
+    bio: |-
+      A member of Ruby core team. He maintains RubyGems, Rake, rdoc, psych, ruby-build, etc. and He is an administrator of ruby-lang.org and supports to develop the environment of Ruby language.
+
+      He is also Executive Officer in GMO Pepabo, Inc. His most interest things are “Productivity”  He believes, there's business value in fun. The team member happiness can make valuable products.
+    github_id: hsbt
+    twitter_id: hsbt
+    gravatar_hash: eabad423977cfc6873b8f5df62b848a6
+  hasumikin:
+    id: hasumikin
+    name: Hitoshi HASUMI
+    bio: A programmer of Monstar Lab at Shimane office
+    github_id: hasumikin
+    twitter_id: hasumikin
+    gravatar_hash: d62b18efd2549587e712cebf6403861a
+  aycabta:
+    id: aycabta
+    name: ITOYANAGI Sakura
+    bio: ''
+    github_id: aycabta
+    twitter_id: 
+    gravatar_hash: 43da97eeeac8fafd2bf196db1f19c534
+  jashmatthews:
+    id: jashmatthews
+    name: Jacob Matthews
+    bio: Software engineer at Airbnb working with Ruby. Interested in compilers and
+      VMs.
+    github_id: 
+    twitter_id: jashmatthews
+    gravatar_hash: 23c8448beeb584d7a3749a0ab16bc0a4
+  jeremyevans0:
+    id: jeremyevans0
+    name: Jeremy Evans
+    bio: Jeremy Evans is a Ruby committer.  He is the maintainer of Ruby ports for
+      the OpenBSD operating system.  He is also the lead developer of the Sequel database
+      library, the Roda web toolkit, the Rodauth authentication framework, and many
+      other Ruby libraries.
+    github_id: jeremyevans
+    twitter_id: jeremyevans0
+    gravatar_hash: f183bcc4176b308c9edabe79299e448f
+  jhawthorn:
+    id: jhawthorn
+    name: John Hawthorn
+    bio: John works on Action View as part of the Rails Committers team and the Ruby
+      Architecture Team at GitHub. He’s based in Victoria, Canada.
+    github_id: jhawthorn
+    twitter_id: 
+    gravatar_hash: 355cd35cc4e716547c8bf3c6b507a1ca
+  jvilk-stripe:
+    id: jvilk-stripe
+    name: John Vilk
+    bio: John is an engineer on Stripe’s Developer Productivity team who specifically
+      focuses on improving productivity within code editors. Recently, he has been
+      working on integrating Sorbet into code editors and implementing IDE features
+      using Sorbet types. Prior to joining Stripe, John completed a PhD in computer
+      science at University of Massachusetts Amherst.
+    github_id: jvilk-stripe
+    twitter_id: 
+    gravatar_hash: ffa9af13b0760c64c757b25ec991cfa8
+  jonatas:
+    id: jonatas
+    name: Jônatas Davi Paganini
+    bio: |-
+      My work is onboard people in a large Ruby codebase, and most of the time, I'm showing code or hunting for some code examples.
+
+      While developing some educational RuboCop cops, I found the RuboCop node pattern very useful to target code offenses. Then, I developed a similar tool to search and allow refactoring code based on node pattern concept.
+    github_id: jonatas
+    twitter_id: 
+    gravatar_hash: faae82c588349e1b51d9ff9b5431e10c
+  kishima:
+    id: kishima
+    name: Katsuhiko Kageyama
+    bio: "Embedded software engineer in a manufacturing company. \nOrganizing a mruby
+      community \"mruby meetup\".\nPersonally, producing technical books about mruby
+      and original devices in TechBookFest, Comic Market and Maker Faire(2020 Tsukuba)."
+    github_id: kishima
+    twitter_id: 
+    gravatar_hash: 30b735d887bdd9c0b0b9ff466ba887d0
+  mrkn:
+    id: mrkn
+    name: Kenta Murata
+    bio: |-
+      A full-time OSS developer at Speee Inc.
+      I'm a committer of Apache Arrow and CRuby.
+      I'm currently focusing on making Ruby a data-science-ready programming language.
+    github_id: mrkn
+    twitter_id: mrkn
+    gravatar_hash: 819b3c0a25f9708fd32261b8ae2d23f6
+  kddeisz:
+    id: kddeisz
+    name: Kevin Deisz
+    bio: I am the CTO of CultureHQ, based out of Boston, Massachusetts. I'm passionate
+      about music, open-source software, and craft beer.
+    github_id: kddeisz
+    twitter_id: kddeisz
+    gravatar_hash: 8a66c2a7197be751b21ebd35319ec797
+  koic:
+    id: koic
+    name: Koichi ITO
+    bio: Koichi ITO is a member of RuboCop's core developers team. He is a practitioner
+      of Ruby/Rails application development with eXtreme Programming. He works at
+      ESM, Inc.
+    github_id: koic
+    twitter_id: koic
+    gravatar_hash: 023b04c98f39cc041293d780352432ff
+  ko1:
+    id: ko1
+    name: Koichi Sasada
+    bio: Koichi Sasada is a programmer, mainly developing Ruby interpreter (CRuby/MRI).
+      He received Ph.D (Information Science and Technology) from the University of
+      Tokyo, 2007. Now he is still working on MRI development at Cookpad Inc. He is
+      also a director of Ruby Association.
+    github_id: ko1
+    twitter_id: 
+    gravatar_hash: 990397e8b38d6f5f4ae8ff343e8b883a
+  lara:
+    id: lara
+    name: Lara Aydin
+    bio: |-
+      Lara Aydin: SRE at Zendesk with an insatiable appetite for everything performance, benchmarking, and reliability related. (Pronouns: she/her)
+
+      Michael Grosser: Mostly Ruby/Rails hacker that tries to OS everything. (Pronouns: he/him)
+    github_id: lara
+    twitter_id: 
+    gravatar_hash: d3b1cbb2eb577f63d3ee74078d4c7a68
+  johnlinvc:
+    id: johnlinvc
+    name: Lin Yu Hsiang
+    bio: Cloud Platform Engineer at Exosite. Ruby lover. Full-stack developer. Organizer
+      of Swift Taipei.  iOS developer. FP lover.
+    github_id: johnlinvc
+    twitter_id: johnlinvc
+    gravatar_hash: 3f7d9611fc919c98512b779cde637dfc
+  maciejmensfeld:
+    id: maciejmensfeld
+    name: Maciej Mensfeld
+    bio: I'm a software architect and engineer working with Castle.io. I have experience
+      in a wide variety of business applications built using multiple Ruby frameworks.
+      I’m particularly interested in code quality and Ruby-based applications security.
+      I’m an active OSS contributor and maintainer of various projects including Karafka,
+      dry-rb libraries and Bundler-Security project.
+    github_id: mensfeld
+    twitter_id: maciejmensfeld
+    gravatar_hash: c571205817eabfe7ae22de3b74ffe900
+  p_ck_:
+    id: p_ck_
+    name: Masataka Kuwabara
+    bio: Masataka Kuwabara works for Bit Journey, inc, and a member of RuboCop's core
+      developers team.
+    github_id: pocke
+    twitter_id: p_ck_
+    gravatar_hash: 7f432d4a8aaadcea1ca77ec81a200121
+  m_seki:
+    id: m_seki
+    name: Masatoshi SEKI
+    bio: Masatoshi Seki is a Ruby committer and the author of several Ruby standard
+      libraries including dRuby, ERB, and Rinda. He’s an expert in object-oriented
+      programming, distributed systems, and eXtreme programming. He has been speaking
+      at RubyKaigi every year since 2006 when the Kaigi first started.
+    github_id: seki
+    twitter_id: m_seki
+    gravatar_hash: 40f4d1f2e77078955bd01e9fb4a503ba
+  takahashim:
+    id: takahashim
+    name: Masayoshi Takahashi
+    bio: Masayoshi Takahashi is an old-time Rubyist and the founder of Nihon Ruby
+      no Kai, a non-profit Ruby community in Japan. He is also the founder of Tatsu-Zine
+      Publising, the e-book publisher for IT engineers in Japan.
+    github_id: takahashim
+    twitter_id: 
+    gravatar_hash: 21a4b941766d805333e11c5766be43b4
+  grosser:
+    id: grosser
+    name: Michael Grosser
+    bio: |-
+      Mostly Ruby/Rails hacker that tries to OS everything.
+      Maintaining about 150 gems and involved in many more repos, working with ruby professionally since 2007. Senior staff engineer at Zendesk.
+    github_id: grosser
+    twitter_id: grosser
+    gravatar_hash: 9e57f24b9d4603e9d0fdd9d669c85a2c
+  jimlock:
+    id: jimlock
+    name: ODA Hirohito
+    bio: ";)"
+    github_id: jinroq
+    twitter_id: jimlock
+    gravatar_hash: 72e4a8bf47620de5381ff20f3deda977
+  Prakriti-nith:
+    id: Prakriti-nith
+    name: Prakriti Gupta
+    bio: Prakriti participated in Google Summer of Code 2018 with Ruby Science Foundation
+      (Sciruby) and worked on the enhancement of daru-view gem.
+    github_id: Prakriti-nith
+    twitter_id: 
+    gravatar_hash: b5400256cd4b4895b079ea6c5c247fa9
+  schneems:
+    id: schneems
+    name: Richard Schneeman
+    bio: Schneems writes Ruby at Heroku, and maintains CodeTriage.com, a tool for
+      helping people contribute to Open Source. He is in the top 50 Rails contributors
+      and is an accidental maintainer of Sprockets and Puma. When he isn't obsessively
+      compulsively refactoring code for performance he writes such gems as Wicked,
+      and derailed_benchmarks.
+    github_id: schneems
+    twitter_id: schneems
+    gravatar_hash: b5646ae10aa002ce46f283966f440251
+  ioquatix:
+    id: ioquatix
+    name: Samuel Williams
+    bio: I am a software engineer, and I am motivated by the beauty I uncover when
+      building complex systems.
+    github_id: ioquatix
+    twitter_id: ioquatix
+    gravatar_hash: 1373435a1059a97614969ab154c5b224
+  shashank_date:
+    id: shashank_date
+    name: Shashank Date
+    bio: Shashank Daté has been programming in Ruby professionally since 2002. He
+      contributed to the early versions of Ruby One Click installer on Windows and
+      win32utils - a set of Ruby libraries for Windows. He is technical editor of
+      "The Ruby Way" (2nd. ed) by Hal Fulton. He has been instrumental in making Ruby
+      popular in his hometowns (KC, USA & Pune, India). He co-founded Kansas City
+      Ruby User Group. He was on the organizing committee of Ruby Midwest 2011/12.
+      Currently, he programs in mruby too.
+    github_id: 
+    twitter_id: 
+    gravatar_hash: 6c0027f7711b0e64253049ba1b3c5336
+  shugomaeda:
+    id: shugomaeda
+    name: Shugo Maeda
+    bio: The Creator of Textbringer, a Ruby committer, Director of Network Applied
+      Communication Laboratory, and Secretary general of the Ruby Association
+    github_id: shugo
+    twitter_id: shugomaeda
+    gravatar_hash: 18a797893e6768e048c1d15429f96bb4
+  _st0012:
+    id: _st0012
+    name: Stan Lo
+    bio: A [Rails contributor](http://contributors.rubyonrails.org/contributors/stan-lo/commits),
+      writes [Goby](https://github.com/goby-lang/goby) once a while. Currently working
+      on [tapping_device](https://github.com/st0012/tapping_device).
+    github_id: st0012
+    twitter_id: _st0012
+    gravatar_hash: 90eb4343c490d4fe855eec64e1b1eaa3
+  ktou:
+    id: ktou
+    name: Sutou Kouhei
+    bio: He is a free software programmer and the president of ClearCode Inc. He is
+      also the namer of ClearCode Inc. The origin of the company name is "clear code".
+      We will be programmers that code clear code as our company name suggests. He
+      is a maintainer of [rake-compiler](https://github.com/rake-compiler/rake-compiler/)
+      gem that helps fat gem developers. He was  maintain [Ruby-GNOME](https://github.com/ruby-gnome/ruby-gnome/)
+      that had many fat gems.
+    github_id: kou
+    twitter_id: ktou
+    gravatar_hash: 2d9386b1504e581be390af978e05a8b9
+  k0kubun:
+    id: k0kubun
+    name: Takashi Kokubun
+    bio: Optimizing Ruby's JIT compiler and maintaining Haml and ERB. Senior Software
+      Engineer at Arm Treasure Data.
+    github_id: k0kubun
+    twitter_id: k0kubun
+    gravatar_hash: '08d5432a5bc31e6d9edec87b94cb1db1'
+  tetiana_chupryna:
+    id: tetiana_chupryna
+    name: Tetiana Chupryna
+    bio: Tetiana is a Backend developer at GitLab. A long time ago she traded graphics
+      programming for a career in web development because she fell in love with Ruby.
+      In her free time, she likes to draw with any materials available.
+    github_id: 
+    twitter_id: 
+    gravatar_hash: c89c739400ad9b6eb5237c760db4ab40
+  tom_enebo:
+    id: tom_enebo
+    name: Thomas E Enebo
+    bio: Thomas Enebo co-leads the JRuby project. He has been passionately working
+      on JRuby for many years. When not working on JRuby, he is writing Ruby applications,
+      playing with Java, and enjoying a decent beer.
+    github_id: enebo
+    twitter_id: tom_enebo
+    gravatar_hash: 13313ac2ec7ba7c43b1b952db034ff3b
+  ohrdev:
+    id: ohrdev
+    name: Tsunenori Oohara
+    bio: Tsunenori is software engineer and architect, working at Drecom Inc.
+    github_id: ohr486
+    twitter_id: ohrdev
+    gravatar_hash: 2a67c9a199a83a5eada6276f20630cb1
+  paracycle:
+    id: paracycle
+    name: Ufuk Kayserilioglu
+    bio: Ufuk is a Physics PhD turned polyglot software developer. He is currently
+      working as a Senior Production Engineer on the Rails team at Shopify. He has
+      over 20 years of experience working with statically and dynamically typed languages
+      ranging from low-level communication programming to web development. He brings
+      that experience to Shopify for the adoption of better Ruby tooling and practices.
+      He currently works remotely from Cyprus where he lives with his beloved wife
+      and wonderful daughter.
+    github_id: paracycle
+    twitter_id: 
+    gravatar_hash: 2bb923c57a1fdc3a2eb484bb8d565fd2
+  shyouhei:
+    id: shyouhei
+    name: Urabe, Shyouhei
+    bio: Money Forward, Inc. hire Shyouhei, a long-time ruby-core committer, to contribute
+      to the whole ruby ecosystem. Being a full-time ruby-core developer, his current
+      interest is to speed up ruby execution by modifying its internals. Doing so
+      is not straight-forward because of ruby's highly dynamic nature. To tackle this
+      problem he is implementing a variety of optimisation techniques that are yet
+      to be applied to it.
+    github_id: shyouhei
+    twitter_id: shyouhei
+    gravatar_hash: 9d2f78236e45a335301ba1195026105d
+  palkan_tula:
+    id: palkan_tula
+    name: Vladimir Dementyev
+    bio: Vladimir is a mathematician who found his happiness in programming Ruby and
+      Erlang, contributing to open source and being an Evil Martian. Author of AnyCable,
+      TestProf and many yet unknown ukulele melodies.
+    github_id: palkan
+    twitter_id: palkan_tula
+    gravatar_hash: 52cc8a838bf44a589d2572833b2dd1b9
+  youchan:
+    id: youchan
+    name: Yoh Osaki
+    bio: |-
+      Software engineer at Retrieva inc.
+      Author of Hyalite which is react like virtual DOM library.
+      Member of Asakusa.rb, Chidoriashi.rb
+    github_id: youchan
+    twitter_id: youchan
+    gravatar_hash: b54abc5e7463fe6470c379e97e3f2477
+  spikeolaf:
+    id: spikeolaf
+    name: Yuichiro Kaneko
+    bio: Ruby committer.
+    github_id: yui-knk
+    twitter_id: spikeolaf
+    gravatar_hash: b3ba3ccedfbf4d605f00bafd1a732529
+  yuji_yokoo:
+    id: yuji_yokoo
+    name: Yuji Yokoo
+    bio: Yuji is a software developer based in Adelaide, South Australia. He was born
+      and raised in Tokyo, Japan. He used to be a Windows desktop application developer
+      until he discovered Ruby. He enjoys console video gaming, programming, and especially
+      mixing both of them together.
+    github_id: 
+    twitter_id: 
+    gravatar_hash: b87628a711b78598dcd409da186cd633
+  yuri_at_earth:
+    id: yuri_at_earth
+    name: Yurie Yamane(team yamanekko)
+    bio: |-
+      "nora" mrubyist.
+      A member of Team Yamanekko.
+      A member of TOPPERS Project.
+    github_id: yurie
+    twitter_id: yuri_at_earth
+    gravatar_hash: 0607f2778a478327d55f9b4fb7954a60
+  mametter:
+    id: mametter
+    name: Yusuke Endoh
+    bio: '''A full-time MRI committer at Cookpad, Inc.  He has been interested in
+      testing, analyzing, abusing of Ruby.  He is an advocate of "transcendental programming"
+      that creates a useless program like this bio. (`_`)''.yield_self{|s|eval(t=%q(puts"''#{s.sub(?_,?_+?_)}''.yield_self{|s|eval(t=%q(#{t}))}"))}'
+    github_id: mame
+    twitter_id: mametter
+    gravatar_hash: e73159002200b33d51b7a6a312f2440e
+  kurotaky:
+    id: kurotaky
+    name: Yuta Kurotaki
+    bio: |-
+      Ethereum.rb maintainer.
+      He is the engineering lead for the print-on-demand service SUZURI at GMO Pepabo, Inc.
+      He is also an organizer of Kagoshima Ruby Kaigi 01, Rails Girls coach, a member of Yokohama.rb and K-Ruby.
+    github_id: kurotaky
+    twitter_id: kurotaky
+    gravatar_hash: 0b2426ff15397042caa863cc7965c091
+  elct9620:
+    id: elct9620
+    name: 蒼時弦也
+    bio: Game Developer / 5xruby's Rails Developer. Enjoy trying anything that can
+      work with Ruby in Game, IoT or anything else.
+    github_id: elct9620
+    twitter_id: elct9620
+    gravatar_hash: 888339de9e7a88688b6acb30d33e66cd


### PR DESCRIPTION
2015, 2017, 2018, 2019, 2020, 2020-takeout のHTMLの元ネタの各種YAMLファイルです。

2021-takeout 以降はschedule appというクライアントが発生したので、public APIとしてYAMLをサイト上から配信してたわけですが、このたび過去にさかのぼってHTMLをスクレイピングする https://github.com/ima1zumi/RubyKaigi-speakers という狂気じみたクライアントが出現したので、そしてやっぱりやってみたらHTMLのスクレイピングよりもYAMLから直接読み取ったほうがどう考えても楽チンってことがわかったので( https://github.com/ima1zumi/RubyKaigi-speakers/pull/10 )、だったらもっと過去のぶんも、内部的には利用してたこいつらがせっかくあるんだから公開してたことにしちゃおう、と思います。